### PR TITLE
Prevent root_dir option from being empty

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -88,7 +88,6 @@ module Annotate
     end
 
     options[:model_dir] = ['app/models'] if options[:model_dir].empty?
-    options[:root_dir] = [''] if options[:root_dir].empty?
 
     options[:wrapper_open] ||= options[:wrapper]
     options[:wrapper_close] ||= options[:wrapper]

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -80,7 +80,13 @@ module AnnotateModels
     attr_writer :model_dir
 
     def root_dir
-      @root_dir.is_a?(Array) ? @root_dir : [@root_dir || '']
+      if @root_dir.blank?
+        ['']
+      elsif @root_dir.is_a?(String)
+        @root_dir.split(',')
+      else
+        @root_dir
+      end
     end
 
     attr_writer :root_dir

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -21,7 +21,7 @@ task annotate_models: :environment do
   options[:show_indexes] = Annotate.true?(ENV['show_indexes'])
   options[:simple_indexes] = Annotate.true?(ENV['simple_indexes'])
   options[:model_dir] = ENV['model_dir'] ? ENV['model_dir'].split(',') : ['app/models']
-  options[:root_dir] = ENV['root_dir'] ? ENV['root_dir'].split(',') : ['']
+  options[:root_dir] = ENV['root_dir'] && !ENV['root_dir'].empty? ? ENV['root_dir'].split(',') : ['']
   options[:include_version] = Annotate.true?(ENV['include_version'])
   options[:require] = ENV['require'] ? ENV['require'].split(',') : []
   options[:exclude_tests] = Annotate.true?(ENV['exclude_tests'])

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -21,7 +21,7 @@ task annotate_models: :environment do
   options[:show_indexes] = Annotate.true?(ENV['show_indexes'])
   options[:simple_indexes] = Annotate.true?(ENV['simple_indexes'])
   options[:model_dir] = ENV['model_dir'] ? ENV['model_dir'].split(',') : ['app/models']
-  options[:root_dir] = ENV['root_dir'] && !ENV['root_dir'].empty? ? ENV['root_dir'].split(',') : ['']
+  options[:root_dir] = ENV['root_dir']
   options[:include_version] = Annotate.true?(ENV['include_version'])
   options[:require] = ENV['require'] ? ENV['require'].split(',') : []
   options[:exclude_tests] = Annotate.true?(ENV['exclude_tests'])


### PR DESCRIPTION
This is a quick fix for #340.

When setting root_dir to an empty string (as is done in the default rake task config) this line previously caused root_dir to become an empty array.

This in turn caused factories, specs etc not to be annotated.

This is just a quick band-aid on a larger problem. We have option parsing spread out over many different places, with slight mismatches like this in the assumptions made.