### PR TITLE
Updates to make annotate smarter about when to touch a model

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Cuong Tran", "Alex Chaffee", "Marcos Piccinini"]
   s.date = %q{2009-10-23}
-  s.default_executable = %q{annotate}
+  #s.default_executable = %q{annotate}
   s.description = %q{Annotates Rails Models, routes, fixtures, and others based on the database schema.}
   s.email = ["alex@stinky.com", "ctran@pragmaquest.com", "x@nofxx.com"]
   s.executables = ["annotate"]

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -119,11 +119,14 @@ module AnnotateModels
         old_content = File.read(file_name)
 
         # Ignore the Schema version line because it changes with each migration
-        header = Regexp.new(/(^# Table name:.*?\n(#.*\n)*\n)/)
+        header = Regexp.new(/(^# Table name:.*?\n(#.*[\r]?\n)*[\r]?\n)/)
         old_header = old_content.match(header).to_s
         new_header = info_block.match(header).to_s
 
-        if old_header == new_header
+        old_columns = old_header && old_header.scan(/#[\t\s]+([\w\d]+)[\t\s]+\:([\d\w]+)/).sort
+        new_columns = new_header && new_header.scan(/#[\t\s]+([\w\d]+)[\t\s]+\:([\d\w]+)/).sort
+
+        if old_columns == new_columns
           false
         else
           # Replace the old schema info with the new schema info


### PR DESCRIPTION
Recognize column+type, and don't change a file unless the column+type combination of the new schema are different than that of the old (i.e., don't regenerate if columns happen to be in a different order. That's just how life is sometimes)
Grab old specification even if it has \r\n as line endings rather than pure \ns
Remove gemspec line causing a warning
