### PR TITLE
require activesupport core extension .blank?

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -6,9 +6,11 @@ require 'annotate/annotate_routes'
 begin
   # ActiveSupport 3.x...
   require 'active_support/hash_with_indifferent_access'
+  require 'active_support/core_ext/object/blank'
 rescue Exception => e
   # ActiveSupport 2.x...
   require 'active_support/core_ext/hash/indifferent_access'
+  require 'active_support/core_ext/blank'
 end
 
 module Annotate


### PR DESCRIPTION
When using annotate outside of a Rails environment activesupport core extension .blank? is required.
