### PR TITLE
Attempt model annotation only if table exists

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -411,7 +411,7 @@ module AnnotateModels
     def annotate_model_file(annotated, file, header, options)
       begin
         klass = get_model_class(file)
-        if klass && klass < ActiveRecord::Base && !klass.abstract_class?
+        if klass && klass < ActiveRecord::Base && !klass.abstract_class? && klass.table_exists?
           if annotate(klass, file, header, options)
             annotated << klass
           end

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -461,4 +461,20 @@ end
        end
     end
   end
+
+  describe '.annotate_model_file' do
+    before do
+      class Foo < ActiveRecord::Base; end;
+      AnnotateModels.stub(:get_model_class).with('foo.rb') { Foo }
+      Foo.stub(:table_exists?) { false }
+    end
+
+    after { Object.send :remove_const, 'Foo' }
+
+    it 'skips attempt to annotate if no table exists for model' do
+      annotate_model_file = AnnotateModels.annotate_model_file([], 'foo.rb', nil, nil)
+
+      annotate_model_file.should eq nil
+    end
+  end
 end


### PR DESCRIPTION
Say a developer begins constructing `class Foo < ActiveRecord::Base` and `class Bar < ActiveRecord::Base`. When she creates a migration to create a table for `Foo`, does `rake db:migrate`, she'll get an error from Annotate via the ActiveRecord adapter explaining that the `bars` table doesn't exist. Regardless of whether this is a good development practice, the error message is an annoyance.
