### PR TITLE
Implement FactoryGirl

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -181,7 +181,9 @@ module AnnotateModels
           File.join(SPEC_MODEL_DIR,     "#{model_name}_spec.rb"), # spec
         ].each do |file| 
           # todo: add an option "position_in_test" -- or maybe just ask if anyone ever wants different positions for model vs. test vs. fixture
-          annotate_one_file(file, info, options_with_position(options, :position_in_fixture))
+          if annotate_one_file(file, info, options_with_position(options, :position_in_fixture))
+            annotated = true
+          end
         end
       end
 
@@ -193,13 +195,17 @@ module AnnotateModels
         File.join(FACTORIES_TEST_DIR, "#{model_name.pluralize}.rb"), # FactoryGirl Factories
         File.join(FACTORIES_SPEC_DIR, "#{model_name.pluralize}.rb"), # FactoryGirl Factories
         ].each do |file| 
-          annotate_one_file(file, info, options_with_position(options, :position_in_fixture))
+          if annotate_one_file(file, info, options_with_position(options, :position_in_fixture))
+            annotated = true
+          end
         end
 
         FIXTURE_DIRS.each do |dir|
           fixture_file_name = File.join(dir,klass.table_name + ".yml")
           if File.exist?(fixture_file_name)
-            annotate_one_file(fixture_file_name, info, options_with_position(options, :position_in_fixture))         
+            if annotate_one_file(fixture_file_name, info, options_with_position(options, :position_in_fixture))
+              annotated = true
+            end
           end
         end
       end


### PR DESCRIPTION
I have implemented annotation of FactoryGirl factories, here. It works fine as long as you use the `(test|spec)/factories/#{model_name}s.rb` pattern. I don't intend to use the single file approach [`spec/factories.rb`], myself, and I would guess implementing annotation of that file would be significantly more involved, so I haven't done that bit, yet. Also, you'll have to keep your factories for a given table within one factory file.

I didn't write any specs for it, because it seems you're not using them at present. I couldn't figure out exactly what was happening with that. (If you'd like me to add some Specs, please let me know and tell me how to run them given the Rakefile.)
