### PR TITLE
Code escape --sort flag in docs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -196,7 +196,7 @@ migrations were run).
 
 If you prefer to sort alphabetically so that the results of
 annotation are consistent regardless of what order migrations are executed in,
-use  --sort.
+use `--sort`.
 
 
 == Markdown


### PR DESCRIPTION
GitHub was automatically converting the `--` into an en-dash.  This code-escapes it to avoid that.
