### PR TITLE
JRuby compatibility

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -316,11 +316,8 @@ module AnnotateModels
 
     # Retrieve loaded model class by path to the file where it's supposed to be defined.
     def get_loaded_model(model_path)
-      ObjectSpace.each_object.
-        select { |c|
-          Class === c and    # note: we use === to avoid a bug in activesupport 2.3.14 OptionMerger vs. is_a?
-          c.ancestors.include?(ActiveRecord::Base) 
-        }.
+      ObjectSpace.each_object(::Class).
+        select { |c| c.ancestors.include?(ActiveRecord::Base) }.
         detect { |c| ActiveSupport::Inflector.underscore(c) == model_path }
     end
 


### PR DESCRIPTION
When I attempt to run in JRuby, the follow error occurs:

```
RuntimeError: ObjectSpace is disabled; each_object will only work with Class, pass -X+O to enable each_object at org/jruby/RubyObjectSpace.java:167
```

By default, `ObjectSpace.each_object` is disabled in JRuby for [performance reasons](https://github.com/jruby/jruby/wiki/PerformanceTuning). However, `ObjectSpace.each_object(Class)` still works without enabling on the whole enchilada. I made this change and all the specs pass on MRI and JRuby, except for the integration tests (I'm having trouble getting the integration tests to pass on my machine even without the patch). Perhaps someone could verify that those pass as well.
