### PR TITLE
Fix composite primary keys test

### DIFF
--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -72,7 +72,7 @@ EOS
   end
 
   it "should get schema info even if the primary key is array, if using composite_primary_keys" do
-    klass = mock_class(:users, nil, [
+    klass = mock_class(:users, [:a_id, :b_id], [
                                      mock_column(:a_id, :integer),
                                      mock_column(:b_id, :integer),
                                      mock_column(:name, :string, :limit => 50)
@@ -83,8 +83,8 @@ EOS
 #
 # Table name: users
 #
-#  a_id :integer          not null
-#  b_id :integer          not null
+#  a_id :integer          not null, primary key
+#  b_id :integer          not null, primary key
 #  name :string(50)       not null
 #
 EOS


### PR DESCRIPTION
Fix an error in test for composite_primary_keys. As current implementation of assertion doesn't check correct behavior with composite keys.
