### PR TITLE
Updaet README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -51,7 +51,7 @@ Also, if you pass the -r option, it'll annotate routes.rb with the output of
 
 Into Gemfile from rubygems.org:
 
-    gem 'annotate', ">~ 2.6.5"
+    gem 'annotate', "~> 2.6.5"
 
 Into Gemfile from Github:
 


### PR DESCRIPTION
When I run `bundle install`, it was error.  
This is sytax error of Gemfile.

I get error message.

```
/Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/2.1.0/rubygems/requirement.rb:86:in `parse': Illformed requirement [">~ 2.6.5"] (Gem::Requirement::BadRequirementError)
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/2.1.0/rubygems/requirement.rb:116:in `block in initialize'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/2.1.0/rubygems/requirement.rb:116:in `map!'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/2.1.0/rubygems/requirement.rb:116:in `initialize'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/2.1.0/rubygems/requirement.rb:53:in `new'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/2.1.0/rubygems/requirement.rb:53:in `create'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/2.1.0/rubygems/dependency.rb:58:in `initialize'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/dependency.rb:39:in `initialize'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/dsl.rb:82:in `new'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/dsl.rb:82:in `gem'
       /Users/Kikeda/a_simple_feedback/Gemfile:46:in `block in eval_gemfile'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/dsl.rb:183:in `group'
       /Users/Kikeda/a_simple_feedback/Gemfile:43:in `eval_gemfile'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/dsl.rb:36:in `instance_eval'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/dsl.rb:36:in `eval_gemfile'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/dsl.rb:10:in `evaluate'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/definition.rb:26:in `build'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler.rb:153:in `definition'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/cli/install.rb:76:in `run'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/cli.rb:145:in `install'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/vendor/thor/command.rb:27:in `run'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/vendor/thor/invocation.rb:121:in `invoke_command'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/vendor/thor.rb:363:in `dispatch'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/vendor/thor/base.rb:440:in `start'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/cli.rb:9:in `start'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/bin/bundle:20:in `block in <top (required)>'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/lib/bundler/friendly_errors.rb:5:in `with_friendly_errors'
       /Users/Kikeda/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/bundler-1.6.5/bin/bundle:18:in `<top (required)>'
       /Users/Kikeda/.rbenv/versions/2.1.0/bin/bundle:23:in `load'
       /Users/Kikeda/.rbenv/versions/2.1.0/bin/bundle:23:in `<main>'
There was an error in your Gemfile, and Bundler cannot continue.
```
