### PR TITLE
Fix annotations for rails 5.1.4

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -249,7 +249,8 @@ module AnnotateModels
       cols = cols.sort_by(&:name) if options[:sort]
       cols = classified_sort(cols) if options[:classified_sort]
       cols.each do |col|
-        col_type = ((col.type && col.type.type) || (col.sql_type && col.sql_type.to_s))
+        col_type = (col.type || col.sql_type)
+        col_type = col_type.respond_to?(:type) ? col_type.type : col_type.to_s
         attrs = []
         attrs << "default(#{schema_default(klass, col)})" unless col.default.nil? || hide_default?(col_type, options)
         attrs << 'unsigned' if col.respond_to?(:unsigned?) && col.unsigned?

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -249,7 +249,7 @@ module AnnotateModels
       cols = cols.sort_by(&:name) if options[:sort]
       cols = classified_sort(cols) if options[:classified_sort]
       cols.each do |col|
-        col_type = (col.type || col.sql_type).to_s
+        col_type = ((col.type && col.type.type) || (col.sql_type && col.sql_type.to_s))
         attrs = []
         attrs << "default(#{schema_default(klass, col)})" unless col.default.nil? || hide_default?(col_type, options)
         attrs << 'unsigned' if col.respond_to?(:unsigned?) && col.unsigned?


### PR DESCRIPTION
- annotate command generate annotation like
  name        :#<ArJdbc::MySQL: default(""), not null
  path        :#<ArJdbc::MySQL:
 ...