### PR TITLE
Fix: Ignore columns not respected when the rake task is invoked

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -143,7 +143,7 @@ module AnnotateModels
         info<< "# #{ '-' * ( max_size + md_names_overhead ) } | #{'-' * md_type_allowance} | #{ '-' * 27 }\n"
       end
 
-      cols = klass.columns
+      cols = klass.columns.dup
       if options[:ignore_columns]
         cols.reject! { |col| col.name.match(/#{options[:ignore_columns]}/) }
       end

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -38,6 +38,7 @@ task :annotate_models => :environment do
   options[:trace] = Annotate.true?(ENV['trace'])
   options[:wrapper_open] = Annotate.fallback(ENV['wrapper_open'], ENV['wrapper'])
   options[:wrapper_close] = Annotate.fallback(ENV['wrapper_close'], ENV['wrapper'])
+  options[:ignore_columns] = ENV['ignore_columns']
   AnnotateModels.do_annotations(options)
 end
 


### PR DESCRIPTION
* Consider ignore_columns config option when evailable
* Don't modify the original klass.columns array
** We are doing .reject! later