### PR TITLE
Fix #110 (incorrect behaviour for spec annotating).

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -460,7 +460,7 @@ module AnnotateModels
     end
 
     def find_test_file(dir, file_name)
-      Dir.glob(File.join(dir, "**", file_name)).first || File.join(dir, file_name)
+      Dir.glob(File.join(dir, file_name)).first || File.join(dir, file_name)
     end
 
     def resolve_filename(filename_template, model_name, table_name)


### PR DESCRIPTION
I have 4 files to annotate:

app/models/job_type.rb
app/models/work_order/job_type.rb
spec/models/job_type_spec.rb
spec/models/work_order/job_type_spec.rb

As result I have spec/models/work_order/job_type_spec.rb annotated with 'job_types' table but not 'work_order_job_types' as expected.

The problem is in find_test_file. It annotate model in the following order:

app/models/work_order/job_type.rb
app/models/job_type.rb

So when you run annotate it annotates spec/models/work_order/job_type_spec.rb with correct and then overrides it with incorrect header.
