### PR TITLE
options[:model_dir] seems to be an array now

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -71,7 +71,7 @@ module Annotate
       options[key] = (!ENV[key.to_s].blank?) ? ENV[key.to_s].split(',') : []
     end
 
-    if(!options[:model_dir])
+    if(options[:model_dir].empty?)
       options[:model_dir] = ['app/models']
     end
 


### PR DESCRIPTION
when using annotate from the command line with rails 4.2.0 and ruby 2.1.3, nothing was happening.
When using annotate with the --model-dir param, it did.

Looks like the defaulting of the model-dir to 'app/models' failed because of the test on whether its nil/empty