### PR TITLE
Runs annotate on 'rake db:rollback' too

### DIFF
--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -2,20 +2,22 @@
 # (They are not used to build annotate itself.)
 
 # Append annotations to Rake tasks for ActiveRecord, so annotate automatically gets
-# run after doing db:migrate. 
+# run after doing db:migrate.
 # Unfortunately it relies on ENV for options; it'd be nice to be able to set options
 # in a per-project config file so this task can read them.
 namespace :db do
-  task :migrate do
-    Annotate::Migration.update_annotations
-  end
+  [:migrate, :rollback].each do |cmd|
+    task cmd do
+      Annotate::Migration.update_annotations
+    end
 
-  namespace :migrate do
-    [:change, :up, :down, :reset, :redo].each do |t|
-      task t do
-        Annotate::Migration.update_annotations 
+    namespace cmd do
+      [:change, :up, :down, :reset, :redo].each do |t|
+        task t do
+          Annotate::Migration.update_annotations
+        end
       end
-    end 
+    end
   end
 end
 
@@ -26,7 +28,7 @@ module Annotate
     def self.update_annotations
       unless @@working || (ENV['skip_on_db_migrate'] =~ /(true|t|yes|y|1)$/i)
         @@working = true
-        Rake::Task['annotate_models'].invoke 
+        Rake::Task['annotate_models'].invoke
       end
     end
   end


### PR DESCRIPTION
This adds the feature discussed in Issue #75 

My editor strips trailing whitespace and I can fix and resubmit if that's a problem.