### PR TITLE
Correctly find annotate_models task in an unmounted engine

### DIFF
--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -29,7 +29,13 @@ module Annotate
     def self.update_annotations
       unless @@working || Annotate.skip_on_migration?
         @@working = true
-        Rake::Task['annotate_models'].invoke
+        if Rake::Task.task_defined?("annotate_models")
+          Rake::Task["annotate_models"].invoke
+        elsif Rake::Task.task_defined?("app:annotate_models")
+          Rake::Task["app:annotate_models"].invoke
+        else
+          raise "Don't know how to build task 'annotate_models'"
+        end
       end
     end
   end


### PR DESCRIPTION
##### Fixes issue: #295

----------

Related to issue: #190 

+ Error is for non-mountable engines
+ Previous workaround was running `annotate` in the `spec/dummy` subdirectory (i.e. not having annotate run after every `db:migrate`)

----------

```
❯❯❯❯ rake db:migrate                                                                                                
rake aborted!
Don't know how to build task 'annotate_models'
/.../gems/annotate-2.6.7/lib/tasks/migrate.rake:29:in `update_annotations'
```