### PR TITLE
Remove "private" since it's not valid in context

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -76,8 +76,6 @@ module AnnotateRoutes
     end
   end
 
-  private
-
   def self.app_routes_map(options)
     routes_map = `rake routes`.split(/\n/, -1)
 


### PR DESCRIPTION
Pointed out by @yhirano55 in #455, the private keyword is not valid in this context.