### PR TITLE
Fix deprecated warnings in Ruby 2.4.0+

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -168,7 +168,7 @@ module AnnotateModels
       when NilClass                 then 'NULL'
       when TrueClass                then 'TRUE'
       when FalseClass               then 'FALSE'
-      when Float, Fixnum, Bignum    then value.to_s
+      when Float, Integer           then value.to_s
         # BigDecimals need to be output in a non-normalized form and quoted.
       when BigDecimal               then value.to_s('F')
       when Array                    then value.map {|v| quote(v)}


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warnings in Ruby 2.4.0-preview3.

- `warning: constant ::Fixnum is deprecated`
- `warning: constant ::Bignum is deprecated`

Thanks