### PR TITLE
fix so that the wrapper-opening does not gets duplicated

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -105,7 +105,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 513
+  Max: 516
 
 # Offense count: 7
 Metrics/PerceivedComplexity:


### PR DESCRIPTION
Hi,

I have found a bug where (wenn generating with an wrapper-open and wrapper-close) the wrapper-open text stays in the document.

The wrapper-open content gets repeated even more when renewing the annotations.

transforming:
```
# rubocop:disable Metrics/LineLength
# == Schema Information
#
# Table name: pages
#
# *id*::                            <tt>integer, not null, primary key</tt>
# *created_at*::                    <tt>datetime</tt>
# *updated_at*::                    <tt>datetime</tt>
#--
# == Schema Information End
#++
# rubocop:enable Metrics/LineLength
```

into:

```
# rubocop:disable Metrics/LineLength
# == Schema Information
#
# Table name: pages
#
# *id*::                            <tt>integer, not null, primary key</tt>
# *created_at*::                    <tt>datetime</tt>
# *updated_at*::                    <tt>datetime</tt>
#--
# == Schema Information End
#++
# rubocop:enable Metrics/LineLength

# rubocop:disable Metrics/LineLength
```

in this example the `# rubocop:disable Metrics/LineLength` gets increased on every annotation change.

this pull request fixes this bug.