### PR TITLE
Improve handling of default values for serialized attributes

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -168,23 +168,32 @@ module AnnotateModels
       current_patterns.map { |p| p.sub(/^[\/]*/, '') }
     end
 
+    def column_coder(column)
+      cast_type = column.cast_type
+      if cast_type.respond_to?(:coder) && cast_type.coder
+        cast_type.coder.method :dump
+      else
+        ->(v) { v }
+      end
+    end
+
     # Simple quoting for the default column value
-    def quote(value)
+    def quote_default(value)
       case value
-      when NilClass                 then 'NULL'
-      when TrueClass                then 'TRUE'
-      when FalseClass               then 'FALSE'
-      when Float, Integer           then value.to_s
+      when NilClass       then 'NULL'
+      when TrueClass      then 'TRUE'
+      when FalseClass     then 'FALSE'
+      when Float, Integer then value.to_s
         # BigDecimals need to be output in a non-normalized form and quoted.
-      when BigDecimal               then value.to_s('F')
-      when Array                    then value.map { |v| quote(v) }
+      when BigDecimal     then value.to_s('F')
+      when Array          then value.map { |v| quote(v) }
       else
         value.inspect
       end
     end
 
     def schema_default(klass, column)
-      quote(klass.column_defaults[column.name])
+      quote_default(column_coder(column).call(klass.column_defaults[column.name]))
     end
 
     def retrieve_indexes_from_table(klass)


### PR DESCRIPTION
If a serialized attribute has a default value, the annotation can include the object id of the default value, which changes every time `annotate` is run,

This PR encodes default values using the column's coder where available.

# Notes

There is another PR (#381) that attempts to solve this problem, but I think this solution is more robust and does not alter existing behaviour.

# TODO

- [ ] Check that it will work for supported versions of Rails
- [ ] Add tests
