### PR TITLE
Re-generate gemspec

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -8,12 +8,12 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = ["Cuong Tran", "Alex Chaffee", "Marcos Piccinini", "Turadg Aleahmad", "Jon Frisby"]
-  s.date = "2012-08-27"
+  s.date = "2012-10-03"
   s.description = "Annotates Rails/ActiveRecord Models, routes, fixtures, and others based on the database schema."
   s.email = ["alex@stinky.com", "ctran@pragmaquest.com", "x@nofxx.com", "turadg@aleahmad.net", "jon@cloudability.com"]
-  s.executables = ["annotate", "annotate_models", "annotate_routes"]
+  s.executables = ["annotate"]
   s.extra_rdoc_files = ["README.rdoc", "CHANGELOG.rdoc", "TODO.rdoc"]
-  s.files = ["CHANGELOG.rdoc", "README.rdoc", "TODO.rdoc", "annotate.gemspec", "bin/annotate", "lib/annotate.rb", "lib/annotate/active_record_patch.rb", "lib/annotate/annotate_models.rb", "lib/annotate/annotate_routes.rb", "lib/annotate/tasks.rb", "lib/annotate/version.rb", "lib/generators/annotate/USAGE", "lib/generators/annotate/install_generator.rb", "lib/generators/annotate/templates/auto_annotate_models.rake", "lib/tasks/migrate.rake"]
+  s.files = ["CHANGELOG.rdoc", "README.rdoc", "TODO.rdoc", "annotate.gemspec", "bin/annotate", "lib/annotate.rb", "lib/annotate/active_record_patch.rb", "lib/annotate/annotate_models.rb", "lib/annotate/annotate_routes.rb", "lib/annotate/tasks.rb", "lib/annotate/version.rb", "lib/generators/annotate/USAGE", "lib/generators/annotate/install_generator.rb", "lib/generators/annotate/templates/auto_annotate_models.rake", "lib/tasks/annotate_models.rake", "lib/tasks/annotate_routes.rake", "tasks/migrate.rake"]
   s.homepage = "http://github.com/ctran/annotate_models"
   s.licenses = ["Ruby"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
The gemspec has fallen behind, and does not accurately represent the repository's structure. Because of that, bundler does not recognize the gem's binary files, so `bundle exec annotate` doesn't work when the gem is installed via a `gem 'annotate', :git => '....'` line.

I ran `rake gem:gemspec` and committed the changes in the Gemfile. Please consider merging this, so bundler will stop complaining.

Thank you very much!
