### PR TITLE
Options parsing should dig booleans from ENV

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -179,7 +179,7 @@ module AnnotateModels
         annotated = true
       end
  
-      unless ENV['exclude_tests']
+      unless options[:exclude_tests]
         [
           File.join(UNIT_TEST_DIR,      "#{model_name}_test.rb"), # test
           File.join(SPEC_MODEL_DIR,     "#{model_name}_spec.rb"), # spec
@@ -191,7 +191,7 @@ module AnnotateModels
         end
       end
 
-      unless ENV['exclude_fixtures']
+      unless options[:exclude_fixtures]
         [
         File.join(EXEMPLARS_TEST_DIR, "#{model_name}_exemplar.rb"),  # Object Daddy
         File.join(EXEMPLARS_SPEC_DIR, "#{model_name}_exemplar.rb"),  # Object Daddy

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -1,14 +1,19 @@
 desc "Add schema information (as comments) to model and fixture files"
 task :annotate_models => :environment do
   require File.expand_path(File.join(File.dirname(__FILE__), '..', 'annotate', 'annotate_models'))
+
+  true_re = /(true|t|yes|y|1)$/i
+
   options={}
   options[:position_in_class] = ENV['position_in_class'] || ENV['position'] || :before
   options[:position_in_fixture] = ENV['position_in_fixture'] || ENV['position']  || :before
-  options[:show_indexes] = ENV['show_indexes']
-  options[:simple_indexes] = ENV['simple_indexes']
+  options[:show_indexes] = ENV['show_indexes'] =~ true_re
+  options[:simple_indexes] = ENV['simple_indexes'] =~ true_re
   options[:model_dir] = ENV['model_dir']
-  options[:include_version] = ENV['include_version']
+  options[:include_version] = ENV['include_version'] =~ true_re
   options[:require] = ENV['require'] ? ENV['require'].split(',') : []
+  options[:exclude_tests] = ENV['exclude_tests'] =~ true_re
+  options[:exclude_fixtures] = ENV['exclude_fixtures'] =~ true_re
   AnnotateModels.do_annotations(options)
 end
 


### PR DESCRIPTION
I added boolean parsing of the ENV settings to the Rake task. I also adjusted annotate to not use ENV directly, but rather options placed into the options hash. This seems more appropriate. 
