### PR TITLE
Skip "models/concerns" (since rails 4.0)

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -354,7 +354,7 @@ module AnnotateModels
             models = if options[:ignore_model_sub_dir]
               Dir["*.rb"]
             else
-              Dir["**/*.rb"]
+              Dir["**/*.rb"].reject{ |f| f["concerns/"] }
             end
           end
         rescue SystemCallError


### PR DESCRIPTION
Since rails 4 `concerns` placed under `models` directory, so we should skip `models/concerns` folder in models annotation
