### PR TITLE
Annotate should reset the cached information about columns

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -347,6 +347,7 @@ module AnnotateModels
     #
     def annotate(klass, file, header, options={})
       begin
+        klass.reset_column_information
         info = get_schema_info(klass, header, options)
         did_annotate = false
         model_name = klass.name.underscore


### PR DESCRIPTION
Annotate should reset the cached information about columns because Annotate may output old information if we load `ActiveRecord::Base` class in migration files.

For example, if we have a following migration file and execute `rake db:migrate`, Annote does not output the default value and a not null constraint of the `some_value` column.

```ruby
class CreatePosts < ActiveRecord::Migration
  def change
    create_table :posts do |t|
      t.integer :some_value
    end

    # add a not null constraint to the some_value column

    # should update some_value with not null values
    # because records might exist which have null value in the some_value column

    Post.update_all(some_value: 1)

    change_column_null(:posts, :some_value, false)
    change_column_default(:posts, :some_value, 1)
  end
end
```

This commit fixes the above issue.

before this commit
```ruby
# == Schema Information
#
# Table name: posts
#
#  id         :integer          not null, primary key
#  some_value :integer
#

class Post < ActiveRecord::Base
end
```

after this commit
```ruby
# == Schema Information
#
# Table name: posts
#
#  id         :integer          not null, primary key
#  some_value :integer          default(1), not null
#

class Post < ActiveRecord::Base
end
```