### PR TITLE
Adjusting column match regexp to match markdown template

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -222,7 +222,7 @@ module AnnotateModels
         old_header = old_content.match(header_pattern).to_s
         new_header = info_block.match(header_pattern).to_s
 
-        column_pattern = /^#[\t ]+\w+[\t ]+.+$/
+        column_pattern = /^#[\t ]+[\w\*`]+[\t ]+.+$/
         old_columns = old_header && old_header.scan(column_pattern).sort
         new_columns = new_header && new_header.scan(column_pattern).sort
 
@@ -235,7 +235,7 @@ module AnnotateModels
           # Replace inline the old schema info with the new schema info
           new_content = old_content.sub(PATTERN, info_block + "\n")
 
-          if new_content.end_with? (info_block + "\n")
+          if new_content.end_with?(info_block + "\n")
             new_content = old_content.sub(PATTERN, "\n" + info_block)
           end
            


### PR DESCRIPTION
`column_pattern` matcher does not match columns generated with markdown formatting.
This leads to `old_columns` and `new_columns` containing only header and not annotating models.
