### PR TITLE
Refactor initialization of exclude options

### DIFF
--- a/bin/annotate
+++ b/bin/annotate
@@ -119,7 +119,8 @@ OptionParser.new do |opts|
     end
   end
 
-  opts.on('-e', '--exclude [tests,fixtures,factories]', ['tests','fixtures','factories'], "Do not annotate fixtures, test files, and/or factories") do |exclusions|
+  opts.on('-e', '--exclude [DIRS]', ['tests','fixtures','factories'], "Do not annotate fixtures, test files, and/or factories") do |exclusions|
+    exclusions ||= %w(tests fixtures factories)  
     exclusions.each { |exclusion| ENV["exclude_#{exclusion}"] = "yes" }
   end
 


### PR DESCRIPTION
- update option parser
- didn't add tests b/c i'm not using rvm and can't see an easy way to add commandline option parsing tests

This seems to address issue #152.  I only did a few spot checks so it might need another look-see before you merge it.
