### PR TITLE
Run tests by Ruby 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3.0-preview1
+  - 2.3.0
 before_install:
   - rvm @global do gem install bundler


### PR DESCRIPTION
[Ruby 2.3.0](https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/) has been released.