### PR TITLE
Update CL options in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -161,7 +161,8 @@ you can do so with a simple environment variable, instead of editing the
 
     Usage: annotate [options] [model_file]*
         -d, --delete                     Remove annotations from all model files or the routes.rb file
-        -p, --position [before|top|after|bottom]    Place the annotations at the top (before) or the bottom (after) of the model/test/fixture/factory/routes file(s)
+        -p [before|top|after|bottom],    Place the annotations at the top (before) or the bottom (after) of the model/test/fixture/factory/route/serializer file(s)
+            --position
             --pc, --position-in-class [before|top|after|bottom]
                                          Place the annotations at the top (before) or the bottom (after) of the model file
             --pf, --position-in-factory [before|top|after|bottom]
@@ -179,17 +180,19 @@ you can do so with a simple environment variable, instead of editing the
             --wo, --wrapper-open STR     Annotation wrapper opening.
             --wc, --wrapper-close STR    Annotation wrapper closing
         -r, --routes                     Annotate routes.rb with the output of 'rake routes'
-        -aa, --active-admin              Annotate all activeadmin models
+        -a, --active-admin               Annotate active_admin models
         -v, --version                    Show the current version of this gem
         -m, --show-migration             Include the migration version number in the annotation
-        -i, --show-indexes               List the table's database indexes in the annotation
         -k, --show-foreign-keys          List the table's foreign key constraints in the annotation
             --ck, --complete-foreign-keys
                                          Complete foreign key names in the annotation
+        -i, --show-indexes               List the table's database indexes in the annotation
         -s, --simple-indexes             Concat the column's related indexes in the annotation
             --model-dir dir              Annotate model files stored in dir rather than app/models, separate multiple dirs with commas
+            --root-dir dir               Annotate files stored within root dir projects, separate multiple dirs with commas
             --ignore-model-subdirects    Ignore subdirectories of the models directory
             --sort                       Sort columns alphabetically, rather than in creation order
+            --classified-sort            Sort columns alphabetically, but first goes id, then the rest columns, then the timestamp columns and then the association columns
         -R, --require path               Additional file to require before loading models, may be used multiple times
         -e [tests,fixtures,factories,serializers],
             --exclude                    Do not annotate fixtures, test files, factories, and/or serializers
@@ -199,6 +202,13 @@ you can do so with a simple environment variable, instead of editing the
             --timestamp                  Include timestamp in (routes) annotation
             --trace                      If unable to annotate a file, print the full stack trace, not just the exception message.
         -I, --ignore-columns REGEX       don't annotate columns that match a given REGEX (i.e., `annotate -I '^(id|updated_at|created_at)'`
+            --ignore-routes REGEX        don't annotate routes that match a given REGEX (i.e., `annotate -I '(mobile|resque|pghero)'`
+            --hide-limit-column-types VALUES
+                                         don't show limit for given column types, separated by commas (i.e., `integer,boolean,text`)
+            --hide-default-column-types VALUES
+                                         don't show default for given column types, separated by commas (i.e., `json,jsonb,hstore`)
+            --ignore-unknown-models      don't display warnings for bad model files
+            --with-comment               include database comments in model annotations
 
 
 

--- a/bin/annotate
+++ b/bin/annotate
@@ -90,7 +90,7 @@ OptionParser.new do |opts|
     ENV['routes'] = 'true'
   end
 
-  opts.on('-aa', '--active-admin', 'Annotate active_admin models') do
+  opts.on('-a', '--active-admin', 'Annotate active_admin models') do
     ENV['active_admin'] = 'true'
   end
 
@@ -198,7 +198,7 @@ OptionParser.new do |opts|
     ENV['ignore_unknown_models'] = 'true'
   end
 
-  opts.on('--with-comment', "include database comments") do |values|
+  opts.on('--with-comment', "include database comments in model annotations") do |values|
     ENV['with_comment'] = 'true'
   end
 end.parse!


### PR DESCRIPTION
@ctran: I've updated the README with the `--with-comment` flag, like you asked. Actually, I just ran `annotate --help` and copied the output to `README.rdoc`. 😄 I guess there are a few new things that were missing.

Also the `-aa` shortcut for the `--active-admin` flag didn't look right, so I changed it. Hope that's OK 😊 