### PR TITLE
Use consistent single quotes in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -51,7 +51,7 @@ Also, if you pass the -r option, it'll annotate routes.rb with the output of
 
 Into Gemfile from rubygems.org:
 
-    gem 'annotate', "~> 2.6.5"
+    gem 'annotate', '~> 2.6.5'
 
 Into Gemfile from Github:
 
@@ -137,11 +137,11 @@ executed whenever you run +rake db:migrate+ (but only in development mode).
 If you want to disable this behavior permanently, edit the +.rake+ file and
 change:
 
-    'skip_on_db_migrate'   => "false",
+    'skip_on_db_migrate'   => 'false',
 
 To:
 
-    'skip_on_db_migrate'   => "true",
+    'skip_on_db_migrate'   => 'true',
 
 If you want to run +rake db:migrate+ as a one-off without running annotate,
 you can do so with a simple environment variable, instead of editing the


### PR DESCRIPTION
This caught my eye while perusing the `README`. Certainly not the end of the world, but also a quick fix :)

Thanks for the work you (and others) have put into this gem!
