### PR TITLE
Allow for non standard model capitalization

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -239,7 +239,11 @@ module AnnotateModels
       begin
         parts.inject(Object) {|klass, part| klass.const_get(part) }
       rescue LoadError, NameError
-        Object.const_get(parts.last)
+        begin
+          Object.const_get(parts.last)
+        rescue LoadError, NameError
+          Object.const_get(Module.constants.detect{|c|parts.last.downcase == c.downcase})
+        end
       end
     end
 

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -69,6 +69,11 @@ EOS
           acts_as_awesome :yah
         end
       EOS
+      create('foo_with_capitals.rb', <<-EOS)
+        class FooWithCAPITALS < ActiveRecord::Base
+          acts_as_awesome :yah
+        end
+      EOS
     end
     it "should work" do
       klass = AnnotateModels.get_model_class("foo.rb")
@@ -77,6 +82,10 @@ EOS
     it "should not care about unknown macros" do
       klass = AnnotateModels.get_model_class("foo_with_macro.rb")
       klass.name.should == "FooWithMacro"
+    end
+    it "should find models with non standard capitalization" do
+      klass = AnnotateModels.get_model_class("foo_with_capitals.rb")
+      klass.name.should == "FooWithCAPITALS"
     end
   end
 


### PR DESCRIPTION
Hi,
We have a number of models that use non Rails standard capitalization, UploadedCSV, for example.
This change makes one more attempt to find the correct model name.

I did consider grepping the file for "XXX < ActiveRecord::Base", to handle even more cases, but I didn't think it was necessary.
