### PR TITLE
don't need parentheses in if check

### DIFF
--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -1,7 +1,7 @@
 # NOTE: only doing this in development as some production environments (Heroku)
 # NOTE: are sensitive to local FS writes, and besides -- it's just not proper
 # NOTE: to have a dev-mode tool do its thing in production.
-if(Rails.env.development?)
+if Rails.env.development?
   task :set_annotation_options do
     # You can override any of these by setting an environment variable of the
     # same name.


### PR DESCRIPTION
Just noticed this when I installed annotate locally.
