### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -122,7 +122,7 @@ anywhere in the file:
 To generate a configuration file (in the form of a `.rake` file), to set
 default options:
 
-    rails g annotate:install
+    rails g annotate_models:install
 
 Edit this file to control things like output format, where annotations are
 added (top or bottom of file), and in which artifacts.
@@ -133,7 +133,7 @@ added (top or bottom of file), and in which artifacts.
 To generate a configuration file (in the form of a `.rake` file), to set
 default options:
 
-    rails g annotate:install
+    rails g annotate_models:install
 
 Edit this file to control things like output format, where annotations are
 added (top or bottom of file), and in which artifacts.
@@ -271,4 +271,4 @@ With help from:
 - Dmitry Lihachev
 - qichunren
 
-and many others that I may have missed to add.
+and many others that I may have forgotten to add.


### PR DESCRIPTION
Corrected rails generate command to reflect the current generator name: annotate_models:install
