### PR TITLE
Fix unable to annotate error when table_name is frozen

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -212,8 +212,8 @@ module AnnotateModels
       return indexes if indexes.any? || !klass.table_name_prefix
 
       # Try to search the table without prefix
-      table_name.to_s.slice!(klass.table_name_prefix)
-      klass.connection.indexes(table_name)
+      table_name_without_prefix = table_name.to_s.sub(klass.table_name_prefix, '')
+      klass.connection.indexes(table_name_without_prefix)
     end
 
     # Use the column information in an ActiveRecord class


### PR DESCRIPTION
I found that `annotate` command is failed when `table_name` of model class is frozen.
Please see the sample model class code.

```ruby
# frozen_string_literal: true

class User < ApplicationRecord
  self.table_name = 'tbl_users'
end
```

When `annotate` command is executed to the model file, it is failed with following message .
(Messages with `--trace` option are [backtraces.txt](https://github.com/ctran/annotate_models/files/1376549/backtraces.txt).)

```
Unable to annotate app/models/user.rb: can't modify frozen String
Unable to annotate app/models/user.rb: no implicit conversion of nil into Array
```

This is seemed to be caused by [this line](https://github.com/ctran/annotate_models/blob/develop/lib/annotate/annotate_models.rb#L215).
`table_name.to_s.slice!(klass.table_name_prefix)` changes `table_name` string itself, but `table_name` is frozen(by frozen_string_literal magic comment), so `can't modify frozen String` error is raised.

I fixed this error. Please check this PR.
