### PR TITLE
Annotate fixtures for nested models

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -48,6 +48,8 @@ module AnnotateModels
   FIXTURE_PATTERNS = [
     File.join(FIXTURE_TEST_DIR, "%TABLE_NAME%.yml"),
     File.join(FIXTURE_SPEC_DIR, "%TABLE_NAME%.yml"),
+    File.join(FIXTURE_TEST_DIR, "%PLURALIZED_MODEL_NAME%.yml"),
+    File.join(FIXTURE_SPEC_DIR, "%PLURALIZED_MODEL_NAME%.yml"),
   ]
 
   FACTORY_PATTERNS = [
@@ -527,6 +529,7 @@ module AnnotateModels
     def resolve_filename(filename_template, model_name, table_name)
       return filename_template.
         gsub('%MODEL_NAME%', model_name).
+        gsub('%PLURALIZED_MODEL_NAME%', model_name.pluralize).
         gsub('%TABLE_NAME%', table_name || model_name.pluralize)
     end
 

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -435,6 +435,35 @@ end
     end
   end
 
+  describe '#resolve_filename' do
+
+    it 'should return the test path for a model' do
+      filename_template = 'test/unit/%MODEL_NAME%_test.rb'
+      model_name        = 'example_model'
+      table_name        = 'example_models'
+
+      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
+      expect(filename). to eq 'test/unit/example_model_test.rb'
+    end
+
+    it 'should return the fixture path for a model' do
+      filename_template = 'test/fixtures/%TABLE_NAME%.yml'
+      model_name        = 'example_model'
+      table_name        = 'example_models'
+
+      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
+      expect(filename). to eq 'test/fixtures/example_models.yml'
+    end
+
+    it 'should return the fixture path for a nested model' do
+      filename_template = 'test/fixtures/%PLURALIZED_MODEL_NAME%.yml'
+      model_name        = 'parent/child'
+      table_name        = 'parent_children'
+
+      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
+      expect(filename). to eq 'test/fixtures/parent/children.yml'
+    end
+  end
   describe "annotating a file" do
     before do
       @model_dir = Dir.mktmpdir('annotate_models')


### PR DESCRIPTION
This is a fix for https://github.com/ctran/annotate_models/issues/228

The gem was trying to annotate a fixture living at filepath ```'test/fixtures/parent_children.yml'```.

Rails generates nested models as such: ```'test/fixtures/parent/children.yml'```

The fix correctly targets fixtures created for nested models. I've added unit tests for the bug and for some existing functionality.