### PR TITLE
annotate bigint correctly

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -249,7 +249,7 @@ module AnnotateModels
       cols = cols.sort_by(&:name) if options[:sort]
       cols = classified_sort(cols) if options[:classified_sort]
       cols.each do |col|
-        col_type = (col.type || col.sql_type).to_s
+        col_type = get_col_type(col)
         attrs = []
         attrs << "default(#{schema_default(klass, col)})" unless col.default.nil? || hide_default?(col_type, options)
         attrs << 'unsigned' if col.respond_to?(:unsigned?) && col.unsigned?
@@ -361,6 +361,14 @@ module AnnotateModels
       end
 
       index_info
+    end
+
+    def get_col_type(col)
+      if col.respond_to?(:bigint?) && col.bigint?
+        'bigint'
+      else
+        (col.type || col.sql_type).to_s
+      end
     end
 
     def index_columns_info(index)

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -157,7 +157,7 @@ EOS
                        [
                          mock_column(:id, :integer),
                          mock_column(:integer, :integer, unsigned?: true),
-                         mock_column(:bigint,  :bigint,  unsigned?: true),
+                         mock_column(:bigint,  :integer, unsigned?: true, bigint?: true),
                          mock_column(:float,   :float,   unsigned?: true),
                          mock_column(:decimal, :decimal, unsigned?: true, precision: 10, scale: 2),
                        ])


### PR DESCRIPTION
Bigint columns display integer in annotation. Because  `ActiveRecord::ConnectionAdapters::Column#type` returns `:integer` if its column type is bigint.

`#bigint?` is provided to distinguish them so I changed to use it.