### PR TITLE
Drop support of Ruby < 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1
   - 2.2.5
   - 2.3.0
   - 2.4.0
@@ -11,7 +8,6 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: 1.9.3
 before_install:
   - gem update --system
   - gem update bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '>= 2.2.0'
+
 gem 'activerecord', '>= 4.2.5', require: false
 gem 'rake', require: false
 

--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = 'annotate'
   s.version = Annotate.version
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.2.0'
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.authors = ['Alex Chaffee', 'Cuong Tran', 'Marcos Piccinini', 'Turadg Aleahmad', 'Jon Frisby']
   s.description = 'Annotates Rails/ActiveRecord Models, routes, fixtures, and others based on the database schema.'

--- a/lib/annotate/version.rb
+++ b/lib/annotate/version.rb
@@ -1,5 +1,5 @@
 module Annotate
   def self.version
-    '3.0.0'
+    '2.7.2'
   end
 end

--- a/lib/annotate/version.rb
+++ b/lib/annotate/version.rb
@@ -1,5 +1,5 @@
 module Annotate
   def self.version
-    '2.7.2'
+    '3.0.0'
   end
 end


### PR DESCRIPTION
Drop support of Ruby < 2.2 since [Support of Ruby 2.1 has ended](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/).