### PR TITLE
Support :change migrations in Rails 3.1

### DIFF
--- a/tasks/migrate.rake
+++ b/tasks/migrate.rake
@@ -11,7 +11,7 @@ namespace :db do
   end
 
   namespace :migrate do
-    [:up, :down, :reset, :redo].each do |t|
+    [:change, :up, :down, :reset, :redo].each do |t|
       task t do
         Annotate::Migration.update_annotations
       end


### PR DESCRIPTION
Rails 3.1 adds :change as a way to specify a migration. Add it to the Annotate rake task so it picks those up.
