### PR TITLE
Annotate on_delete/on_update foreign key constraints

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -105,7 +105,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 507
+  Max: 513
 
 # Offense count: 7
 Metrics/PerceivedComplexity:

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -330,10 +330,14 @@ module AnnotateModels
       max_size = foreign_keys.collect{|fk| fk.name.size}.max + 1
       foreign_keys.sort_by(&:name).each do |fk|
         ref_info = "#{fk.column} => #{fk.to_table}.#{fk.primary_key}"
+        constraints_info = ''
+        constraints_info += "ON DELETE => #{fk.on_delete} " if fk.on_delete
+        constraints_info += "ON UPDATE => #{fk.on_update} " if fk.on_update
+        constraints_info.strip!
         if options[:format_markdown]
-          fk_info << sprintf("# * `%s`:\n#     * **`%s`**\n", fk.name, ref_info)
+          fk_info << sprintf("# * `%s`%s:\n#     * **`%s`**\n", fk.name, constraints_info.blank? ? '' : " (_#{constraints_info}_)", ref_info)
         else
-          fk_info << sprintf("#  %-#{max_size}.#{max_size}s %s", fk.name, "(#{ref_info})").rstrip + "\n"
+          fk_info << sprintf("#  %-#{max_size}.#{max_size}s %s %s", fk.name, "(#{ref_info})", constraints_info).rstrip + "\n"
         end
       end
 


### PR DESCRIPTION
I find it very useful to have `on_delete` and `on_update` FK constraint values in annotations.

e.g.

`fk_rails_02e851e3b7  (foreign_thing_id => foreign_things.id) ON DELETE => nullify ON UPDATE => cascade`

in case of `-f makrdown` option:

`fk_rails_02e851e3b7 ` (_ON DELETE => nullify ON UPDATE => cascade_)