### PR TITLE
Removing reference to VERSION.yml from gemspec

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.extra_rdoc_files = ["README.rdoc"]
   
-  s.files             = %w( README.rdoc VERSION.yml History.txt )
+  s.files             = %w( README.rdoc History.txt )
   s.files            += Dir.glob("lib/**/*")
   s.files            += Dir.glob("tasks/**/*")  
   s.files            += ["bin/annotate"]  # todo: annotate_models


### PR DESCRIPTION
It no longer exists
