### PR TITLE
Replacing old block with new one.

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -241,13 +241,17 @@ module AnnotateModels
 #           end
 # =======
 
-          # Strip the old schema info, and insert new schema info.
-          old_content.sub!(encoding, '')
-          old_content.sub!(PATTERN, '')
+          if PATTERN.match(old_content)
+            new_content = old_content.sub(PATTERN, info_block)
+          else
+            # Strip the old schema info, and insert new schema info.
+            old_content.sub!(encoding, '')
+            old_content.sub!(PATTERN, '')
 
-          new_content = options[position].to_s == 'after' ?
-            (encoding_header + (old_content.rstrip + "\n\n" + info_block)) :
-            (encoding_header + info_block + "\n" + old_content)
+            new_content = options[position].to_s == 'after' ?
+              (encoding_header + (old_content.rstrip + "\n\n" + info_block)) :
+              (encoding_header + info_block + "\n" + old_content)
+          end
 
           File.open(file_name, "wb") { |f| f.puts new_content }
           return true


### PR DESCRIPTION
When the old block with database schema is already present in file, but was moved around (eg. pushed to the bottom of documentation block), instead of rewriting the file, replace old schema info with new one in the same place.
