### PR TITLE
Automatically move position

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -215,7 +215,14 @@ module AnnotateModels
         encoding = Regexp.new(/(^#\s*encoding:.*\n)|(^# coding:.*\n)|(^# -\*- coding:.*\n)/)
         encoding_header = old_content.match(encoding).to_s
 
-        if old_columns == new_columns && !options[:force]
+        same_columns = (old_columns == new_columns)
+
+        change_before_to_after = (old_content =~ /\A# == Schema Info/ && options[position].to_s == 'after')
+        change_after_to_before = (old_content =~ /\n#\n\n\z/ && options[position].to_s == 'before')
+
+        same_position = !(change_before_to_after || change_after_to_before)
+
+        if same_columns && same_position && !options[:force]
           return false
         else
 

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -360,7 +360,7 @@ end
       File.read(@model_file_name).should == "#{@file_content}\n#{@schema_info}"
     end
 
-    it "should update annotate position" do
+    it "should update annotate position during schema change" do
       annotate_one_file :position => :before
 
       another_schema_info = AnnotateModels.get_schema_info(mock_class(:users, :id, [mock_column(:id, :integer),]),
@@ -370,6 +370,23 @@ end
       annotate_one_file :position => :after
 
       File.read(@model_file_name).should == "#{@file_content}\n#{another_schema_info}"
+    end
+
+    it "should update annotate position with no schema change" do
+      annotate_one_file :position => :before
+      annotate_one_file :position => :after
+
+      File.read(@model_file_name).should == "#{@file_content}\n#{@schema_info}"
+      annotate_one_file :position => :before
+
+      File.read(@model_file_name).should == "#{@schema_info}#{@file_content}"
+    end
+
+    it "should not touch the file when no schema change, no position change, and no force option" do
+      annotate_one_file :position => :before
+      File.should_not_receive(:open).with(@model_file_name, "wb")
+      
+      annotate_one_file :position => :before
     end
 
     it "works with namespaced models (i.e. models inside modules/subdirectories)" do


### PR DESCRIPTION
1, I like annotations after my models.
2, I frequently forget to add the '-p after' option when using this gem.
3, Simply running the command again adding the '-p after' option does not change the position since it detects that the model has already been annotated.
4, During writing this functionality I discovered you could simply pass the --force option, however there is nothing in the documentation about this, and it seems to me this functionality should be default, so I wrote the change anyway.

I understand if other people feel differently about moving the position of the annotations by default.

Much like the other code I see in annotate_models, to detect the need to move the position of the annotations, this code relies on the following two regular expressions to find the beginning and end of the string (model file):

`/\A# == Schema Info/`
`/\n#\n\n\z/`
