### PR TITLE
Fix annotations for enum columns when using enum_column3 gem

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -118,11 +118,9 @@ module AnnotateModels
         col_type = (col.type || col.sql_type).to_s
         if col_type == "decimal"
           col_type << "(#{col.precision}, #{col.scale})"
-        elsif col_type == "enum"
+        elsif col_type == "enum" && col.limit && !col.limit.empty?
           # Handles the enum_column3 gem format for storing the enum values in the limit field
-          if (col.limit)
-            attrs << "values: #{col.limit.inspect}"
-          end
+          attrs << "values: #{col.limit.inspect}"
         else
           if (col.limit)
             col_type << "(#{col.limit})" unless NO_LIMIT_COL_TYPES.include?(col_type)


### PR DESCRIPTION
Minor change (2 lines) to handle enum columns as per enum_column3 gem: https://github.com/taktsoft/enum_column3 that generates annotations for enum columns as follows:

#  status          :enum             default(:submitted), not null, values: [:submitted, :in_progress, :closed]

which adds the list of enum values at the end instead of the current behavior which generates this:

#  status          :enum([:submitted default(:submitted), not null

(which as you can see cuts off the list of enum values at 16 characters as part of the type)
