### PR TITLE
Fixed Posgresql index tables with `public`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   gem 'rubocop', '~> 0.37.2', require: false unless RUBY_VERSION =~ /^1.8/
   gem 'coveralls'
   gem 'codeclimate-test-reporter'
+  gem 'ruby_dep', '1.3.1'
 
   platforms :mri, :mingw do
     gem 'pry', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rake', '>= 10.4.2', require: false
+gem 'rake', require: false
 gem 'activerecord', '>= 4.2.5', require: false
 
 group :development do
@@ -16,7 +16,7 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'terminal-notifier-guard', require: false
   gem 'simplecov', require: false
-  gem 'rubocop', '~> 0.37.2', require: false unless RUBY_VERSION =~ /^1.8/
+  gem 'rubocop', '~> 0.39.0', require: false unless RUBY_VERSION =~ /^1.8/
   gem 'coveralls'
   gem 'codeclimate-test-reporter'
   gem 'ruby_dep', '1.3.1'


### PR DESCRIPTION
Hello,

I have a issue with my Postgresql database and the index annotations. 
In some models I added the table_name_prefix = 'public.' because I'm using different schemas and the annotation doesn't work because is looking for 'public.table_name' and doesn't exist.

Regards.
