### PR TITLE
Add additional-subdir option

### DIFF
--- a/bin/annotate
+++ b/bin/annotate
@@ -189,7 +189,7 @@ OptionParser.new do |opts|
     ENV['ignore_unknown_models'] = 'true'
   end
 
-  opts.on('--additional-subdir dir', "Additionally annotate files in subdir of each scaffold/serializer/controller/helper dir, separate multiple dirs with comas" ) do |dir|
+  opts.on('--additional-subdir dir', "Additionally annotate files in subdir of each scaffold/serializer/controller/helper dir, separate multiple dirs with comas") do |dir|
     ENV['additional_subdir'] = "#{dir}"
   end
 

--- a/bin/annotate
+++ b/bin/annotate
@@ -189,6 +189,10 @@ OptionParser.new do |opts|
     ENV['ignore_unknown_models'] = 'true'
   end
 
+  opts.on('--additional-subdir dir', "Additionally annotate files in subdir of each scaffold/serializer/controller/helper dir, separate multiple dirs with comas" ) do |dir|
+    ENV['additional_subdir'] = "#{dir}"
+  end
+
 end.parse!
 
 options = Annotate.setup_options({is_rake: ENV['is_rake'] && !ENV['is_rake'].empty?})

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -37,7 +37,7 @@ module Annotate
     :hide_limit_column_types, :ignore_routes, :active_admin
   ].freeze
   PATH_OPTIONS = [
-    :require, :model_dir, :root_dir
+    :require, :model_dir, :root_dir, :additional_subdir
   ].freeze
 
   ##

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -83,7 +83,7 @@ module AnnotateModels
 
     attr_writer :root_dir
 
-    def test_files(root_directory, options)
+    def test_files(root_directory)
       [
           File.join(root_directory, UNIT_TEST_DIR,  "%MODEL_NAME%_test.rb"),
           File.join(root_directory, MODEL_TEST_DIR,  "%MODEL_NAME%_test.rb"),
@@ -91,7 +91,7 @@ module AnnotateModels
       ]
     end
 
-    def fixture_files(root_directory, options)
+    def fixture_files(root_directory)
       [
           File.join(root_directory, FIXTURE_TEST_DIR, "%TABLE_NAME%.yml"),
           File.join(root_directory, FIXTURE_SPEC_DIR, "%TABLE_NAME%.yml"),
@@ -106,7 +106,7 @@ module AnnotateModels
           File.join(root_directory, CONTROLLER_TEST_DIR, "%PLURALIZED_MODEL_NAME%_controller_test.rb"),
           File.join(root_directory, CONTROLLER_SPEC_DIR, "%PLURALIZED_MODEL_NAME%_controller_spec.rb"),
           File.join(root_directory, REQUEST_SPEC_DIR,    "%PLURALIZED_MODEL_NAME%_spec.rb"),
-          File.join(root_directory, ROUTING_SPEC_DIR,    "%PLURALIZED_MODEL_NAME%_routing_spec.rb"),
+          File.join(root_directory, ROUTING_SPEC_DIR,    "%PLURALIZED_MODEL_NAME%_routing_spec.rb")
         ]
 
       if options[:additional_subdir].try(:any?)
@@ -123,7 +123,7 @@ module AnnotateModels
       files
     end
 
-    def factory_files(root_directory, options)
+    def factory_files(root_directory)
       [
           File.join(root_directory, EXEMPLARS_TEST_DIR,     "%MODEL_NAME%_exemplar.rb"),
           File.join(root_directory, EXEMPLARS_SPEC_DIR,     "%MODEL_NAME%_exemplar.rb"),
@@ -195,10 +195,10 @@ module AnnotateModels
 
     def files_by_pattern(root_directory, pattern_type, options)
       case pattern_type
-        when 'test'       then test_files(root_directory, options)
-        when 'fixture'    then fixture_files(root_directory, options)
+        when 'test'       then test_files(root_directory)
+        when 'fixture'    then fixture_files(root_directory)
         when 'scaffold'   then scaffold_files(root_directory, options)
-        when 'factory'    then factory_files(root_directory, options)
+        when 'factory'    then factory_files(root_directory)
         when 'serializer' then serialize_files(root_directory, options)
         when 'controller' then controller_files(root_directory, options)
         when 'helper'     then helper_files(root_directory, options)

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -45,6 +45,7 @@ task annotate_models: :environment do
   options[:ignore_columns] = ENV.fetch('ignore_columns', nil)
   options[:ignore_routes] = ENV.fetch('ignore_routes', nil)
   options[:hide_limit_column_types] = Annotate.fallback(ENV['hide_limit_column_types'], '')
+  options[:additional_subdir] = ENV.fetch('additional_subdir', nil)
 
   AnnotateModels.do_annotations(options)
 end


### PR DESCRIPTION
This adds a path option called --additional-subdir, which according to the description, allows one to "Additionally annotate files in subdir of each scaffold/serializer/controller/helper dir, separate multiple dirs with comas"

The reason I made this feature is because in my app, I have a bunch of models, but each of these models can have multiple serializers, for example: serializers/products_serializer.rb and serializers/api/v1/products_serializer.rb both exist for the Product model. I do not want to namespace the Product model, because we are simply providing two different interfaces for the same model.

To accomplish this, we make the call annotate --additional-subdir api/v1 and it works great!
