### PR TITLE
Coerce class to string for comparison

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -399,7 +399,7 @@ module AnnotateModels
             c.ancestors.respond_to?(:include?) and  # to fix FactoryGirl bug, see https://github.com/ctran/annotate_models/pull/82
             c.ancestors.include?(ActiveRecord::Base)
           end.
-          detect { |c| ActiveSupport::Inflector.underscore(c) == model_path }
+          detect { |c| ActiveSupport::Inflector.underscore(c.to_s) == model_path }
       end
     end
 


### PR DESCRIPTION
Fixes #173, by ensuring that the model is coerced to a string before it's run through `ActiveSupport::Inflector.underscore`, which then correctly compares to the filename (which is a string already).
