### PR TITLE
Fixed that schema kept prepending additional newlines

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -133,7 +133,9 @@ module AnnotateModels
           new_content = old_content.sub(/^# #{COMPAT_PREFIX}.*?\n(#.*\n)*\n/, info_block)
           # But, if there *was* no old schema info, we simply need to insert it
           if new_content == old_content
-            new_content = options[:position] == 'before' ?  (info_block + old_content) : (old_content + "\n" + info_block)
+            new_content = options[:position] == 'before' ?
+              (info_block + old_content) :
+              ((old_content =~ /\n$/ ? old_content : old_content + '\n') + info_block)
           end
 
           File.open(file_name, "wb") { |f| f.puts new_content }


### PR DESCRIPTION
Prior to this patch every time the schema was regenerated at the end of
the file it prepended an additional newline character. This made the
schema slowly creep down the file over time. Finally annoyed me enough
to fork and fix ;)
