### PR TITLE
Fix documentation: rails generator syntax changed to `rails g annotate_models:install`

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -133,7 +133,7 @@ added (top or bottom of file), and in which artifacts.
 To generate a configuration file (in the form of a `.rake` file), to set
 default options:
 
-    rails g annotate:install
+    rails g annotate_models:install
 
 Edit this file to control things like output format, where annotations are
 added (top or bottom of file), and in which artifacts.


### PR DESCRIPTION
rails generator syntax changed to `rails g annotate_models:install`
