### PR TITLE
sort simple_index indexes by name

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -151,7 +151,7 @@ module AnnotateModels
         if options[:simple_indexes] && klass.table_exists?# Check out if this column is indexed
           indices = klass.connection.indexes(klass.table_name)
           if indices = indices.select { |ind| ind.columns.include? col.name }
-            indices.each do |ind|
+            indices.sort_by{|ind| ind.name}.each do |ind|
               ind = ind.columns.reject! { |i| i == col.name }
               attrs << (ind.length == 0 ? "indexed" : "indexed => [#{ind.join(", ")}]")
             end


### PR DESCRIPTION
Prevent different users from suffering huge model diffs due to random change of ordering.

Similar to #79 but applies when using simple_index. 
