### PR TITLE
Fix rubocop problems due to version change

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -542,7 +542,7 @@ Style/SpaceAfterComma:
 
 # Offense count: 16
 # Cop supports --auto-correct.
-Style/SpaceAfterControlKeyword:
+Style/SpaceAroundKeyword:
   Exclude:
     - 'spec/integration/common_validation.rb'
     - 'spec/integration/integration_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'terminal-notifier-guard', require: false
   gem 'simplecov', require: false
-  gem 'rubocop', require: false unless RUBY_VERSION =~ /^1.8/
+  gem 'rubocop', '~> 0.37.2', require: false unless RUBY_VERSION =~ /^1.8/
   gem 'coveralls'
   gem 'codeclimate-test-reporter'
 

--- a/Rakefile
+++ b/Rakefile
@@ -133,8 +133,8 @@ namespace :integration do
     integration_dir = File.expand_path(File.join(File.dirname(__FILE__), 'spec', 'integration'))
     # fixture_dir = File.expand_path(File.join(File.dirname(__FILE__), 'spec', 'fixtures'))
     target_dir = File.expand_path(ENV['TARGET']) if ENV['TARGET']
-    fail 'Must specify TARGET=x, where x is an integration test scenario!' unless target_dir && Dir.exist?(target_dir)
-    fail 'TARGET directory must be within spec/integration/!' unless target_dir.start_with?(integration_dir)
+    raise 'Must specify TARGET=x, where x is an integration test scenario!' unless target_dir && Dir.exist?(target_dir)
+    raise 'TARGET directory must be within spec/integration/!' unless target_dir.start_with?(integration_dir)
     candidates = {}
     FileList[
       "#{target_dir}/.rvmrc",

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -248,7 +248,7 @@ module AnnotateModels
           if indices = indices.select { |ind| ind.columns.include? col.name }
             indices.sort_by(&:name).each do |ind|
               ind = ind.columns.reject! { |i| i == col.name }
-              attrs << (ind.length == 0 ? "indexed" : "indexed => [#{ind.join(", ")}]")
+              attrs << (ind.empty? ? "indexed" : "indexed => [#{ind.join(", ")}]")
             end
           end
         end

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -143,13 +143,15 @@ module AnnotateRoutes
   end
 
   def self.where_header_found(real_content, header_found_at)
-    # By default assume the annotation was found in the middle of the file...
-    if header_found_at == 1 # ... unless we have evidence it was at the beginning ...
-      return real_content, :before
-    elsif header_found_at >= real_content.count # ... or that it was at the end.
-      return real_content, :after
-    end
+    # By default assume the annotation was found in the middle of the file
 
+    # ... unless we have evidence it was at the beginning ...
+    return real_content, :before if header_found_at == 1
+
+    # ... or that it was at the end.
+    return real_content, :after if header_found_at >= real_content.count
+
+    # and the default
     return real_content, header_found_at
   end
 


### PR DESCRIPTION
 - Replace SpaceAroundKeyword with SpaceAfterControlKeyword
 - Use an explicit rubocop version to avoid breakages during PRs