### PR TITLE
fix column pattern regex

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -130,7 +130,7 @@ module AnnotateModels
         old_header = old_content.match(header_pattern).to_s
         new_header = info_block.match(header_pattern).to_s
 
-        column_pattern = /^#[\t ]+\w+[\t ]+(?:(?::\w+)|(?:\([\w,]+\)(?:[\t ]+[\w ]+)?))(?:[\t ]+[\w, ]+)?$/
+        column_pattern = /^#[\t ]+\w+[\t ]+.+$/
         old_columns = old_header && old_header.scan(column_pattern).sort
         new_columns = new_header && new_header.scan(column_pattern).sort
 


### PR DESCRIPTION
As you can see [here](http://rubular.com/r/3yMij21l5G) the current implementation doesn't not work fine, where "doesn't work" means that the annotate gem does not recognize in a proper way when a model get some column changes. 

Well I changed it a very simple implementation because we actually need only to compare new and old columns. And using this regex will ensure we are really comparing the new and the old columns. It works very fine now.
