### PR TITLE
Fix bug of annotate position in routes

### DIFF
--- a/bin/annotate
+++ b/bin/annotate
@@ -63,7 +63,7 @@ OptionParser.new do |opts|
 
   opts.on('--pr', '--position-in-routes [before|after]', ['before', 'after'],
           "Place the annotations at the top (before) or the bottom (after) of the routes.rb file") do |p|
-    ENV['position_in_test'] = p
+    ENV['position_in_routes'] = p
     has_set_position['position_in_routes'] = true
   end
 


### PR DESCRIPTION
Currently, we cannot annotate routes in after position. Please merge this and update gem version.

Thanks.
