### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -85,7 +85,7 @@ To annotate just your models, tests, and factories:
 
 To annotate just your models:
 
-    annotate --exclude tests,fixtures,factories
+    annotate --exclude # This will annotate automatically all models and exclude: tests, fixtures and factories.
 
 To annotate routes.rb:
 


### PR DESCRIPTION
I noticed that executing:
annotate --exclude tests,fixtures,factories

throws the error:
/bin/annotate:21:in `<top (required)>': invalid argument: --exclude tests,fixtures,factories (OptionParser::InvalidArgument)

and digging in the gem, I found that it should be only:
annotate --exclude
or:
annotate -e

So I propose the following update to your REAMDME file:

86  To annotate just your models:
87  
88      annotate --exclude # This will annotate automatically all models and exclude: tests, fixtures and factories.

Thanks.
