### PR TITLE
Do not check if an index includes another column if the name is a String, instead of an Array.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -103,7 +103,7 @@ Lint/UselessAccessModifier:
 
 # Offense count: 17
 Metrics/AbcSize:
-  Max: 144
+  Max: 146
 
 # Offense count: 3
 # Configuration parameters: CountComments.
@@ -116,7 +116,7 @@ Metrics/BlockNesting:
 
 # Offense count: 8
 Metrics/CyclomaticComplexity:
-  Max: 36
+  Max: 37
 
 # Offense count: 350
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
@@ -127,7 +127,7 @@ Metrics/LineLength:
 # Offense count: 24
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 70
+  Max: 71
 
 # Offense count: 1
 # Configuration parameters: CountComments.
@@ -136,7 +136,7 @@ Metrics/ModuleLength:
 
 # Offense count: 7
 Metrics/PerceivedComplexity:
-  Max: 41
+  Max: 42
 
 # Offense count: 1
 Style/AccessorMethodName:

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -259,6 +259,7 @@ module AnnotateModels
           indices = retrieve_indexes_from_table(klass)
           if indices = indices.select { |ind| ind.columns.include? col.name }
             indices.sort_by(&:name).each do |ind|
+              next if ind.columns.is_a?(String)
               ind = ind.columns.reject! { |i| i == col.name }
               attrs << (ind.empty? ? "indexed" : "indexed => [#{ind.join(", ")}]")
             end

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -303,6 +303,25 @@ EOS
 EOS
   end
 
+  it 'should get simple indexes keys if one is in string form' do
+    klass = mock_class(:users,
+                       :id,
+                       [
+                         mock_column("id", :integer),
+                         mock_column("name", :string)
+                       ], [mock_index('index_rails_02e851e3b7', ['id']),
+                       mock_index('index_rails_02e851e3b8', 'LOWER(name)')])
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', simple_indexes: true)).to eql(<<-EOS)
+# Schema Info
+#
+# Table name: users
+#
+#  id   :integer          not null, primary key, indexed
+#  name :string           not null
+#
+EOS
+  end
+
   it 'should not crash getting indexes keys' do
     klass = mock_class(:users,
                        :id,


### PR DESCRIPTION
## Issues Fixed
https://github.com/ctran/annotate_models/issues/380