### PR TITLE
Fix it possible to specify model files as argument

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -649,33 +649,29 @@ module AnnotateModels
     # of model files from root dir. Otherwise we take all the model files
     # in the model_dir directory.
     def get_model_files(options)
-      models = []
-      unless options[:is_rake]
-        models = ARGV.dup
+      if !options[:is_rake] && !ARGV.empty?
+        return ARGV.dup
       end
 
-      if models.empty?
-        begin
-          model_dir.each do |dir|
-            Dir.chdir(dir) do
-              lst =
-                if options[:ignore_model_sub_dir]
-                  Dir["*.rb"].map{ |f| [dir, f] }
-                else
-                  Dir["**/*.rb"].reject{ |f| f["concerns/"] }.map{ |f| [dir, f] }
-                end
-              models.concat(lst)
-            end
-          end
-        rescue SystemCallError
-          puts "No models found in directory '#{model_dir.join("', '")}'."
-          puts "Either specify models on the command line, or use the --model-dir option."
-          puts "Call 'annotate --help' for more info."
-          exit 1
+      model_files = []
+
+      model_dir.each do |dir|
+        Dir.chdir(dir) do
+          list = if options[:ignore_model_sub_dir]
+                   Dir["*.rb"].map { |f| [dir, f] }
+                 else
+                   Dir["**/*.rb"].reject { |f| f["concerns/"] }.map { |f| [dir, f] }
+                 end
+          model_files.concat(list)
         end
       end
 
-      models
+      model_files
+    rescue SystemCallError
+      puts "No models found in directory '#{model_dir.join("', '")}'."
+      puts "Either specify models on the command line, or use the --model-dir option."
+      puts "Call 'annotate --help' for more info."
+      exit 1
     end
 
     # Retrieve the classes belonging to the model names we're asked to process

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -651,7 +651,7 @@ module AnnotateModels
     def get_model_files(options)
       models = []
       unless options[:is_rake]
-        models = ARGV.dup.reject { |m| m.match(/^(.*)=/) }
+        models = ARGV.dup
       end
 
       if models.empty?

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -3,6 +3,7 @@ require File.dirname(__FILE__) + '/../spec_helper.rb'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'
+require 'files'
 
 describe AnnotateModels do
   def mock_index(name, params = {})
@@ -947,6 +948,104 @@ EOS
         # **`name(Name)`**  | `string(50)`       | `not null`
         #
         EOS
+      end
+    end
+  end
+
+  describe '#get_model_files' do
+    subject { described_class.get_model_files(options) }
+
+    before do
+      ARGV.clear
+
+      described_class.model_dir = [model_dir]
+    end
+
+    context 'when `model_dir` is valid' do
+      let(:model_dir) do
+        Files do
+          file 'foo.rb'
+          dir 'bar' do
+            file 'baz.rb'
+            dir 'qux' do
+              file 'quux.rb'
+            end
+          end
+          dir 'concerns' do
+            file 'corge.rb'
+          end
+        end
+      end
+
+      context 'when the model files are not specified' do
+        context 'when no option is specified' do
+          let(:options) { {} }
+
+          it 'returns all model files under `model_dir` directory' do
+            is_expected.to contain_exactly(
+              [model_dir, 'foo.rb'],
+              [model_dir, File.join('bar', 'baz.rb')],
+              [model_dir, File.join('bar', 'qux', 'quux.rb')]
+            )
+          end
+        end
+
+        context 'when `ignore_model_sub_dir` option is enabled' do
+          let(:options) { { ignore_model_sub_dir: true } }
+
+          it 'returns model files just below `model_dir` directory' do
+            is_expected.to contain_exactly([model_dir, 'foo.rb'])
+          end
+        end
+      end
+
+      context 'when the model files are specified' do
+        let(:model_files) do
+          [
+            File.join(model_dir, 'foo.rb'),
+            File.join(model_dir, 'bar/baz.rb')
+          ]
+        end
+
+        before do
+          ARGV.concat(model_files)
+
+          described_class.model_dir
+        end
+
+        context 'when no option is specified' do
+          let(:options) { {} }
+
+          it 'returns specified files' do
+            is_expected.to eq(model_files)
+          end
+        end
+
+        context 'when `is_rake` option is enabled' do
+          let(:options) { { is_rake: true } }
+
+          it 'returns all model files under `model_dir` directory' do
+            is_expected.to contain_exactly(
+              [model_dir, 'foo.rb'],
+              [model_dir, File.join('bar', 'baz.rb')],
+              [model_dir, File.join('bar', 'qux', 'quux.rb')]
+            )
+          end
+        end
+      end
+    end
+
+    context 'when `model_dir` is invalid' do
+      let(:model_dir) { '/not_exist_path' }
+      let(:options) { {} }
+
+      it 'exits with the status code' do
+        begin
+          subject
+          raise
+        rescue SystemExit => e
+          expect(e.status).to eq(1)
+        end
       end
     end
   end


### PR DESCRIPTION
The `annotate` command can accept the target model files as command line arguments:

```
Usage: annotate [options] [model_file]*
```

However, the following error occurred:

```
% bundle exec annotate app/models/author.rb
bundler: failed to load command: annotate (/Users/hideki/repos/src/local/sample/vendor/bundle/ruby/2.4.0/bin/annotate)
TypeError: no implicit conversion of nil into String
  /Users/hideki/repos/src/local/sample/vendor/bundle/ruby/2.4.0/gems/annotate-2.7.2/lib/annotate/annotate_models.rb:646:in `join'
  /Users/hideki/repos/src/local/sample/vendor/bundle/ruby/2.4.0/gems/annotate-2.7.2/lib/annotate/annotate_models.rb:646:in `block in do_annotations'
  /Users/hideki/repos/src/local/sample/vendor/bundle/ruby/2.4.0/gems/annotate-2.7.2/lib/annotate/annotate_models.rb:645:in `each'
  /Users/hideki/repos/src/local/sample/vendor/bundle/ruby/2.4.0/gems/annotate-2.7.2/lib/annotate/annotate_models.rb:645:in `do_annotations'
  /Users/hideki/repos/src/local/sample/vendor/bundle/ruby/2.4.0/gems/annotate-2.7.2/bin/annotate:201:in `<top (required)>'
  /Users/hideki/repos/src/local/sample/vendor/bundle/ruby/2.4.0/bin/annotate:22:in `load'
  /Users/hideki/repos/src/local/sample/vendor/bundle/ruby/2.4.0/bin/annotate:22:in `<top (required)>'
```

Fixed as the data structure returned by `AnnotateModels#get_model_files` is different when the model files are specified as arguments.

- https://github.com/ctran/annotate_models/commit/7b8e36c7bfeebccf358e737ce7422bb361298767

In addition, I added tests, removed unnecessary logic and refactored.

- https://github.com/ctran/annotate_models/commit/f177fb200caca87ed395393942800f5f78b88407
- https://github.com/ctran/annotate_models/commit/cf61952f68a4d2b3f099ee2d92690414e40b4c45
- https://github.com/ctran/annotate_models/commit/2e08ad0395e9cf8e9ebfc2fe92f1be0bd21ea056

Thanks
