### PR TITLE
add option to exclude STI subclasses from annotation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -105,7 +105,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 517
+  Max: 522
 
 # Offense count: 7
 Metrics/PerceivedComplexity:

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -29,7 +29,8 @@ module Annotate
     :exclude_fixtures, :exclude_factories, :ignore_model_sub_dir,
     :format_bare, :format_rdoc, :format_markdown, :sort, :force, :trace,
     :timestamp, :exclude_serializers, :classified_sort, :show_foreign_keys,
-    :exclude_scaffolds, :exclude_controllers, :exclude_helpers, :ignore_unknown_models
+    :exclude_scaffolds, :exclude_controllers, :exclude_helpers,
+    :exclude_sti_subclasses, :ignore_unknown_models
   ].freeze
   OTHER_OPTIONS = [
     :ignore_columns, :skip_on_db_migrate, :wrapper_open, :wrapper_close, :wrapper, :routes,

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -453,6 +453,7 @@ module AnnotateModels
     #  :exclude_scaffolds<Symbol>:: whether to skip modification of scaffold files
     #  :exclude_controllers<Symbol>:: whether to skip modification of controller files
     #  :exclude_helpers<Symbol>:: whether to skip modification of helper files
+    #  :exclude_sti_subclasses<Symbol>:: whether to skip modification of files for STI subclasses
     #
     # == Returns:
     # an array of file names that were annotated.
@@ -609,7 +610,12 @@ module AnnotateModels
       begin
         return false if /# -\*- SkipSchemaAnnotations.*/ =~ (File.exist?(file) ? File.read(file) : '')
         klass = get_model_class(file)
-        if klass && klass < ActiveRecord::Base && !klass.abstract_class? && klass.table_exists?
+        do_annotate = klass &&
+          klass < ActiveRecord::Base &&
+          (!options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name)) &&
+          !klass.abstract_class? &&
+          klass.table_exists?
+        if do_annotate
           annotated.concat(annotate(klass, file, header, options))
         end
       rescue BadModelFileError => e

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -27,6 +27,7 @@ if Rails.env.development?
       'exclude_scaffolds'       => 'true',
       'exclude_controllers'     => 'true',
       'exclude_helpers'         => 'true',
+      'exclude_sti_subclasses'  => 'false',
       'ignore_model_sub_dir'    => 'false',
       'ignore_columns'          => nil,
       'ignore_routes'           => nil,

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -31,6 +31,7 @@ task annotate_models: :environment do
   options[:exclude_scaffolds] = Annotate.true?(ENV['exclude_scaffolds'])
   options[:exclude_controllers] = Annotate.true?(ENV.fetch('exclude_controllers', 'true'))
   options[:exclude_helpers] = Annotate.true?(ENV.fetch('exclude_helpers', 'true'))
+  options[:exclude_sti_subclasses] = Annotate.true?(ENV['exclude_sti_subclasses'])
   options[:ignore_model_sub_dir] = Annotate.true?(ENV['ignore_model_sub_dir'])
   options[:format_bare] = Annotate.true?(ENV['format_bare'])
   options[:format_rdoc] = Annotate.true?(ENV['format_rdoc'])

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -905,7 +905,7 @@ end
     after { Object.send :remove_const, 'Foo' }
 
     it 'skips attempt to annotate if no table exists for model' do
-      annotate_model_file = AnnotateModels.annotate_model_file([], 'foo.rb', nil, nil)
+      annotate_model_file = AnnotateModels.annotate_model_file([], 'foo.rb', nil, {})
 
       expect(annotate_model_file).to eq nil
     end


### PR DESCRIPTION
I've added an option named `exclude_sti_subclasses` and code which checks if a model has a superclass under AR::B with the same table in order to exclude STI subclasses from annotation. 

this is a need I have on a project with a large number of subclasses of certain models, where annotating every one generates a lot of noise on any schema change, so I prefer to just annotate the parent class. 