### PR TITLE
Annotate non-model test files: #286

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -27,13 +27,13 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rake>, ["~> 10.4"])
-      s.add_runtime_dependency(%q<activerecord>, [">= 3.2", "<= 4.3"])
+      s.add_runtime_dependency(%q<activerecord>, [">= 3.2", "< 6.0"])
     else
       s.add_dependency(%q<rake>, ["~> 10.4"])
-      s.add_dependency(%q<activerecord>, [">= 3.2", "<= 4.3"])
+      s.add_dependency(%q<activerecord>, [">= 3.2", "< 6.0"])
     end
   else
     s.add_dependency(%q<rake>, [">= 0.8.7"])
-    s.add_dependency(%q<activerecord>, [">= 3.2", "<= 4.3"])
+    s.add_dependency(%q<activerecord>, [">= 3.2", "< 6.0"])
   end
 end

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -27,6 +27,7 @@ module Annotate
     :exclude_fixtures, :exclude_factories, :ignore_model_sub_dir,
     :format_bare, :format_rdoc, :format_markdown, :sort, :force, :trace,
     :timestamp, :exclude_serializers, :classified_sort, :show_foreign_keys,
+    :exclude_scaffolds
   ]
   OTHER_OPTIONS=[
     :ignore_columns, :skip_on_db_migrate, :wrapper_open, :wrapper_close, :wrapper

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -17,6 +17,12 @@ module AnnotateModels
   FIXTURE_TEST_DIR      = File.join("test", "fixtures")
   FIXTURE_SPEC_DIR      = File.join("spec", "fixtures")
 
+  # Other test files
+  CONTROLLER_TEST_DIR   = File.join("test", "controllers")
+  CONTROLLER_SPEC_DIR   = File.join("spec", "controllers")
+  REQUEST_SPEC_DIR      = File.join("spec", "requests")
+  ROUTING_SPEC_DIR      = File.join("spec", "routing")
+
   # Object Daddy http://github.com/flogic/object_daddy/tree/master
   EXEMPLARS_TEST_DIR    = File.join("test", "exemplars")
   EXEMPLARS_SPEC_DIR    = File.join("spec", "exemplars")
@@ -50,6 +56,13 @@ module AnnotateModels
     File.join(FIXTURE_SPEC_DIR, "%TABLE_NAME%.yml"),
     File.join(FIXTURE_TEST_DIR, "%PLURALIZED_MODEL_NAME%.yml"),
     File.join(FIXTURE_SPEC_DIR, "%PLURALIZED_MODEL_NAME%.yml"),
+  ]
+
+  SCAFFOLD_PATTERNS = [
+    File.join(CONTROLLER_TEST_DIR, "%PLURALIZED_MODEL_NAME%_controller_test.rb"),
+    File.join(CONTROLLER_SPEC_DIR, "%PLURALIZED_MODEL_NAME%_controller_spec.rb"),
+    File.join(REQUEST_SPEC_DIR,    "%PLURALIZED_MODEL_NAME%_spec.rb"),
+    File.join(ROUTING_SPEC_DIR,    "%PLURALIZED_MODEL_NAME%_routing_spec.rb"),
   ]
 
   FACTORY_PATTERNS = [
@@ -344,6 +357,7 @@ module AnnotateModels
     #  :exclude_fixtures<Symbol>:: whether to skip modification of fixture files
     #  :exclude_factories<Symbol>:: whether to skip modification of factory files
     #  :exclude_serializers<Symbol>:: whether to skip modification of serializer files
+    #  :exclude_scaffolds<Symbol>:: whether to skip modification of scaffold files
     #
     def annotate(klass, file, header, options={})
       begin
@@ -357,7 +371,7 @@ module AnnotateModels
           did_annotate = true
         end
 
-        %w(test fixture factory serializer).each do |key|
+        %w(test fixture factory serializer scaffold).each do |key|
           exclusion_key = "exclude_#{key.pluralize}".to_sym
           patterns_constant = "#{key.upcase}_PATTERNS".to_sym
           position_key = "position_in_#{key}".to_sym
@@ -510,7 +524,7 @@ module AnnotateModels
             model_file_name = file
             deannotated_klass = true if(remove_annotation_of_file(model_file_name))
 
-            (TEST_PATTERNS + FIXTURE_PATTERNS + FACTORY_PATTERNS + SERIALIZER_PATTERNS).
+            (TEST_PATTERNS + SCAFFOLD_PATTERNS + FIXTURE_PATTERNS + FACTORY_PATTERNS + SERIALIZER_PATTERNS).
               map { |file| resolve_filename(file, model_name, table_name) }.
               each do |file|
                 if File.exist?(file)

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -22,6 +22,7 @@ if Rails.env.development?
       'exclude_fixtures'        => "false",
       'exclude_factories'       => "false",
       'exclude_serializers'     => "false",
+      'exclude_scaffolds'       => "false",
       'ignore_model_sub_dir'    => "false",
       'skip_on_db_migrate'      => "false",
       'format_bare'             => "true",

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -27,6 +27,7 @@ task :annotate_models => :environment do
   options[:exclude_factories] = Annotate.true?(ENV['exclude_factories'])
   options[:exclude_fixtures] = Annotate.true?(ENV['exclude_fixtures'])
   options[:exclude_serializers] = Annotate.true?(ENV['exclude_serializers'])
+  options[:exclude_scaffolds] = Annotate.true?(ENV['exclude_scaffolds'])
   options[:ignore_model_sub_dir] = Annotate.true?(ENV['ignore_model_sub_dir'])
   options[:format_bare] = Annotate.true?(ENV['format_bare'])
   options[:format_rdoc] = Annotate.true?(ENV['format_rdoc'])


### PR DESCRIPTION
----------

Related to #286:

----------

a scaffold generates files in the following rspec subdirectories:

+ `spec/models`
+ `spec/controllers`
+ `spec/requests`
+ `spec/routing`

currently, only `spec/models` is annotated. is there a way to annotate the other three?