### PR TITLE
[Fix #401] Allow wrappers in routes annotation

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -1,3 +1,5 @@
+# rubocop:disable  Metrics/ModuleLength
+
 # == Annotate Routes
 #
 # Based on:
@@ -36,7 +38,10 @@ module AnnotateRoutes
     def header(options = {})
       routes_map = app_routes_map(options)
 
-      out = ["# #{options[:format_markdown] ? PREFIX_MD : PREFIX}" + (options[:timestamp] ? " (Updated #{Time.now.strftime('%Y-%m-%d %H:%M')})" : '')]
+      out = []
+      out += ["# #{options[:wrapper_open]}"] if options[:wrapper_open]
+
+      out += ["# #{options[:format_markdown] ? PREFIX_MD : PREFIX}" + (options[:timestamp] ? " (Updated #{Time.now.strftime('%Y-%m-%d %H:%M')})" : '')]
       out += ['#']
       return out if routes_map.size.zero?
 
@@ -51,7 +56,10 @@ module AnnotateRoutes
         out += ["# #{content(routes_map[0], maxs, options)}"]
       end
 
-      out + routes_map[1..-1].map { |line| "# #{content(options[:format_markdown] ? line.split(' ') : line, maxs, options)}" }
+      out += routes_map[1..-1].map { |line| "# #{content(options[:format_markdown] ? line.split(' ') : line, maxs, options)}" }
+      out += ["# #{options[:wrapper_close]}"] if options[:wrapper_close]
+
+      out
     end
 
     def do_annotations(options = {})

--- a/lib/tasks/annotate_routes.rake
+++ b/lib/tasks/annotate_routes.rake
@@ -8,6 +8,8 @@ task :annotate_routes => :environment do
   options[:position_in_routes] = Annotate.fallback(ENV['position_in_routes'], ENV['position'])
   options[:ignore_routes] = Annotate.fallback(ENV['ignore_routes'],  nil)
   options[:require] = ENV['require'] ? ENV['require'].split(',') : []
+  options[:wrapper_open] = Annotate.fallback(ENV['wrapper_open'], ENV['wrapper'])
+  options[:wrapper_close] = Annotate.fallback(ENV['wrapper_close'], ENV['wrapper'])
   AnnotateRoutes.do_annotations(options)
 end
 

--- a/spec/annotate/annotate_routes_spec.rb
+++ b/spec/annotate/annotate_routes_spec.rb
@@ -56,6 +56,21 @@ describe AnnotateRoutes do
 
       AnnotateRoutes.do_annotations(format_markdown: true)
     end
+
+    it 'wraps annotation if wrapper is specified' do
+      expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
+      expect(@mock_file).to receive(:puts).with("
+# START
+# == Route Map
+#
+#                                       Prefix Verb       URI Pattern                                               Controller#Action
+#                                    myaction1 GET        /url1(.:format)                                           mycontroller1#action
+#                                    myaction2 POST       /url2(.:format)                                           mycontroller2#action
+#                                    myaction3 DELETE|GET /url3(.:format)                                           mycontroller3#action
+# END\n")
+
+      AnnotateRoutes.do_annotations(wrapper_open: 'START', wrapper_close: 'END')
+    end
   end
 
   describe 'When adding' do


### PR DESCRIPTION
Please see #401

TL;DR: now you can use `wrapper_open`/`wrapper_close` options not only in models annotation, but also in routes annotation as well.