### PR TITLE
Always load models, since they may not be autoloaded by Rails

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -370,7 +370,7 @@ module AnnotateModels
     # in subdirectories without namespacing.
     def get_model_class(file)
       # this is for non-rails projects, which don't get Rails auto-require magic
-      require File.expand_path("#{model_dir}/#{file}") unless Module.const_defined?(:Rails)
+      require File.expand_path("#{model_dir}/#{file}")
       model_path = file.gsub(/\.rb$/, '')
       get_loaded_model(model_path) || get_loaded_model(model_path.split('/').last)
     end


### PR DESCRIPTION
When invoking annotation via `rake annotate_models`, it is not necessarily the case that models will have been auto-required by Rails (perhaps this is a new behavior in Rails 4?), so skipping the `require` means that nothing gets annotated.
