### PR TITLE
fix for require statements in tasks

### DIFF
--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -1,6 +1,6 @@
 desc "Add schema information (as comments) to model and fixture files"
 task :annotate_models => :environment do
-  require 'annotate/annotate_models'
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', 'annotate', 'annotate_models'))
   options={}
   options[:position_in_class] = ENV['position_in_class'] || ENV['position'] || :before
   options[:position_in_fixture] = ENV['position_in_fixture'] || ENV['position']  || :before
@@ -14,7 +14,7 @@ end
 
 desc "Remove schema information from model and fixture files"
 task :remove_annotation => :environment do
-  require 'annotate/annotate_models'
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', 'annotate', 'annotate_models'))
   options={}
   options[:model_dir] = ENV['model_dir']
   AnnotateModels.remove_annotations(options)

--- a/lib/tasks/annotate_routes.rake
+++ b/lib/tasks/annotate_routes.rake
@@ -1,5 +1,5 @@
 desc "Prepends the route map to the top of routes.rb"
 task :annotate_routes do
-  require 'annotate/annotate_routes'
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', 'annotate', 'annotate_routes'))
   AnnotateRoutes.do_annotate
 end


### PR DESCRIPTION
After installing the annotate gem and attempting to run annotate on my project, I received the following error:

  no such file to load -- annotate/annotate_models (MissingSourceFile)

To correct the problem, I simply updated the require statements in the tasks to use a fully qualified path to the needed files.  I've tested this with success locally, but my tests have not been formal or robust... basically 1 developer machine with the patch applied.

It would be great to have this fix deployed in later versions of the gem, so I don't have to tweak the gem after installation though.

Thanks for considering my patch.

--Nathan 
