### PR TITLE
Allow rake 11 in annotate.gemspec

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -26,10 +26,10 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rake>, ["~> 10.4"])
+      s.add_runtime_dependency(%q<rake>, [">= 10.4", "< 12.0"])
       s.add_runtime_dependency(%q<activerecord>, [">= 3.2", "< 6.0"])
     else
-      s.add_dependency(%q<rake>, ["~> 10.4"])
+      s.add_dependency(%q<rake>, [">= 10.4", "< 12.0"])
       s.add_dependency(%q<activerecord>, [">= 3.2", "< 6.0"])
     end
   else


### PR DESCRIPTION
This is the same as #359 but against the develop branch.