### PR TITLE
dropped ruby version < 2.2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0
   - 2.1
   - 2.2
-  - 2.2.3
   - 2.2.4
+  - 2.2.5
   - 2.3.0
+  - 2.3.1
   - ruby-head
 matrix:
   allow_failures:
@@ -16,6 +15,7 @@ matrix:
     - rvm: 2.0
     - rvm: 2.1
     - rvm: 2.2
+    - rvm: 2.3
 before_install:
   - rvm @global do gem install bundler
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     - rvm: 2.0
     - rvm: 2.1
     - rvm: 2.2
+    - rvm: 2.2.4
     - rvm: 2.3
 before_install:
   - rvm @global do gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'terminal-notifier-guard', require: false
   gem 'simplecov', require: false
-  gem 'rubocop', '~> 0.37.2', require: false unless RUBY_VERSION =~ /^1.8/
+  gem 'rubocop', '~> 0.37.2', require: false
   gem 'coveralls'
   gem 'codeclimate-test-reporter'
 

--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -37,5 +37,12 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<activerecord>, [">= 3.2", "< 6.0"])
   end
 
-  s.add_dependency "ruby_dep", "<= 1.3.1"
+  begin
+    require "ruby_dep/travis"
+    s.required_ruby_version = RubyDep::Travis.new.version_constraint
+  rescue LoadError
+    abort "Install 'ruby_dep' gem before building this gem"
+  end
+
+  s.add_development_dependency 'ruby_dep', '~> 1.1'
 end

--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = "annotate"
   s.version = Annotate.version
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.1.0'
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Alex Chaffee", "Cuong Tran", "Marcos Piccinini", "Turadg Aleahmad", "Jon Frisby"]
   s.description = "Annotates Rails/ActiveRecord Models, routes, fixtures, and others based on the database schema."
@@ -36,4 +36,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<rake>, [">= 0.8.7"])
     s.add_dependency(%q<activerecord>, [">= 3.2", "< 6.0"])
   end
+
+  s.add_dependency "ruby_dep", "<= 1.3.1"
 end


### PR DESCRIPTION
https://github.com/ctran/annotate_models/issues/397

I'm sorry for pull requests in succession. I made a commit that I dropped old versions of Ruby.
This PR can make some of fail tests of other PRs passed.