### PR TITLE
Check if model has skip tag in annotate_model_file

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -477,6 +477,7 @@ module AnnotateModels
 
     def annotate_model_file(annotated, file, header, options)
       begin
+        return false if (/# -\*- SkipSchemaAnnotations.*/ =~ (File.exist?(file) ? File.read(file) : '') )
         klass = get_model_class(file)
         if klass && klass < ActiveRecord::Base && !klass.abstract_class? && klass.table_exists?
           if annotate(klass, file, header, options)


### PR DESCRIPTION
Potentially addresses issue# #167
Annotate_model_file is called automatically on all files in models directory and does not check if model contains SkipSchemaAnnotations tag.