### PR TITLE
Update annotate_models.rb

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -477,6 +477,8 @@ module AnnotateModels
 
     def annotate_model_file(annotated, file, header, options)
       begin
+        old_content = File.read(file) # Check model file for SkipSchemaAnnotations
+        return false if(old_content =~ /# -\*- SkipSchemaAnnotations.*\n/)
         klass = get_model_class(file)
         if klass && klass < ActiveRecord::Base && !klass.abstract_class? && klass.table_exists?
           if annotate(klass, file, header, options)


### PR DESCRIPTION
Potentially addresses issue# https://github.com/ctran/annotate_models/issues/167
Annotate_model_file is called automatically on all files in models directory and does not check if model contains SkipSchemaAnnotations tag.