### PR TITLE
method_missing monkey patch breaks Rails DynamicFinder

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
     "annotate.gemspec",
     "bin/annotate",
     "lib/annotate.rb",
+    "lib/annotate/active_record_patch.rb",
     "lib/annotate/annotate_models.rb",
     "lib/annotate/annotate_routes.rb",
     "lib/tasks/annotate_models.rake",

--- a/lib/annotate/active_record_patch.rb
+++ b/lib/annotate/active_record_patch.rb
@@ -1,0 +1,9 @@
+# monkey patches
+
+module ::ActiveRecord
+  class Base
+    def self.method_missing(name, *args)
+      # ignore this, so unknown/unloaded macros won't cause parsing to fail
+    end
+  end
+end

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -353,13 +353,3 @@ module AnnotateModels
     end
   end
 end
-
-# monkey patches
-
-module ::ActiveRecord
-  class Base
-    def self.method_missing(name, *args)
-      # ignore this, so unknown/unloaded macros won't cause parsing to fail
-    end
-  end
-end

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -1,6 +1,7 @@
 desc "Add schema information (as comments) to model and fixture files"
 task :annotate_models => :environment do
   require File.expand_path(File.join(File.dirname(__FILE__), '..', 'annotate', 'annotate_models'))
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', 'annotate', 'active_record_patch'))
 
   true_re = /(true|t|yes|y|1)$/i
 
@@ -20,6 +21,7 @@ end
 desc "Remove schema information from model and fixture files"
 task :remove_annotation => :environment do
   require File.expand_path(File.join(File.dirname(__FILE__), '..', 'annotate', 'annotate_models'))
+  require File.expand_path(File.join(File.dirname(__FILE__), '..', 'annotate', 'active_record_patch'))
   options={}
   options[:model_dir] = ENV['model_dir']
   AnnotateModels.remove_annotations(options)

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -1,5 +1,6 @@
 require File.dirname(__FILE__) + '/../spec_helper.rb'
 require 'annotate/annotate_models'
+require 'annotate/active_record_patch'
 require 'rubygems'
 require 'active_support'
 


### PR DESCRIPTION
If the annotate gem happens to be loaded into the environment, the dynamic finders (find_by_name, find_by_id, etc.) will always return nil.
