### PR TITLE
Prefer SQL column type over normalized AR type

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -140,7 +140,7 @@ module AnnotateModels
         attrs << "not null" unless col.null
         attrs << "primary key" if klass.primary_key && (klass.primary_key.is_a?(Array) ? klass.primary_key.collect{|c|c.to_sym}.include?(col.name.to_sym) : col.name.to_sym == klass.primary_key.to_sym)
 
-        col_type = (col.type || col.sql_type).to_s
+        col_type = (col.sql_type || col.type).to_s
         if col_type == "decimal"
           col_type << "(#{col.precision}, #{col.scale})"
         elsif col_type != "spatial"

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -28,7 +28,7 @@ describe AnnotateModels do
 
     stubs = default_options.dup
     stubs.merge!(options)
-    stubs.merge!(:name => name, :type => type)
+    stubs.merge!(:name => name, :sql_type => type, :type => type)
 
     double("Column", stubs)
   end


### PR DESCRIPTION
We have columns of type `point` in our PostgreSQL database:

```
#<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x007ffd7b829aa8
 @coder=nil,
 @default=nil,
 @limit=nil,
 @name="point",
 @null=false,
 @precision=nil,
 @primary=false,
 @scale=nil,
 @sql_type="point",
 @type=:string>
```

http://www.postgresql.org/docs/9.4/interactive/datatype-geometric.html

They are annotated as `string` in our models. This is misleading: `point` is actually 2 floats; not even close to a string.

I thought that SQL type should take precedence.

I understand that this change may be not enough or is completely wrong, and would welcome suggestions on the best solution.