### PR TITLE
Test against latest Rubies (2.2.7 / 2.3.4 / 2.4.1) on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.5
-  - 2.3.0
-  - 2.4.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
   - ruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
Use latest Rubies (2.2.7 / 2.3.4 / 2.4.1) for TravisCI.