### PR TITLE
annotate --routes modifies only routes.rb

### DIFF
--- a/bin/annotate
+++ b/bin/annotate
@@ -202,7 +202,7 @@ end.parse!
 options = Annotate.setup_options(
   is_rake: ENV['is_rake'] && !ENV['is_rake'].empty?
 )
-Annotate.eager_load(options)
+Annotate.eager_load(options) if Annotate.include_models?
 
 AnnotateModels.send(target_action, options) if Annotate.include_models?
 AnnotateRoutes.send(target_action, options) if Annotate.include_routes?

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -114,7 +114,7 @@ module Annotate
   end
 
   def self.include_models?
-    true
+    ENV['routes'] !~ TRUE_RE
   end
 
   def self.loaded_tasks=(val)


### PR DESCRIPTION
This change is a proposed solution to #357 and an alternative to the already proposed solution #361.
In #361 it is needed to call `annotate --routes --ignore-models` to achieve the same as in this change with only `annotate --routes`.