### PR TITLE
with comment

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -38,7 +38,7 @@ module Annotate
   OTHER_OPTIONS = [
     :ignore_columns, :skip_on_db_migrate, :wrapper_open, :wrapper_close,
     :wrapper, :routes, :hide_limit_column_types, :hide_default_column_types,
-    :ignore_routes, :active_admin
+    :ignore_routes, :active_admin, :with_comment
   ].freeze
   PATH_OPTIONS = [
     :require, :model_dir, :root_dir

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -226,8 +226,6 @@ module AnnotateModels
 
       max_size = klass.column_names.map(&:size).max || 0
       with_comment = options[:with_comment] && klass.columns.first.respond_to?(:comment)
-      max_size = klass.columns.map{|col| col.name.size + col.comment.size }.max || 0 if with_comment
-      max_size += 2 if with_comment
       max_size += options[:format_rdoc] ? 5 : 1
       md_names_overhead = 6
       md_type_allowance = 18
@@ -291,11 +289,10 @@ module AnnotateModels
             end
           end
         end
-        col_name = if with_comment
-                     "#{col.name}(#{col.comment})"
-                   else
-                     col.name
-                   end
+        if with_comment && col.comment
+          attrs << "comment[#{col.comment}]"
+        end
+        col_name = col.name
         if options[:format_rdoc]
           info << sprintf("# %-#{max_size}.#{max_size}s<tt>%s</tt>", "*#{col_name}*::", attrs.unshift(col_type).join(", ")).rstrip + "\n"
         elsif options[:format_markdown]

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -47,6 +47,7 @@ task annotate_models: :environment do
   options[:ignore_routes] = ENV.fetch('ignore_routes', nil)
   options[:hide_limit_column_types] = Annotate.fallback(ENV['hide_limit_column_types'], '')
   options[:hide_default_column_types] = Annotate.fallback(ENV['hide_default_column_types'], '')
+  options[:with_comment] = Annotate.true?(ENV['with_comment'])
 
   AnnotateModels.do_annotations(options)
 end


### PR DESCRIPTION
Whether it is better to put the `comment` at the end of `attrs`?  
For double-byte character sets, the character width is greater than character size.