### PR TITLE
One line patch to sort the indexes by name.

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -101,7 +101,7 @@ module AnnotateModels
       return "" if indexes.empty?
 
       max_size = indexes.collect{|index| index.name.size}.max + 1
-      indexes.each do |index|
+      indexes.sort_by{|index| index.name}.each do |index|
         index_info << sprintf("#  %-#{max_size}.#{max_size}s %s %s", index.name, "(#{index.columns.join(",")})", index.unique ? "UNIQUE" : "").rstrip + "\n"
       end
       return index_info


### PR DESCRIPTION
Just started using annotate.  Nice!  Noticed that it returns the indexes in a random order, causing unnecessary chatter in my commits.  Patch is a one line change to sort the indexes by name to prevent this from happening.
