### PR TITLE
Add `unsigned` support for numeric data types

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -81,7 +81,7 @@ Lint/UselessAccessModifier:
 
 # Offense count: 16
 Metrics/AbcSize:
-  Max: 154
+  Max: 156
 
 # Offense count: 2
 Metrics/BlockNesting:
@@ -89,7 +89,7 @@ Metrics/BlockNesting:
 
 # Offense count: 7
 Metrics/CyclomaticComplexity:
-  Max: 36
+  Max: 38
 
 # Offense count: 344
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes.
@@ -100,16 +100,16 @@ Metrics/LineLength:
 # Offense count: 24
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 83
+  Max: 84
 
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 522
+  Max: 523
 
 # Offense count: 7
 Metrics/PerceivedComplexity:
-  Max: 43
+  Max: 45
 
 # Offense count: 1
 Style/AccessorMethodName:

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -221,6 +221,7 @@ module AnnotateModels
 
         attrs = []
         attrs << "default(#{schema_default(klass, col)})" unless col.default.nil? || NO_DEFAULT_COL_TYPES.include?(col_type)
+        attrs << 'unsigned' if col.respond_to?(:unsigned?) && col.unsigned?
         attrs << 'not null' unless col.null
         attrs << 'primary key' if klass.primary_key && (klass.primary_key.is_a?(Array) ? klass.primary_key.collect(&:to_sym).include?(col.name.to_sym) : col.name.to_sym == klass.primary_key.to_sym)
 

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -118,6 +118,7 @@ EOS
 #
 EOS
   end
+
   it "should get schema info with enum type " do
     klass = mock_class(:users, nil, [
                                      mock_column(:id, :integer),
@@ -131,6 +132,29 @@ EOS
 #
 #  id   :integer          not null
 #  name :enum             not null, (enum1, enum2)
+#
+EOS
+  end
+
+  it "should get schema info with unsigned" do
+    klass = mock_class(:users, nil, [
+                                     mock_column(:id, :integer),
+                                     mock_column(:integer, :integer, :unsigned? => true),
+                                     mock_column(:bigint,  :bigint,  :unsigned? => true),
+                                     mock_column(:float,   :float,   :unsigned? => true),
+                                     mock_column(:decimal, :decimal, :unsigned? => true, :precision => 10, :scale => 2),
+                                    ])
+
+    expect(AnnotateModels.get_schema_info(klass, "Schema Info")).to eql(<<-EOS)
+# Schema Info
+#
+# Table name: users
+#
+#  id      :integer          not null
+#  integer :integer          unsigned, not null
+#  bigint  :bigint           unsigned, not null
+#  float   :float            unsigned, not null
+#  decimal :decimal(10, 2)   unsigned, not null
 #
 EOS
   end


### PR DESCRIPTION
Hi,

A data type of unsigned is supported from Rails 5, so this pull request supports it.

Example:

```
# Schema Info
#
# Table name: users
#
#  id      :integer          not null
#  integer :integer          unsigned, not null
#  bigint  :bigint           unsigned, not null
#  float   :float            unsigned, not null
#  decimal :decimal(10, 2)   unsigned, not null
#
```