### PR TITLE
Add :ignore_routes option to skip routes which should not be annotated based on regex

### DIFF
--- a/bin/annotate
+++ b/bin/annotate
@@ -178,6 +178,10 @@ OptionParser.new do |opts|
     ENV['ignore_columns'] = regex
   end
 
+  opts.on('--ignore-routes REGEX', "don't annotate routes that match a given REGEX (i.e., `annotate -I '(mobile|resque|pghero)'`" ) do |regex|
+    ENV['ignore_routes'] = regex
+  end
+
   opts.on('--hide-limit-column-types VALUES', "don't show limit for given column types, separated by comas (i.e., `integer,boolean,text`)" ) do |values|
     ENV['hide_limit_column_types'] = "#{values}"
   end

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -31,7 +31,7 @@ module Annotate
   ]
   OTHER_OPTIONS=[
     :ignore_columns, :skip_on_db_migrate, :wrapper_open, :wrapper_close, :wrapper, :routes,
-    :hide_limit_column_types,
+    :hide_limit_column_types, :ignore_routes
   ]
   PATH_OPTIONS=[
     :require, :model_dir, :root_dir

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -32,6 +32,10 @@ module AnnotateRoutes
     # keep the line around.
     routes_map.shift if(routes_map.first =~ /^\(in \//)
 
+    # Skip routes which match given regex
+    # Note: it matches the complete line (route_name, path, controller/action)
+    routes_map.reject!{|line| line.match(/#{options[:ignore_routes]}/)} if options[:ignore_routes]
+
     header = [
       "#{PREFIX}" + (options[:timestamp] ? " (Updated #{Time.now.strftime("%Y-%m-%d %H:%M")})" : ""),
       "#"

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -29,6 +29,7 @@ if Rails.env.development?
       'exclude_helpers'         => 'false',
       'ignore_model_sub_dir'    => 'false',
       'ignore_columns'          => nil,
+      'ignore_routes'           => nil,
       'ignore_unknown_models'   => 'false',
       'hide_limit_column_types' => '<%= AnnotateModels::NO_LIMIT_COL_TYPES.join(',') %>',
       'skip_on_db_migrate'      => 'false',

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -42,6 +42,7 @@ task :annotate_models => :environment do
   options[:wrapper_open] = Annotate.fallback(ENV['wrapper_open'], ENV['wrapper'])
   options[:wrapper_close] = Annotate.fallback(ENV['wrapper_close'], ENV['wrapper'])
   options[:ignore_columns] = ENV.fetch('ignore_columns', nil)
+  options[:ignore_routes] = ENV.fetch('ignore_routes', nil)
 
   AnnotateModels.do_annotations(options)
 end

--- a/lib/tasks/annotate_routes.rake
+++ b/lib/tasks/annotate_routes.rake
@@ -6,6 +6,7 @@ task :annotate_routes => :environment do
   options={}
   ENV['position'] = options[:position] = Annotate.fallback(ENV['position'], 'before')
   options[:position_in_routes] = Annotate.fallback(ENV['position_in_routes'], ENV['position'])
+  options[:ignore_routes] = Annotate.fallback(ENV['ignore_routes'],  nil)
   options[:require] = ENV['require'] ? ENV['require'].split(',') : []
   AnnotateRoutes.do_annotations(options)
 end


### PR DESCRIPTION
I use to skip routes which generate an annotation which includes local path e.g.,
````
#     /mobile       #<Rack::Builder:0x0000000a2ff800 @run=Mobile::Dispatch, @map=nil, @use=[#<Proc:0x0000000a30e2d8@/home/hasan/.rvm/gems/ruby-2.1.7@gogo/gems/rack-1.5.5/lib/rack/builder.rb:86>]>
#     /resque       #<Resque::Server app_file="/home/hasan/.rvm/gems/ruby-2.1.7@gogo/gems/resque-1.25.2/lib/resque/server.rb">
````
which causes a file change after every annotate run - leading to bad churn on codeclimate

add `ignore_routes: "#<"` to config options to skip such routes