### PR TITLE
Enable the option to always annotate a file.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -105,7 +105,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 516
+  Max: 521
 
 # Offense count: 7
 Metrics/PerceivedComplexity:

--- a/README.rdoc
+++ b/README.rdoc
@@ -120,6 +120,10 @@ anywhere in the file:
 
     # -*- SkipSchemaAnnotations
 
+If you want to always annotate a particular model, add this string anywhere in the file (note: SkipSchemaAnnotations takes precedence over this option):
+
+    # -*- AlwaysAnnotate
+
 === Configuration in Rails
 
 To generate a configuration file (in the form of a +.rake+ file), to set

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -29,7 +29,8 @@ module Annotate
     :exclude_fixtures, :exclude_factories, :ignore_model_sub_dir,
     :format_bare, :format_rdoc, :format_markdown, :sort, :force, :trace,
     :timestamp, :exclude_serializers, :classified_sort, :show_foreign_keys,
-    :exclude_scaffolds, :exclude_controllers, :exclude_helpers, :ignore_unknown_models
+    :exclude_scaffolds, :exclude_controllers, :exclude_helpers,
+    :exclude_sti_subclasses, :ignore_unknown_models
   ].freeze
   OTHER_OPTIONS = [
     :ignore_columns, :skip_on_db_migrate, :wrapper_open, :wrapper_close, :wrapper, :routes,

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -607,15 +607,24 @@ module AnnotateModels
 
     def annotate_model_file(annotated, file, header, options)
       begin
-        return false if /# -\*- SkipSchemaAnnotations.*/ =~ (File.exist?(file) ? File.read(file) : '')
-        klass = get_model_class(file)
-        do_annotate = klass &&
-          klass < ActiveRecord::Base &&
-          (!options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name)) &&
-          !klass.abstract_class? &&
-          klass.table_exists?
-        if do_annotate
-          annotated.concat(annotate(klass, file, header, options))
+        if File.exists?(file)
+          old_content = File.read(file)
+          return false if old_content =~ /# -\*- SkipSchemaAnnotations.*\n/
+
+          # always_annotate = true if old content has the AlwaysAnnotate comment.
+          always_annotate = (old_content =~ /# -\*- AlwaysAnnotate.*\n/)
+
+          klass = get_model_class(file)
+          do_annotate = klass &&
+            klass < ActiveRecord::Base &&
+            (always_annotate || !options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name)) &&
+            !klass.abstract_class? &&
+            klass.table_exists?
+          if do_annotate
+            annotated.concat(annotate(klass, file, header, options))
+          end
+        else
+          return false
         end
       rescue BadModelFileError => e
         unless options[:ignore_unknown_models]

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -453,6 +453,7 @@ module AnnotateModels
     #  :exclude_scaffolds<Symbol>:: whether to skip modification of scaffold files
     #  :exclude_controllers<Symbol>:: whether to skip modification of controller files
     #  :exclude_helpers<Symbol>:: whether to skip modification of helper files
+    #  :exclude_sti_subclasses<Symbol>:: whether to skip modification of files for STI subclasses
     #
     # == Returns:
     # an array of file names that were annotated.
@@ -608,7 +609,12 @@ module AnnotateModels
       begin
         return false if /# -\*- SkipSchemaAnnotations.*/ =~ (File.exist?(file) ? File.read(file) : '')
         klass = get_model_class(file)
-        if klass && klass < ActiveRecord::Base && !klass.abstract_class? && klass.table_exists?
+        do_annotate = klass &&
+          klass < ActiveRecord::Base &&
+          (!options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name)) &&
+          !klass.abstract_class? &&
+          klass.table_exists?
+        if do_annotate
           annotated.concat(annotate(klass, file, header, options))
         end
       rescue BadModelFileError => e

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -27,6 +27,7 @@ if Rails.env.development?
       'exclude_scaffolds'       => 'true',
       'exclude_controllers'     => 'true',
       'exclude_helpers'         => 'true',
+      'exclude_sti_subclasses'  => 'false',
       'ignore_model_sub_dir'    => 'false',
       'ignore_columns'          => nil,
       'ignore_routes'           => nil,

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -31,6 +31,7 @@ task annotate_models: :environment do
   options[:exclude_scaffolds] = Annotate.true?(ENV['exclude_scaffolds'])
   options[:exclude_controllers] = Annotate.true?(ENV.fetch('exclude_controllers', 'true'))
   options[:exclude_helpers] = Annotate.true?(ENV.fetch('exclude_helpers', 'true'))
+  options[:exclude_sti_subclasses] = Annotate.true?(ENV['exclude_sti_subclasses'])
   options[:ignore_model_sub_dir] = Annotate.true?(ENV['ignore_model_sub_dir'])
   options[:format_bare] = Annotate.true?(ENV['format_bare'])
   options[:format_rdoc] = Annotate.true?(ENV['format_rdoc'])


### PR DESCRIPTION
If you want to always annotate a particular model, add this string anywhere in the file (note: SkipSchemaAnnotations takes precedence over this option):

    # -*- AlwaysAnnotate