### PR TITLE
Test against Ruby 2.2.6 on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   ruby:
-    version: 2.2.4
+    version: 2.2.6


### PR DESCRIPTION
Fixed following error when run `bundle install`.

```sh
bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3 
Bundler can't satisfy your Gemfile's dependencies.
Install missing gems with `bundle install`.
Fetching gem metadata from https://rubygems.org/........
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Resolving dependencies...
ruby_dep-1.5.0 requires ruby version >= 2.2.5, which is incompatible with the
current version, ruby 2.2.4p230
```

cf. https://circleci.com/gh/ctran/annotate_models/257