### PR TITLE
Fix :ignore_columns option in "auto_annotate_models" task

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -36,24 +36,26 @@ module Annotate
     :require, :model_dir
   ]
 
-
   ##
   # Set default values that can be overridden via environment variables.
   #
   def self.set_defaults(options = {})
     return if(@has_set_defaults)
     @has_set_defaults = true
+
     options = HashWithIndifferentAccess.new(options)
+
     [POSITION_OPTIONS, FLAG_OPTIONS, PATH_OPTIONS, OTHER_OPTIONS].flatten.each do |key|
-      if(options.has_key?(key))
-        default_value = if(options[key].is_a?(Array))
+      if options.has_key?(key)
+        default_value = if options[key].is_a?(Array)
           options[key].join(",")
         else
           options[key]
         end
       end
-      default_value = ENV[key.to_s] if(!ENV[key.to_s].blank?)
-      ENV[key.to_s] = default_value.to_s
+
+      default_value = ENV[key.to_s] if !ENV[key.to_s].blank?
+      ENV[key.to_s] = default_value.nil? ? nil : default_value.to_s
     end
   end
 

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -143,10 +143,13 @@ module AnnotateModels
         info<< "# #{ '-' * ( max_size + md_names_overhead ) } | #{'-' * md_type_allowance} | #{ '-' * 27 }\n"
       end
 
-      cols = klass.columns.dup
-      if options[:ignore_columns]
-        cols.reject! { |col| col.name.match(/#{options[:ignore_columns]}/) }
-      end
+      cols = if ignore_columns = options[:ignore_columns]
+               klass.columns.reject do |col|
+                 col.name.match(/#{ignore_columns}/)
+               end
+             else
+               klass.columns
+             end
 
       cols = cols.sort_by(&:name) if(options[:sort])
       cols = classified_sort(cols) if(options[:classified_sort])

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -24,6 +24,7 @@ if Rails.env.development?
       'exclude_serializers'     => 'false',
       'exclude_scaffolds'       => 'false',
       'ignore_model_sub_dir'    => 'false',
+      'ignore_columns'          => nil,
       'skip_on_db_migrate'      => 'false',
       'format_bare'             => 'true',
       'format_rdoc'             => 'false',

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -1,6 +1,6 @@
 annotate_lib = File.expand_path(File.dirname(File.dirname(__FILE__)))
 
-if(!ENV['is_cli'])
+if !ENV['is_cli']
   task :set_annotation_options
   task :annotate_models => :set_annotation_options
 end
@@ -38,7 +38,8 @@ task :annotate_models => :environment do
   options[:trace] = Annotate.true?(ENV['trace'])
   options[:wrapper_open] = Annotate.fallback(ENV['wrapper_open'], ENV['wrapper'])
   options[:wrapper_close] = Annotate.fallback(ENV['wrapper_close'], ENV['wrapper'])
-  options[:ignore_columns] = ENV['ignore_columns']
+  options[:ignore_columns] = ENV.fetch('ignore_columns', nil)
+
   AnnotateModels.do_annotations(options)
 end
 


### PR DESCRIPTION
When using the `auto_annotate_models` task, the `ignore_columns` option was always set to `""`, which caused `AnnotateModels.do_annotations` to ignore all columns.
