### PR TITLE
#476 add missing complete-foreign-keys option to bin

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -108,7 +108,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/BlockLength:
-  Max: 134
+  Max: 140
 
 # Offense count: 2
 Metrics/BlockNesting:

--- a/README.rdoc
+++ b/README.rdoc
@@ -184,6 +184,8 @@ you can do so with a simple environment variable, instead of editing the
         -m, --show-migration             Include the migration version number in the annotation
         -i, --show-indexes               List the table's database indexes in the annotation
         -k, --show-foreign-keys          List the table's foreign key constraints in the annotation
+            --ck, --complete-foreign-keys
+                                         Complete foreign key names in the annotation
         -s, --simple-indexes             Concat the column's related indexes in the annotation
             --model-dir dir              Annotate model files stored in dir rather than app/models, separate multiple dirs with commas
             --ignore-model-subdirects    Ignore subdirectories of the models directory

--- a/bin/annotate
+++ b/bin/annotate
@@ -107,6 +107,12 @@ OptionParser.new do |opts|
     ENV['show_foreign_keys'] = 'yes'
   end
 
+  opts.on('--ck',
+          '--complete-foreign-keys', 'Complete foreign key names in the annotation') do
+    ENV['show_foreign_keys'] = 'yes'
+    ENV['show_complete_foreign_keys'] = 'yes'
+  end
+
   opts.on('-i', '--show-indexes',
           "List the table's database indexes in the annotation") do
     ENV['show_indexes'] = 'yes'


### PR DESCRIPTION
adds the show_complete_foreign_keys flag to the cli, which i forgot. see #475.

i named it `--ck` in short, to have it aligned under `-k` hence is why i also set the `show_foreign_keys` option positive.

had to increase the `Metrics/BlockLength` a bit to make rubocop pass. Since `bin/annotate` is a good candidate for even more lines, i`d recommend to keep smaller blocks and exclude the file from this check.
However, this is a entirely different discussion which is why i did the increment only.

Did not find a spec for the bin options itself. is it missing or is it just me?

also, sorry all for the wrong branch name after an creating a useless ticket, bad memory.