### PR TITLE
Fix show_complete_foreign_keys setting

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -30,7 +30,8 @@ module Annotate
     :show_indexes, :simple_indexes, :include_version, :exclude_tests,
     :exclude_fixtures, :exclude_factories, :ignore_model_sub_dir,
     :format_bare, :format_rdoc, :format_markdown, :sort, :force, :trace,
-    :timestamp, :exclude_serializers, :classified_sort, :show_foreign_keys,
+    :timestamp, :exclude_serializers, :classified_sort,
+    :show_foreign_keys, :show_complete_foreign_keys,
     :exclude_scaffolds, :exclude_controllers, :exclude_helpers,
     :exclude_sti_subclasses, :ignore_unknown_models
   ].freeze

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -484,6 +484,21 @@ EOS
 EOS
   end
 
+  describe '#set_defaults' do
+    it 'should default show_complete_foreign_keys to false' do
+      expect(Annotate.true?(ENV['show_complete_foreign_keys'])).to be(false)
+    end
+
+    it 'should be able to set show_complete_foreign_keys to true' do
+      Annotate.set_defaults('show_complete_foreign_keys' => 'true')
+      expect(Annotate.true?(ENV['show_complete_foreign_keys'])).to be(true)
+    end
+
+    after :each do
+      ENV.delete('show_complete_foreign_keys')
+    end
+  end
+
   describe '#get_schema_info with custom options' do
     def self.when_called_with(options = {})
       expected = options.delete(:returns)


### PR DESCRIPTION
https://github.com/ctran/annotate_models/pull/458 introduced a `show_complete_foreign_keys` setting that defaults to `false`.  But, setting it to `true` didn't actually work, because it was excluded from `FLAG_OPTIONS`