### PR TITLE
Additional checks

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -82,7 +82,7 @@ module AnnotateModels
         attrs = []
         attrs << "default(#{quote(col.default)})" unless col.default.nil?
         attrs << "not null" unless col.null
-        attrs << "primary key" if col.name.to_sym == klass.primary_key.to_sym
+        attrs << "primary key" if klass.primary_key && col.name.to_sym == klass.primary_key.to_sym
 
         col_type = (col.type || col.sql_type).to_s
         if col_type == "decimal"
@@ -318,7 +318,7 @@ module AnnotateModels
     # Retrieve loaded model class by path to the file where it's supposed to be defined.
     def get_loaded_model(model_path)
       ObjectSpace.each_object.
-        select { |c| c.is_a?(Class) && c.ancestors.include?(ActiveRecord::Base) }.
+        select { |c| Class === c && c.ancestors.respond_to?(:include?) && c.ancestors.include?(ActiveRecord::Base) }.
         detect { |c| ActiveSupport::Inflector.underscore(c) == model_path }
     end
 


### PR DESCRIPTION
---

First check is to support models with no primary key

---

Also I changed `c.is_a?(Class)` to `Class === c` because of the following error:

```
Unable to annotate my_model.rb: wrong number of arguments(2 for 1)
(.../activesupport-3.2.5/lib/active_support/option_merger.rb:22:in `is_a?')
```

I didn't find the reason of that error, just tried `Class === c` and it worked.

---

And I had to add the last check because of some strange errors from factory_girl:

```
Unable to annotate my_model.rb: undefined method `include?' for
#<FactoryGirl::Declaration::Implicit:0x9615d74> 
(.../lib/annotate/annotate_models.rb:322:in `block in get_loaded_model')
```

I've found that it was trying to get ancestors for instance of [FactoryGirl::DefinitionProxy](https://github.com/thoughtbot/factory_girl/blob/master/lib/factory_girl/definition_proxy.rb), which seems to be making a lot of magic.

---
