### PR TITLE
Allow task loading from Rakefile for gems

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,8 +40,7 @@ Also, if you pass the -r option, it'll annotate routes.rb with the output of "ra
 
 Into Gemfile from Github:
 
-    gem 'annotate', :git => 'git://github.com/ctran/annotate_models.git'
-    
+    gem 'annotate', :git => 'git://github.com/ctran/annotate_models.git'    
 
 Into environment gems From Rubygems.org:
 
@@ -53,7 +52,6 @@ Into environment gems from Github checkout:
   cd annotate
   rake build
   sudo gem install pkg/annotate-*.gem
-
 
 == USAGE
 
@@ -83,7 +81,21 @@ To automatically annotate after running 'rake db:migrate':
 If you install annotate_models as a plugin, it will automatically
 adjust your <tt>rake db:migrate</tt> tasks so that they update the
 annotations in your model files for you once the migration is
-completed.
+completed. To get the same behavior from a gem, add the following to
+your Rakefile:
+
+  require 'annotate/tasks'
+
+To customize the behavior of annotate when it is running as a Rake
+task, use the following (in your Rakefile or wherever):
+
+  ENV['position_in_class']   = "before"
+  ENV['position_in_fixture'] = "before"
+  ENV['show_indexes']        = "false"
+  ENV['include_version']     = "false"
+  ENV['exclude_tests']       = "false"
+  ENV['exclude_fixtures']    = "false"
+  ENV['skip_on_db_migrate']  = "false"
 
 == OPTIONS
 

--- a/lib/annotate/tasks.rb
+++ b/lib/annotate/tasks.rb
@@ -1,0 +1,6 @@
+require 'rubygems'
+require 'rake'
+
+# Make tasks visible for Rails also when used as gem.
+Dir[File.join(File.dirname(__FILE__), '..', 'tasks', '**/*.rake')].each { |rake| load rake }
+Dir[File.join(File.dirname(__FILE__), '..', '..', 'tasks', '**/*.rake')].each { |rake| load rake }

--- a/tasks/migrate.rake
+++ b/tasks/migrate.rake
@@ -13,9 +13,9 @@ namespace :db do
   namespace :migrate do
     [:change, :up, :down, :reset, :redo].each do |t|
       task t do
-        Annotate::Migration.update_annotations
+        Annotate::Migration.update_annotations 
       end
-    end
+    end 
   end
 end
 
@@ -24,9 +24,9 @@ module Annotate
     @@working = false
 
     def self.update_annotations
-      unless @@working
+      unless @@working || (ENV['skip_on_db_migrate'] =~ /(true|t|yes|y|1)$/i)
         @@working = true
-        Rake::Task['annotate_models'].invoke
+        Rake::Task['annotate_models'].invoke 
       end
     end
   end


### PR DESCRIPTION
I added lib/annotate/tasks.rb which will load the Rake tasks. It can be used from a project Rakefile to pull in the annotate tasks (which should probably be namespaced... but that's a bigger change). Since the db:migrate autorun functionality was plugin-only before, I added a skip_on_db_migrate option that can be used in conjunction with this.
