### PR TITLE
Accept wrapper default params

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -29,7 +29,7 @@ module Annotate
     :timestamp, :exclude_serializers, :classified_sort, :show_foreign_keys,
   ]
   OTHER_OPTIONS=[
-    :ignore_columns, :skip_on_db_migrate
+    :ignore_columns, :skip_on_db_migrate, :wrapper_open, :wrapper_close
   ]
   PATH_OPTIONS=[
     :require, :model_dir

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -78,6 +78,12 @@ module Annotate
     return options
   end
 
+  def self.reset_options
+    [POSITION_OPTIONS, FLAG_OPTIONS, PATH_OPTIONS, OTHER_OPTIONS].flatten.each do |key|
+      ENV[key.to_s] = nil
+    end
+  end
+
   def self.skip_on_migration?
     ENV['skip_on_db_migrate'] =~ TRUE_RE
   end

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -30,6 +30,8 @@ if Rails.env.development?
       'sort'                    => "false",
       'force'                   => "false",
       'trace'                   => "false",
+      'wrapper_open'            => nil,
+      'wrapper_close'           => nil,
     })
   end
 

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -479,6 +479,7 @@ end
                                         mock_column(:name, :string, :limit => 50)
                                        ])
       @schema_info = AnnotateModels.get_schema_info(@klass, "== Schema Info")
+      Annotate.reset_options
     end
 
     def write_model file_name, file_content


### PR DESCRIPTION
This PR allows setting default `wrapper_start` and `wrapper_end` options for rake task.
I didn't include `wrapper` option here. While it's useful as a shorthand when setting options directly from the command line, I think it might be unnecessarily confusing here. If you don't agree, I can include it in the rake task as well.

PR fixes issue #266 