### PR TITLE
Add option for classified annotation (id first, timestamps/assotiactions last)

### DIFF
--- a/bin/annotate
+++ b/bin/annotate
@@ -134,6 +134,11 @@ OptionParser.new do |opts|
     ENV['sort'] = "yes"
   end
 
+  opts.on('--classified-sort',
+          "Sort columns alphabetically, but first goes id, then the rest columns, then the timestamp columns and then the association columns") do |dir|
+    ENV['classified_sort'] = "yes"
+  end
+
   opts.on('-R', '--require path',
           "Additional file to require before loading models, may be used multiple times") do |path|
     if !ENV['require'].blank?

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -6,9 +6,11 @@ require 'annotate/annotate_routes'
 begin
   # ActiveSupport 3.x...
   require 'active_support/hash_with_indifferent_access'
+  require 'active_support/core_ext/object/blank'
 rescue Exception => e
   # ActiveSupport 2.x...
   require 'active_support/core_ext/hash/indifferent_access'
+  require 'active_support/core_ext/blank'
 end
 
 module Annotate
@@ -24,7 +26,7 @@ module Annotate
     :show_indexes, :simple_indexes, :include_version, :exclude_tests,
     :exclude_fixtures, :exclude_factories, :ignore_model_sub_dir,
     :format_bare, :format_rdoc, :format_markdown, :sort, :force, :trace,
-    :timestamp, :exclude_serializers
+    :timestamp, :exclude_serializers, :classified_sort
   ]
   OTHER_OPTIONS=[
     :ignore_columns

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -125,7 +125,9 @@ module AnnotateModels
       if options[:ignore_columns]
         cols.reject! { |col| col.name.match(/#{options[:ignore_columns]}/) }
       end
+
       cols = cols.sort_by(&:name) if(options[:sort])
+      cols = classified_sort(cols) if(options[:classified_sort])
       cols.each do |col|
         attrs = []
         attrs << "default(#{quote(col.default)})" unless col.default.nil?
@@ -490,6 +492,28 @@ module AnnotateModels
       return filename_template.
         gsub('%MODEL_NAME%', model_name).
         gsub('%TABLE_NAME%', table_name || model_name.pluralize)
+    end
+
+    def classified_sort(cols)
+      rest_cols = []
+      timestamps = []
+      associations = []
+      id = nil
+
+      cols = cols.each do |c|
+        if c.name.eql?("id")
+          id = c
+        elsif (c.name.eql?("created_at") || c.name.eql?("updated_at"))
+          timestamps << c
+        elsif c.name[-3,3].eql?("_id")
+          associations << c
+        else
+          rest_cols << c
+        end
+      end
+      [rest_cols, timestamps, associations].each {|a| a.sort_by!(&:name) }
+
+      return ([id] << rest_cols << timestamps << associations).flatten
     end
   end
 end

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -30,6 +30,7 @@ task :annotate_models => :environment do
   options[:format_markdown] = Annotate.true?(ENV['format_markdown'])
   options[:sort] = Annotate.true?(ENV['sort'])
   options[:force] = Annotate.true?(ENV['force'])
+  options[:classified_sort] = Annotate.true?(ENV['classified_sort'])
   options[:trace] = Annotate.true?(ENV['trace'])
   options[:wrapper_open] = Annotate.fallback(ENV['wrapper_open'], ENV['wrapper'])
   options[:wrapper_close] = Annotate.fallback(ENV['wrapper_close'], ENV['wrapper'])


### PR DESCRIPTION
Example:
        # == Schema Information
        #
        # Table name: pdsas
        #
        #  id              :integer          not null, primary key
        #  act             :text
        #  act_status      :string(255)
        #  end_date        :date
        #  evaluation      :text
        #  expectation     :text
        #  measurable_goal :text
        #  motivation      :text
        #  name            :string(255)
        #  plan            :text
        #  start_date      :date
        #  study           :text
        #  created_at      :datetime
        #  updated_at      :datetime
        #  area_id         :integer
        #  owner_id        :integer          indexed
        #  subject_id      :integer
        #  unit_id         :integer          indexed
        #
        # Indexes
        #
        #  index_pdsas_on_owner_id  (owner_id)
        #  index_pdsas_on_unit_id   (unit_id)
        #


I think it's much easier to work in that way. The option is --classified-sort.