### PR TITLE
Quote each value in default arrays

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -93,6 +93,7 @@ module AnnotateModels
       when Float, Fixnum, Bignum    then value.to_s
         # BigDecimals need to be output in a non-normalized form and quoted.
       when BigDecimal               then value.to_s('F')
+      when Array                    then value.map {|v| quote(v)}
       else
         value.inspect
       end

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -56,6 +56,8 @@ describe AnnotateModels do
   it { expect(AnnotateModels.quote(25)).to eql("25") }
   it { expect(AnnotateModels.quote(25.6)).to eql("25.6") }
   it { expect(AnnotateModels.quote(1e-20)).to eql("1.0e-20") }
+  it { expect(AnnotateModels.quote(BigDecimal.new("1.2"))).to eql("1.2") }
+  it { expect(AnnotateModels.quote([BigDecimal.new("1.2")])).to eql(["1.2"]) }
 
   it "should get schema info" do
     klass = mock_class(:users, :id, [


### PR DESCRIPTION
Previously, quoting an array fell back to `inspect`, which is ok for
strings, but not good for BigDecimals, for instance.