### PR TITLE
expect a model without primary key

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -82,7 +82,7 @@ module AnnotateModels
         attrs = []
         attrs << "default(#{quote(col.default)})" unless col.default.nil?
         attrs << "not null" unless col.null
-        attrs << "primary key" if col.name.to_sym == klass.primary_key.to_sym
+        attrs << "primary key" if klass.primary_key && col.name.to_sym == klass.primary_key.to_sym
 
         col_type = (col.type || col.sql_type).to_s
         if col_type == "decimal"

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -8,7 +8,7 @@ describe AnnotateModels do
     options = {
       :connection   => mock("Conn", :indexes => []),
       :table_name   => table_name,
-      :primary_key  => primary_key.to_s,
+      :primary_key  => primary_key && primary_key.to_s,
       :column_names => columns.map { |col| col.name.to_s },
       :columns      => columns
     }
@@ -49,6 +49,24 @@ describe AnnotateModels do
 # Table name: users
 #
 #  id   :integer          not null, primary key
+#  name :string(50)       not null
+#
+
+EOS
+  end
+
+  it "should get schema info even if the primary key is not set" do
+    klass = mock_class(:users, nil, [
+                                     mock_column(:id, :integer),
+                                     mock_column(:name, :string, :limit => 50)
+                                    ])
+
+    AnnotateModels.get_schema_info(klass, "Schema Info").should eql(<<-EOS)
+# Schema Info
+#
+# Table name: users
+#
+#  id   :integer          not null
 #  name :string(50)       not null
 #
 


### PR DESCRIPTION
If we try to annotate a model without primary key, we will get an error `undefined method 'to_sym' for nil:NilClass` on `lib/annotate/annotate_models.rb:85`.

This patch fixes this problem.
