### PR TITLE
Fix fatal error when using `annotate` with ActiveRecord 4.1

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -321,7 +321,8 @@ module AnnotateModels
         fk_info = "#\n# Foreign Keys\n#\n"
       end
 
-      return '' unless klass.connection.supports_foreign_keys? && klass.connection.respond_to?(:foreign_keys)
+      return '' unless klass.connection.respond_to?(:supports_foreign_keys?) &&
+        klass.connection.supports_foreign_keys? && klass.connection.respond_to?(:foreign_keys)
 
       foreign_keys = klass.connection.foreign_keys(klass.table_name)
       return '' if foreign_keys.empty?


### PR DESCRIPTION
The fatal error was introduced with commit fc31d85. The method
`supports_foreign_keys?` is only available on ActiveRecord versions
`>= 4.2`.

Fixes issue 316.