### PR TITLE
match indexes and column options too when comparing annotation headers

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -127,7 +127,7 @@ module AnnotateModels
         old_header = old_content.match(header_pattern).to_s
         new_header = info_block.match(header_pattern).to_s
 
-        column_pattern = /^#[\t ]+\w+[\t ]+:\w+/
+        column_pattern = /^#[\t ]+\w+[\t ]+(?:(?::\w+)|(?:\([\w,]+\)(?:[\t ]+[\w ]+)?))(?:[\t ]+[\w, ]+)?$/
         old_columns = old_header && old_header.scan(column_pattern).sort
         new_columns = new_header && new_header.scan(column_pattern).sort
 


### PR DESCRIPTION
If I change any column options (for example I add :null) or I modify any indexes then annotate wouldn't pick up the change.

See the difference here: http://cl.ly/0y1s2e121l2B2Q3R2e2Q and http://cl.ly/310z383s2N0J3T1f372X
