### PR TITLE
Remove empty line with trailing space at the end of routes map

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -77,7 +77,7 @@ module AnnotateRoutes
   end
 
   def self.app_routes_map(options)
-    routes_map = `rake routes`.split(/\n/, -1)
+    routes_map = `rake routes`.chomp("\n").split(/\n/, -1)
 
     # In old versions of Rake, the first line of output was the cwd.  Not so
     # much in newer ones.  We ditch that line if it exists, and if not, we

--- a/spec/annotate/annotate_routes_spec.rb
+++ b/spec/annotate/annotate_routes_spec.rb
@@ -22,10 +22,10 @@ describe AnnotateRoutes do
       expect(File).to receive(:exists?).with(ROUTE_FILE).and_return(true)
 
       expect(File).to receive(:read).with(ROUTE_FILE).and_return("")
-      expect(AnnotateRoutes).to receive(:`).with('rake routes').and_return('                                      Prefix Verb       URI Pattern                                               Controller#Action
+      expect(AnnotateRoutes).to receive(:`).with('rake routes').and_return("                                      Prefix Verb       URI Pattern                                               Controller#Action
                                    myaction1 GET        /url1(.:format)                                           mycontroller1#action
                                    myaction2 POST       /url2(.:format)                                           mycontroller2#action
-                                   myaction3 DELETE|GET /url3(.:format)                                           mycontroller3#action')
+                                   myaction3 DELETE|GET /url3(.:format)                                           mycontroller3#action\n")
 
       expect(AnnotateRoutes).to receive(:puts).with(ANNOTATION_ADDED)
     end


### PR DESCRIPTION
Fixes https://github.com/ctran/annotate_models/issues/474

Actually, not only fixes issue with trailing space, but removes last empty line (`#[EOL]`) at the end of routes map completely.

Example:
Instead of
```
# == Route Map
#
#   Prefix Verb   URI Pattern    Controller#Action
#   root GET       /                    main#index
# [EOL]
```
Now it will be
```
# == Route Map
#
#   Prefix Verb   URI Pattern    Controller#Action
#   root GET       /                    main#index
```

Here is why this empty line occurred in the first place:
`rake routes` returns text with a new line character at the very end.
`AnnotateRoutes` treated this last empty line as a useful content and added `# [EOL]` because of it.

I decided to remove `# [EOL]`, because specs show that it wasn't expected from the beginning. Specs passed only because there was an assumption that `rake routes` doesn't add new line character at the end, which is wrong.

