### PR TITLE
Don't leave wrapper when removing annotations

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -403,10 +403,11 @@ module AnnotateModels
       end
     end
 
-    def remove_annotation_of_file(file_name)
+    def remove_annotation_of_file(file_name, options={})
       if File.exist?(file_name)
         content = File.read(file_name)
-        content.sub!(PATTERN, '')
+        wrapper_open = options[:wrapper_open] ? "# #{options[:wrapper_open]}\n" : ""
+        content.sub!(/(#{wrapper_open})?#{PATTERN}/, '')
 
         File.open(file_name, 'wb') { |f| f.puts content }
 
@@ -623,13 +624,13 @@ module AnnotateModels
             model_name = klass.name.underscore
             table_name = klass.table_name
             model_file_name = file
-            deannotated_klass = true if remove_annotation_of_file(model_file_name)
+            deannotated_klass = true if remove_annotation_of_file(model_file_name, options)
 
             get_patterns(matched_types(options)).
               map { |f| resolve_filename(f, model_name, table_name) }.
               each do |f|
                 if File.exist?(f)
-                  remove_annotation_of_file(f)
+                  remove_annotation_of_file(f, options)
                   deannotated_klass = true
                 end
               end

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -514,6 +514,55 @@ class Foo < ActiveRecord::Base
 end
       EOS
     end
+
+    it "should remove opening wrapper" do
+      path = create "opening_wrapper.rb", <<-EOS
+# wrapper
+# == Schema Information
+#
+# Table name: foo
+#
+#  id                  :integer         not null, primary key
+#  created_at          :datetime
+#  updated_at          :datetime
+#
+
+class Foo < ActiveRecord::Base
+end
+      EOS
+
+      AnnotateModels.remove_annotation_of_file(path, wrapper_open: 'wrapper')
+
+      expect(content(path)).to eq <<-EOS
+class Foo < ActiveRecord::Base
+end
+      EOS
+    end
+
+    it "should remove closing wrapper" do
+      path = create "closing_wrapper.rb", <<-EOS
+class Foo < ActiveRecord::Base
+end
+
+# == Schema Information
+#
+# Table name: foo
+#
+#  id                  :integer         not null, primary key
+#  created_at          :datetime
+#  updated_at          :datetime
+#
+# wrapper
+
+      EOS
+
+      AnnotateModels.remove_annotation_of_file(path, wrapper_close: 'wrapper')
+
+      expect(content(path)).to eq <<-EOS
+class Foo < ActiveRecord::Base
+end
+      EOS
+    end
   end
 
   describe '#resolve_filename' do


### PR DESCRIPTION
This fixes issue #329 .
When removing annotations it will also remove the opening wrapper.
There are two ways it could be implemented:
* remove line before the annotation if it matches the `wrapper_open`
* remove the line before the annotation if it's a comment

I went with the first option, because I wanted to avoid the risk of removing a comment that isn't a wrapper opening. The drawback is that it will only work if the `wrapper_option` is set to the same value as it was when the annotation was created.
Let me know if you think the alternative approach would be better.
