### PR TITLE
use setup_options instead of set_defaults in rake task template

### DIFF
--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -5,7 +5,7 @@ if Rails.env.development?
   task :set_annotation_options do
     # You can override any of these by setting an environment variable of the
     # same name.
-    Annotate.set_defaults({
+    Annotate.setup_options({
       'position_in_routes'   => "before",
       'position_in_class'    => "before",
       'position_in_test'     => "before",


### PR DESCRIPTION
The template for automated rake task should probably use `setup_options` method instead of `set_defaults`