### PR TITLE
Modify private class methods

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -74,125 +74,125 @@ module AnnotateRoutes
         puts "Removed annotations from #{routes_file}."
       end
     end
-  end
 
-  private
+    private
 
-  def self.app_routes_map(options)
-    routes_map = `rake routes`.split(/\n/, -1)
+    def app_routes_map(options)
+      routes_map = `rake routes`.split(/\n/, -1)
 
-    # In old versions of Rake, the first line of output was the cwd.  Not so
-    # much in newer ones.  We ditch that line if it exists, and if not, we
-    # keep the line around.
-    routes_map.shift if routes_map.first =~ /^\(in \//
+      # In old versions of Rake, the first line of output was the cwd.  Not so
+      # much in newer ones.  We ditch that line if it exists, and if not, we
+      # keep the line around.
+      routes_map.shift if routes_map.first =~ /^\(in \//
 
-    # Skip routes which match given regex
-    # Note: it matches the complete line (route_name, path, controller/action)
-    if options[:ignore_routes]
-      routes_map.reject! { |line| line =~ /#{options[:ignore_routes]}/ }
+      # Skip routes which match given regex
+      # Note: it matches the complete line (route_name, path, controller/action)
+      if options[:ignore_routes]
+        routes_map.reject! { |line| line =~ /#{options[:ignore_routes]}/ }
+      end
+
+      routes_map
     end
 
-    routes_map
-  end
-
-  def self.routes_file
-    @routes_rb ||= File.join('config', 'routes.rb')
-  end
-
-  def self.routes_exists?
-    routes_exists = File.exists?(routes_file)
-    puts "Can't find routes.rb" unless routes_exists
-
-    routes_exists
-  end
-
-  def self.write_contents(existing_text, header, options = {})
-    content, where_header_found = strip_annotations(existing_text)
-    new_content = annotate_routes(header, content, where_header_found, options)
-
-    # Make sure we end on a trailing newline.
-    new_content << '' unless new_content.last == ''
-    new_text = new_content.join("\n")
-
-    if existing_text == new_text
-      puts "#{routes_file} unchanged."
-      false
-    else
-      File.open(routes_file, 'wb') { |f| f.puts(new_text) }
-      true
-    end
-  end
-
-  def self.annotate_routes(header, content, where_header_found, options = {})
-    if %w(before top).include?(options[:position_in_routes])
-      header = header << '' if content.first != ''
-      new_content = header + content
-    else
-      # Ensure we have adequate trailing newlines at the end of the file to
-      # ensure a blank line separating the content from the annotation.
-      content << '' unless content.last == ''
-
-      # We're moving something from the top of the file to the bottom, so ditch
-      # the spacer we put in the first time around.
-      content.shift if where_header_found == :before && content.first == ''
-
-      new_content = content + header
+    def routes_file
+      @routes_rb ||= File.join('config', 'routes.rb')
     end
 
-    new_content
-  end
+    def routes_exists?
+      routes_exists = File.exists?(routes_file)
+      puts "Can't find routes.rb" unless routes_exists
 
-  # TODO: write the method doc using ruby rdoc formats
-  # where_header_found => This will either be :before, :after, or
-  # a number.  If the number is > 0, the
-  # annotation was found somewhere in the
-  # middle of the file.  If the number is
-  # zero, no annotation was found.
-  def self.strip_annotations(content)
-    real_content = []
-    mode = :content
-    header_found_at = 0
+      routes_exists
+    end
 
-    content.split(/\n/, -1).each_with_index do |line, line_number|
-      if mode == :header && line !~ /\s*#/
-        mode = :content
-        next unless line == ''
-      elsif mode == :content
-        if line =~ /^\s*#\s*== Route.*$/
-          header_found_at = line_number + 1 # index start's at 0
-          mode = :header
-        else
-          real_content << line
-        end
+    def write_contents(existing_text, header, options = {})
+      content, where_header_found = strip_annotations(existing_text)
+      new_content = annotate_routes(header, content, where_header_found, options)
+
+      # Make sure we end on a trailing newline.
+      new_content << '' unless new_content.last == ''
+      new_text = new_content.join("\n")
+
+      if existing_text == new_text
+        puts "#{routes_file} unchanged."
+        false
+      else
+        File.open(routes_file, 'wb') { |f| f.puts(new_text) }
+        true
       end
     end
 
-    where_header_found(real_content, header_found_at)
-  end
+    def annotate_routes(header, content, where_header_found, options = {})
+      if %w(before top).include?(options[:position_in_routes])
+        header = header << '' if content.first != ''
+        new_content = header + content
+      else
+        # Ensure we have adequate trailing newlines at the end of the file to
+        # ensure a blank line separating the content from the annotation.
+        content << '' unless content.last == ''
 
-  def self.where_header_found(real_content, header_found_at)
-    # By default assume the annotation was found in the middle of the file
+        # We're moving something from the top of the file to the bottom, so ditch
+        # the spacer we put in the first time around.
+        content.shift if where_header_found == :before && content.first == ''
 
-    # ... unless we have evidence it was at the beginning ...
-    return real_content, :before if header_found_at == 1
+        new_content = content + header
+      end
 
-    # ... or that it was at the end.
-    return real_content, :after if header_found_at >= real_content.count
-
-    # and the default
-    return real_content, header_found_at
-  end
-
-  def self.strip_on_removal(content, where_header_found)
-    if where_header_found == :before
-      content.shift while content.first == ''
-    elsif where_header_found == :after
-      content.pop while content.last == ''
+      new_content
     end
 
-    # TODO: If the user buried it in the middle, we should probably see about
-    # TODO: preserving a single line of space between the content above and
-    # TODO: below...
-    content
+    # TODO: write the method doc using ruby rdoc formats
+    # where_header_found => This will either be :before, :after, or
+    # a number.  If the number is > 0, the
+    # annotation was found somewhere in the
+    # middle of the file.  If the number is
+    # zero, no annotation was found.
+    def strip_annotations(content)
+      real_content = []
+      mode = :content
+      header_found_at = 0
+
+      content.split(/\n/, -1).each_with_index do |line, line_number|
+        if mode == :header && line !~ /\s*#/
+          mode = :content
+          next unless line == ''
+        elsif mode == :content
+          if line =~ /^\s*#\s*== Route.*$/
+            header_found_at = line_number + 1 # index start's at 0
+            mode = :header
+          else
+            real_content << line
+          end
+        end
+      end
+
+      where_header_found(real_content, header_found_at)
+    end
+
+    def where_header_found(real_content, header_found_at)
+      # By default assume the annotation was found in the middle of the file
+
+      # ... unless we have evidence it was at the beginning ...
+      return real_content, :before if header_found_at == 1
+
+      # ... or that it was at the end.
+      return real_content, :after if header_found_at >= real_content.count
+
+      # and the default
+      return real_content, header_found_at
+    end
+
+    def strip_on_removal(content, where_header_found)
+      if where_header_found == :before
+        content.shift while content.first == ''
+      elsif where_header_found == :after
+        content.pop while content.last == ''
+      end
+
+      # TODO: If the user buried it in the middle, we should probably see about
+      # TODO: preserving a single line of space between the content above and
+      # TODO: below...
+      content
+    end
   end
 end


### PR DESCRIPTION
I found wrong definitions.

This does not work:

```
[1] pry(main)> module Foo
[1] pry(main)*   private
[1] pry(main)*   def self.say
[1] pry(main)*     __method__
[1] pry(main)*   end
[1] pry(main)* end
=> :say
[2] pry(main)> Foo.say
=> :say
```

We should define `private_class_method` or define inside its singleton class block:

```
[3] pry(main)> module Bar
[3] pry(main)*   def self.say
[3] pry(main)*     __method__
[3] pry(main)*   end
[3] pry(main)*   private_class_method :say
[3] pry(main)* end
=> Bar
[4] pry(main)> Bar.say
NoMethodError: private method `say' called for Bar:Module
from (pry):14:in `__pry__'
```

```
[5] pry(main)> module Baz
[5] pry(main)*   class << self
[5] pry(main)*     private
[5] pry(main)*     def say
[5] pry(main)*       __method__
[5] pry(main)*     end
[5] pry(main)*   end
[5] pry(main)* end
=> :say
[6] pry(main)> Baz.say
NoMethodError: private method `say' called for Baz:Module
from (pry):23:in `__pry__'
```