### PR TITLE
Adds support for foreign key annotations

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -175,6 +175,7 @@ you can do so with a simple environment variable, instead of editing the
         -v, --version                    Show the current version of this gem
         -m, --show-migration             Include the migration version number in the annotation
         -i, --show-indexes               List the table's database indexes in the annotation
+        -k, --show-foreign-keys          List the table's foreign key constraints in the annotation
         -s, --simple-indexes             Concat the column's related indexes in the annotation
             --model-dir dir              Annotate model files stored in dir rather than app/models, separate multiple dirs with comas
             --ignore-model-subdirects    Ignore subdirectories of the models directory

--- a/bin/annotate
+++ b/bin/annotate
@@ -109,6 +109,11 @@ OptionParser.new do |opts|
     ENV['include_version'] = "yes"
   end
 
+  opts.on('-k', '--show-foreign-keys',
+          "List the table's foreign key constraints in the annotation") do
+    ENV['show_foreign_keys'] = "yes"
+  end
+
   opts.on('-i', '--show-indexes',
           "List the table's database indexes in the annotation") do
     ENV['show_indexes'] = "yes"

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -26,7 +26,7 @@ module Annotate
     :show_indexes, :simple_indexes, :include_version, :exclude_tests,
     :exclude_fixtures, :exclude_factories, :ignore_model_sub_dir,
     :format_bare, :format_rdoc, :format_markdown, :sort, :force, :trace,
-    :timestamp, :exclude_serializers, :classified_sort
+    :timestamp, :exclude_serializers, :classified_sort, :show_foreign_keys,
   ]
   OTHER_OPTIONS=[
     :ignore_columns

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -11,6 +11,7 @@ if Rails.env.development?
       'position_in_test'     => "before",
       'position_in_fixture'  => "before",
       'position_in_factory'  => "before",
+      'show_foreign_keys'    => "true",
       'show_indexes'         => "true",
       'simple_indexes'       => "false",
       'model_dir'            => "app/models",

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -4,15 +4,32 @@ require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 
 describe AnnotateModels do
-  def mock_class(table_name, primary_key, columns)
+  def mock_foreign_key(name, from_column, to_table, to_column = 'id')
+    double("ForeignKeyDefinition",
+      :name         => name,
+      :column       => from_column,
+      :to_table     => to_table,
+      :primary_key  => to_column,
+    )
+  end
+
+  def mock_connection(indexes = [], foreign_keys = [])
+    double("Conn",
+      :indexes      => indexes,
+      :foreign_keys => foreign_keys,
+    )
+  end
+
+  def mock_class(table_name, primary_key, columns, foreign_keys = [])
     options = {
-      :connection   => double("Conn", :indexes => []),
-      :table_name   => table_name,
-      :primary_key  => primary_key,
-      :column_names => columns.map { |col| col.name.to_s },
-      :columns      => columns,
-      :column_defaults => Hash[columns.map { |col| 
-        [col.name, col.default] 
+      :connection       => mock_connection([], foreign_keys),
+      :table_exists?    => true,
+      :table_name       => table_name,
+      :primary_key      => primary_key,
+      :column_names     => columns.map { |col| col.name.to_s },
+      :columns          => columns,
+      :column_defaults  => Hash[columns.map { |col|
+        [col.name, col.default]
       }]
     }
 
@@ -123,6 +140,33 @@ EOS
 #  id   :integer          not null, primary key
 #  size :integer          default(20), not null
 #  flag :boolean          default(FALSE), not null
+#
+EOS
+  end
+
+  it "should get foreign key info" do
+           klass = mock_class(:users, :id, [
+              mock_column(:id, :integer),
+              mock_column(:foreign_thing_id, :integer),
+            ],
+            [
+              mock_foreign_key(
+                'fk_rails_02e851e3b7',
+                'foreign_thing_id',
+                'foreign_things'
+              )
+            ])
+            expect(AnnotateModels.get_schema_info(klass, "Schema Info", :show_foreign_keys => true)).to eql(<<-EOS)
+# Schema Info
+#
+# Table name: users
+#
+#  id               :integer          not null, primary key
+#  foreign_thing_id :integer          not null
+#
+# Foreign Keys
+#
+#  fk_rails_02e851e3b7  (foreign_thing_id => foreign_things.id)
 #
 EOS
   end

--- a/spec/integration/rails_4.1.1/lib/tasks/auto_annotate_models.rake
+++ b/spec/integration/rails_4.1.1/lib/tasks/auto_annotate_models.rake
@@ -11,6 +11,7 @@ if Rails.env.development?
       'position_in_test'     => "before",
       'position_in_fixture'  => "before",
       'position_in_factory'  => "before",
+      'show_foreign_keys'    => "true",
       'show_indexes'         => "true",
       'simple_indexes'       => "false",
       'model_dir'            => "app/models",

--- a/spec/integration/rails_4.2.0/lib/tasks/auto_annotate_models.rake
+++ b/spec/integration/rails_4.2.0/lib/tasks/auto_annotate_models.rake
@@ -11,6 +11,7 @@ if Rails.env.development?
       'position_in_test'     => "before",
       'position_in_fixture'  => "before",
       'position_in_factory'  => "before",
+      'show_foreign_keys'    => "true",
       'show_indexes'         => "true",
       'simple_indexes'       => "false",
       'model_dir'            => "app/models",


### PR DESCRIPTION
This adds support for foreign key annotations as requested in issue #236 .

I tried to follow the pattern used for index annotation, so it's enabled by default, and adds an additional section below the column definitions.

There's an example of the format in the spec: https://github.com/subakva/annotate_models/blob/features/foreign_key_annotations/spec/annotate/annotate_models_spec.rb#L160