### PR TITLE
Support hide_limit_column_types options in annotate_models.rake

### DIFF
--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -43,6 +43,7 @@ task :annotate_models => :environment do
   options[:wrapper_close] = Annotate.fallback(ENV['wrapper_close'], ENV['wrapper'])
   options[:ignore_columns] = ENV.fetch('ignore_columns', nil)
   options[:ignore_routes] = ENV.fetch('ignore_routes', nil)
+  options[:hide_limit_column_types] = Annotate.fallback(ENV['hide_limit_column_types'], '')
 
   AnnotateModels.do_annotations(options)
 end


### PR DESCRIPTION
Support `hide_limit_column_types` options in annotate_models.rake.

I want to output 'integer(8)'.