### PR TITLE
update installation command

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -122,21 +122,11 @@ anywhere in the file:
 To generate a configuration file (in the form of a `.rake` file), to set
 default options:
 
-    rails g annotate:install
+    rails g annotate_models:install
 
 Edit this file to control things like output format, where annotations are
 added (top or bottom of file), and in which artifacts.
 
-
-=== Configuration in Rails
-
-To generate a configuration file (in the form of a `.rake` file), to set
-default options:
-
-    rails g annotate:install
-
-Edit this file to control things like output format, where annotations are
-added (top or bottom of file), and in which artifacts.
 == Rails Integration
 
 By default, once you've generated a configuration file, annotate will be


### PR DESCRIPTION
- previous rake task name (`annotate:install`) is no longer used
- rails configuration in readme was duplicated
