### PR TITLE
use existence of 'Rails::Application' as indicator of Rails App

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -137,7 +137,7 @@ module Annotate
     load_requires(options)
     require 'annotate/active_record_patch'
 
-    if defined?(Rails)
+    if defined?(Rails::Application)
       if Rails.version.split('.').first.to_i < 3
         Rails.configuration.eager_load_paths.each do |load_path|
           matcher = /\A#{Regexp.escape(load_path)}(.*)\.rb\Z/


### PR DESCRIPTION
use existence of 'Rails::Application' as indicator of Rails App instead of using 'Rails', as many Ruby applications are using railties such as generators outside Rails.