### PR TITLE
Add specification for filename to -i option

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -654,6 +654,10 @@ module AnnotateModels
         models = ARGV.dup.reject { |m| m.match(/^(.*)=/) }
       end
 
+      tmp = []
+      models.each { |path| tmp.concat [[File.dirname(path), File.basename(path)]] }
+      models = tmp
+
       if models.empty?
         begin
           model_dir.each do |dir|


### PR DESCRIPTION
This commit allows specification for filename with -i option.
For example, you can execute following command:
```
$ bundle exec annotation -i path/to/file.rb
```