### PR TITLE
Revise the warning in the README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -217,12 +217,17 @@ Be sure to add this to your `Gemfile` as well:
 
 == WARNING
 
-Note that this code will blow away the initial/final comment block in your
-models if it looks like it was previously added by this gem, so you don't want
-to add additional text to an automatically created comment block.
+<b>Don't add text after an automatically-created comment block.</b> This tool
+will blow away the initial/final comment block in your models if it looks like
+it was previously added by this gem.
 
-BACK UP YOUR MODELS BEFORE USING THIS TOOL!
+Be sure to check the changes that this tool makes! If you are using Git,
+you may simply check your project's status after running `annotate`:
 
+    $ git status
+
+If you are not using a VCS (like Git, Subversion or similar), please tread
+extra carefully, and consider using one.
 
 == Links
 


### PR DESCRIPTION
See #122. I've revised the wording to placing the important text in the first sentence, and made the warning a bit more 2013-like by referencing VCS instead of backing files up.
