### PR TITLE
quote default Rails attribute

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -161,7 +161,7 @@ module AnnotateModels
     end
 
     # Simple quoting for the default column value
-    def quote(value)
+    def quote(value, column, klass = nil)
       case value
       when NilClass                 then 'NULL'
       when TrueClass                then 'TRUE'
@@ -170,13 +170,18 @@ module AnnotateModels
         # BigDecimals need to be output in a non-normalized form and quoted.
       when BigDecimal               then value.to_s('F')
       when Array                    then value.map {|v| quote(v)}
+      when String                   then value.inspect
       else
-        value.inspect
+        if defined?(Rails) && !klass.nil?
+          quote(klass._default_attributes[column.name].type.serialize(value), column)
+        else
+          value.inspect
+        end
       end
     end
 
     def schema_default(klass, column)
-      quote(klass.column_defaults[column.name])
+      quote(klass.column_defaults[column.name], column, klass)
     end
 
     # Use the column information in an ActiveRecord class


### PR DESCRIPTION
Hiho

I'm developing Rails application with Rails 5.0.0.rc1 and using custom model attrubute, and default value **0** in mysql (http://edgeapi.rubyonrails.org/classes/ActiveRecord/Attributes/ClassMethods.html#method-i-attribute-label-Creating+Custom+Types), as annotate was doing value.inspect on this object, each time i called **annotate** the header changed, as object id changed. It looked like this:

``` ruby
# == Schema Information
#
# Table name: blockades
#
#  id              :integer          not null, primary key
#  user_id         :integer
#  blocked_user_id :integer
#  reason          :integer
#  days            :integer          default(#<ActiverecordTypes::BlockadeDays:0x00000006551440 @value=0>), not null
#  created_at      :datetime         not null
#  updated_at      :datetime         not null
#
class Blockade < ApplicationRecord
  # see activerecord_types/blockade_days.rb for details
  attribute :days, ActiverecordTypes::BlockadeDays::Type.new

```

Class **ActiverecordTypes::BlockadeDays::Type** was casting to this ActiverecordTypes::BlockadeDays

``` ruby
module ActiverecordTypes
  class BlockadeDays
   # (...)

    class Type < ActiveRecord::Type::Value
      def cast(value)
        BlockadeDays.new(value)
      end

      def serialize(value)
        case value.class
        when BlockadeDays
          value.value
        when Integer
          value
        else
          BlockadeDays.new(value).value
        end
      end

      def deserialize(value)
        BlockadeDays.new(value)
      end
    end
  end
end
```

I feel like showing default value from database is more useful and less irritating than previous implementation so after this changes it shows:

``` ruby
# == Schema Information
#
# Table name: blockades
#
#  id              :integer          not null, primary key
#  user_id         :integer
#  blocked_user_id :integer
#  reason          :integer
#  days            :integer          default(0), not null
#  created_at      :datetime         not null
#  updated_at      :datetime         not null
#

class Blockade < ApplicationRecord
  # see activerecord_types/blockade_days.rb for details
  attribute :days, ActiverecordTypes::BlockadeDays::Type.new
```
