### PR TITLE
Fix spelling to commas

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -184,7 +184,7 @@ you can do so with a simple environment variable, instead of editing the
         -i, --show-indexes               List the table's database indexes in the annotation
         -k, --show-foreign-keys          List the table's foreign key constraints in the annotation
         -s, --simple-indexes             Concat the column's related indexes in the annotation
-            --model-dir dir              Annotate model files stored in dir rather than app/models, separate multiple dirs with comas
+            --model-dir dir              Annotate model files stored in dir rather than app/models, separate multiple dirs with commas
             --ignore-model-subdirects    Ignore subdirectories of the models directory
             --sort                       Sort columns alphabetically, rather than in creation order
         -R, --require path               Additional file to require before loading models, may be used multiple times

--- a/bin/annotate
+++ b/bin/annotate
@@ -119,12 +119,12 @@ OptionParser.new do |opts|
   end
 
   opts.on('--model-dir dir',
-          "Annotate model files stored in dir rather than app/models, separate multiple dirs with comas") do |dir|
+          "Annotate model files stored in dir rather than app/models, separate multiple dirs with commas") do |dir|
     ENV['model_dir'] = dir
   end
 
   opts.on('--root-dir dir',
-          "Annotate files stored within root dir projects, separate multiple dirs with comas") do |dir|
+          "Annotate files stored within root dir projects, separate multiple dirs with commas") do |dir|
     ENV['root_dir'] = dir
   end
 
@@ -181,7 +181,7 @@ OptionParser.new do |opts|
     ENV['ignore_routes'] = regex
   end
 
-  opts.on('--hide-limit-column-types VALUES', "don't show limit for given column types, separated by comas (i.e., `integer,boolean,text`)") do |values|
+  opts.on('--hide-limit-column-types VALUES', "don't show limit for given column types, separated by commas (i.e., `integer,boolean,text`)") do |values|
     ENV['hide_limit_column_types'] = "#{values}"
   end
 


### PR DESCRIPTION
Command line options documentation previously asked for values to be separated by "comas" not "commas."