### PR TITLE
Optional FK-Truncation / Rake update

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.summary = 'Annotates Rails Models, routes, fixtures, and others based on the database schema.'
 
   s.specification_version = 4 if s.respond_to? :specification_version
-  s.add_runtime_dependency(%q<rake>, ['>= 10.4'])
+  s.add_runtime_dependency(%q<rake>, ['>= 10.4', '< 13.0'])
   s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 6.0'])
 end

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -374,7 +374,7 @@ module AnnotateModels
       foreign_keys = klass.connection.foreign_keys(klass.table_name)
       return '' if foreign_keys.empty?
 
-      format_name = ->(fk) { fk.name.gsub(/(?<=^fk_rails_)[0-9a-f]{10}$/, '...') }
+      format_name = ->(fk) { options[:show_complete_foreign_keys] ? fk.name : fk.name.gsub(/(?<=^fk_rails_)[0-9a-f]{10}$/, '...') }
 
       max_size = foreign_keys.map(&format_name).map(&:size).max + 1
       foreign_keys.sort_by {|fk| [format_name.call(fk), fk.column]}.each do |fk|

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -14,6 +14,7 @@ if Rails.env.development?
       'position_in_factory'       => 'before',
       'position_in_serializer'    => 'before',
       'show_foreign_keys'         => 'true',
+      'show_complete_foreign_keys' => 'false',
       'show_indexes'              => 'true',
       'simple_indexes'            => 'false',
       'model_dir'                 => 'app/models',

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -18,6 +18,7 @@ task annotate_models: :environment do
   options[:position_in_test] = Annotate.fallback(ENV['position_in_test'], ENV['position'])
   options[:position_in_serializer] = Annotate.fallback(ENV['position_in_serializer'], ENV['position'])
   options[:show_foreign_keys] = Annotate.true?(ENV['show_foreign_keys'])
+  options[:show_complete_foreign_keys] = Annotate.true?(ENV['show_complete_foreign_keys'])
   options[:show_indexes] = Annotate.true?(ENV['show_indexes'])
   options[:simple_indexes] = Annotate.true?(ENV['simple_indexes'])
   options[:model_dir] = ENV['model_dir'] ? ENV['model_dir'].split(',') : ['app/models']

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -229,6 +229,42 @@ EOS
 EOS
   end
 
+  it 'should get complete foreign key info' do
+    klass = mock_class(:users,
+                       :id,
+                       [
+                         mock_column(:id, :integer),
+                         mock_column(:foreign_thing_id, :integer)
+                       ],
+                       [],
+                       [
+                         mock_foreign_key('fk_rails_cf2568e89e',
+                                          'foreign_thing_id',
+                                          'foreign_things'),
+                         mock_foreign_key('custom_fk_name',
+                                          'other_thing_id',
+                                          'other_things'),
+                         mock_foreign_key('fk_rails_a70234b26c',
+                                          'third_thing_id',
+                                          'third_things')
+                       ])
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)).to eql(<<-EOS)
+# Schema Info
+#
+# Table name: users
+#
+#  id               :integer          not null, primary key
+#  foreign_thing_id :integer          not null
+#
+# Foreign Keys
+#
+#  custom_fk_name       (other_thing_id => other_things.id)
+#  fk_rails_a70234b26c  (third_thing_id => third_things.id)
+#  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
+#
+    EOS
+  end
+
   it 'should get foreign key info if on_delete/on_update options present' do
     klass = mock_class(:users,
                        :id,


### PR DESCRIPTION
upgrading old(er) projects dependencies, including annotate, causes loads of random changes which are not of any use, spamming git history with noise. comments-only-changes.

also, upgrading rake too then causes a downgrade form 2.7 to order version, causing further noise. 
without exaggerating, i almost died because of this. twice.

always trying to keep my history clean, i made fk-truncation optional and allowing rake 12. feel free.

Sorry for the bad vibes, but, based on my perspective, this was quite a waste of time to force change into existing annotations.

To let it sparkle however, thanks for this -gem-, literally. Cheers
