### PR TITLE
Remove excessive newline when annotation is put after code

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -5,7 +5,7 @@ module AnnotateModels
   PREFIX           = "== Schema Information"
   PREFIX_MD        = "## Schema Information"
   END_MARK         = "== Schema Information End"
-  PATTERN          = /^\n?# (?:#{COMPAT_PREFIX}|#{COMPAT_PREFIX_MD}).*?\n(#.*\n)*\n/
+  PATTERN          = /^\n?# (?:#{COMPAT_PREFIX}|#{COMPAT_PREFIX_MD}).*?\n(#.*\n)*\n*/
 
   # File.join for windows reverse bar compat?
   # I dont use windows, can`t test
@@ -160,9 +160,9 @@ module AnnotateModels
       if options[:format_rdoc]
         info << "#--\n"
         info << "# #{END_MARK}\n"
-        info << "#++\n\n"
+        info << "#++\n"
       else
-        info << "#\n\n"
+        info << "#\n"
       end
     end
 
@@ -204,7 +204,7 @@ module AnnotateModels
         return false if(old_content =~ /# -\*- SkipSchemaAnnotations.*\n/)
 
         # Ignore the Schema version line because it changes with each migration
-        header_pattern = /(^# Table name:.*?\n(#.*[\r]?\n)*[\r]?\n)/
+        header_pattern = /(^# Table name:.*?\n(#.*[\r]?\n)*[\r]?)/
         old_header = old_content.match(header_pattern).to_s
         new_header = info_block.match(header_pattern).to_s
 
@@ -238,7 +238,7 @@ module AnnotateModels
 
           new_content = options[position].to_s == 'after' ?
             (encoding_header + (old_content.rstrip + "\n\n" + info_block)) :
-            (encoding_header + info_block + old_content)
+            (encoding_header + info_block + "\n" + old_content)
 
           File.open(file_name, "wb") { |f| f.puts new_content }
           return true

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -51,7 +51,6 @@ describe AnnotateModels do
 #  id   :integer          not null, primary key
 #  name :string(50)       not null
 #
-
 EOS
   end
 
@@ -69,7 +68,6 @@ EOS
 #  id   :integer          not null
 #  name :string(50)       not null
 #
-
 EOS
   end
 
@@ -88,7 +86,6 @@ EOS
 #  b_id   :integer        not null
 #  name :string(50)       not null
 #
-
 EOS
   end
 
@@ -107,7 +104,6 @@ EOS
 #--
 # #{AnnotateModels::END_MARK}
 #++
-
 EOS
   end
 
@@ -177,7 +173,7 @@ EOS
       EOS
       check_class_name 'foo_with_macro.rb', 'FooWithMacro'
     end
-    
+
     it "should not care about known macros" do
       create('foo_with_known_macro.rb', <<-EOS)
         class FooWithKnownMacro < ActiveRecord::Base
@@ -347,12 +343,12 @@ end
 
     it "should annotate the file before the model if position == 'before'" do
       annotate_one_file :position => "before"
-      File.read(@model_file_name).should == "#{@schema_info}#{@file_content}"
+      File.read(@model_file_name).should == "#{@schema_info}\n#{@file_content}"
     end
 
     it "should annotate before if given :position => :before" do
       annotate_one_file :position => :before
-      File.read(@model_file_name).should == "#{@schema_info}#{@file_content}"
+      File.read(@model_file_name).should == "#{@schema_info}\n#{@file_content}"
     end
 
     it "should annotate after if given :position => :after" do
@@ -384,7 +380,7 @@ end
                                        ])
       schema_info = AnnotateModels.get_schema_info(klass, "== Schema Info")
       AnnotateModels.annotate_one_file(model_file_name, schema_info, :position => :before)
-      File.read(model_file_name).should == "#{schema_info}#{file_content}"
+      File.read(model_file_name).should == "#{schema_info}\n#{file_content}"
     end
 
     describe "if a file can't be annotated" do


### PR DESCRIPTION
There is no need to add second new line when annotation is situated at bottom of file. 

Most editors remove such lines, and when next time you attempt to annotate, new annotation is put under old one (because old is not longer match to pattern).
