### PR TITLE
Do not remove magic comments (AnnotateRoutes)

### DIFF
--- a/spec/annotate/annotate_routes_spec.rb
+++ b/spec/annotate/annotate_routes_spec.rb
@@ -11,6 +11,22 @@ describe AnnotateRoutes do
     @mock_file ||= double(File, stubs)
   end
 
+  def magic_comments_list_each
+    [
+      '# encoding: UTF-8',
+      '# coding: UTF-8',
+      '# -*- coding: UTF-8 -*-',
+      '#encoding: utf-8',
+      '# encoding: utf-8',
+      '# -*- encoding : utf-8 -*-',
+      "# encoding: utf-8\n# frozen_string_literal: true",
+      "# frozen_string_literal: true\n# encoding: utf-8",
+      '# frozen_string_literal: true',
+      '#frozen_string_literal: false',
+      '# -*- frozen_string_literal : true -*-'
+    ].each { |magic_comment| yield magic_comment }
+  end
+
   it 'should check if routes.rb exists' do
     expect(File).to receive(:exists?).with(ROUTE_FILE).and_return(false)
     expect(AnnotateRoutes).to receive(:puts).with("Can't find routes.rb")
@@ -18,21 +34,29 @@ describe AnnotateRoutes do
   end
 
   describe 'Annotate#example' do
-    before(:each) do
-      expect(File).to receive(:exists?).with(ROUTE_FILE).and_return(true)
-
-      expect(File).to receive(:read).with(ROUTE_FILE).and_return("")
-      expect(AnnotateRoutes).to receive(:`).with('rake routes').and_return("                                      Prefix Verb       URI Pattern                                               Controller#Action
+    let(:rake_routes_content) do
+      "                                      Prefix Verb       URI Pattern                                               Controller#Action
                                    myaction1 GET        /url1(.:format)                                           mycontroller1#action
                                    myaction2 POST       /url2(.:format)                                           mycontroller2#action
-                                   myaction3 DELETE|GET /url3(.:format)                                           mycontroller3#action\n")
-
-      expect(AnnotateRoutes).to receive(:puts).with(ANNOTATION_ADDED)
+                                   myaction3 DELETE|GET /url3(.:format)                                           mycontroller3#action\n"
     end
 
-    it 'annotate normal' do
-      expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
-      expect(@mock_file).to receive(:puts).with("
+    before(:each) do
+      expect(File).to receive(:exists?).with(ROUTE_FILE).and_return(true).at_least(:once)
+
+      expect(File).to receive(:read).with(ROUTE_FILE).and_return("").at_least(:once)
+
+      expect(AnnotateRoutes).to receive(:puts).with(ANNOTATION_ADDED).at_least(:once)
+    end
+
+    context 'without magic comments' do
+      before(:each) do
+        expect(AnnotateRoutes).to receive(:`).with('rake routes').and_return(rake_routes_content)
+      end
+
+      it 'annotate normal' do
+        expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
+        expect(@mock_file).to receive(:puts).with("
 # == Route Map
 #
 #                                       Prefix Verb       URI Pattern                                               Controller#Action
@@ -40,12 +64,12 @@ describe AnnotateRoutes do
 #                                    myaction2 POST       /url2(.:format)                                           mycontroller2#action
 #                                    myaction3 DELETE|GET /url3(.:format)                                           mycontroller3#action\n")
 
-      AnnotateRoutes.do_annotations
-    end
+        AnnotateRoutes.do_annotations
+      end
 
-    it 'annotate markdown' do
-      expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
-      expect(@mock_file).to receive(:puts).with("
+      it 'annotate markdown' do
+        expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
+        expect(@mock_file).to receive(:puts).with("
 # ## Route Map
 #
 # Prefix    | Verb       | URI Pattern     | Controller#Action   
@@ -54,12 +78,12 @@ describe AnnotateRoutes do
 # myaction2 | POST       | /url2(.:format) | mycontroller2#action
 # myaction3 | DELETE-GET | /url3(.:format) | mycontroller3#action\n")
 
-      AnnotateRoutes.do_annotations(format_markdown: true)
-    end
+        AnnotateRoutes.do_annotations(format_markdown: true)
+      end
 
-    it 'wraps annotation if wrapper is specified' do
-      expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
-      expect(@mock_file).to receive(:puts).with("
+      it 'wraps annotation if wrapper is specified' do
+        expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
+        expect(@mock_file).to receive(:puts).with("
 # START
 # == Route Map
 #
@@ -69,14 +93,78 @@ describe AnnotateRoutes do
 #                                    myaction3 DELETE|GET /url3(.:format)                                           mycontroller3#action
 # END\n")
 
-      AnnotateRoutes.do_annotations(wrapper_open: 'START', wrapper_close: 'END')
+        AnnotateRoutes.do_annotations(wrapper_open: 'START', wrapper_close: 'END')
+      end
+    end
+
+    context 'file with magic comments' do
+      it 'should not remove magic comments' do
+        magic_comments_list_each do |magic_comment|
+          expect(AnnotateRoutes).to receive(:`).with('rake routes')
+            .and_return("#{magic_comment}\n#{rake_routes_content}")
+
+          expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
+          expect(@mock_file).to receive(:puts).with("
+#{magic_comment}
+# == Route Map
+#
+#                                       Prefix Verb       URI Pattern                                               Controller#Action
+#                                    myaction1 GET        /url1(.:format)                                           mycontroller1#action
+#                                    myaction2 POST       /url2(.:format)                                           mycontroller2#action
+#                                    myaction3 DELETE|GET /url3(.:format)                                           mycontroller3#action\n")
+
+          AnnotateRoutes.do_annotations
+        end
+      end
+
+      it 'annotate markdown' do
+        magic_comments_list_each do |magic_comment|
+          expect(AnnotateRoutes).to receive(:`).with('rake routes')
+            .and_return("#{magic_comment}\n#{rake_routes_content}")
+
+          expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
+          expect(@mock_file).to receive(:puts).with("
+#{magic_comment}
+# ## Route Map
+#
+# Prefix    | Verb       | URI Pattern     | Controller#Action   
+# --------- | ---------- | --------------- | --------------------
+# myaction1 | GET        | /url1(.:format) | mycontroller1#action
+# myaction2 | POST       | /url2(.:format) | mycontroller2#action
+# myaction3 | DELETE-GET | /url3(.:format) | mycontroller3#action\n")
+
+          AnnotateRoutes.do_annotations(format_markdown: true)
+        end
+      end
+
+      it 'wraps annotation if wrapper is specified' do
+        magic_comments_list_each do |magic_comment|
+          expect(AnnotateRoutes).to receive(:`).with('rake routes')
+            .and_return("#{magic_comment}\n#{rake_routes_content}")
+          expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
+          expect(@mock_file).to receive(:puts).with("
+#{magic_comment}
+# START
+# == Route Map
+#
+#                                       Prefix Verb       URI Pattern                                               Controller#Action
+#                                    myaction1 GET        /url1(.:format)                                           mycontroller1#action
+#                                    myaction2 POST       /url2(.:format)                                           mycontroller2#action
+#                                    myaction3 DELETE|GET /url3(.:format)                                           mycontroller3#action
+# END\n")
+
+          AnnotateRoutes.do_annotations(wrapper_open: 'START', wrapper_close: 'END')
+        end
+      end
     end
   end
 
   describe 'When adding' do
     before(:each) do
-      expect(File).to receive(:exists?).with(ROUTE_FILE).and_return(true)
-      expect(AnnotateRoutes).to receive(:`).with('rake routes').and_return('')
+      expect(File).to receive(:exists?).with(ROUTE_FILE)
+        .and_return(true).at_least(:once)
+      expect(AnnotateRoutes).to receive(:`).with('rake routes')
+        .and_return('').at_least(:once)
     end
 
     it 'should insert annotations if file does not contain annotations' do
@@ -111,6 +199,42 @@ describe AnnotateRoutes do
       expect(AnnotateRoutes).to receive(:puts).with(FILE_UNCHANGED)
 
       AnnotateRoutes.do_annotations
+    end
+
+    context 'file with magic comments' do
+      it 'leaves magic comment on top, adds an empty line between magic comment and annotation (position_in_routes :top)' do
+        expect(File).to receive(:open).with(ROUTE_FILE, 'wb')
+          .and_yield(mock_file).at_least(:once)
+
+        magic_comments_list_each do |magic_comment|
+          expect(File).to receive(:read).with(ROUTE_FILE).and_return("#{magic_comment}\nSomething")
+          expect(@mock_file).to receive(:puts).with("#{magic_comment}\n# == Route Map\n#\n\nSomething\n")
+          expect(AnnotateRoutes).to receive(:puts).with(ANNOTATION_ADDED)
+          AnnotateRoutes.do_annotations(position_in_routes: 'top')
+        end
+      end
+
+      it 'leaves magic comment on top, adds an empty line between magic comment and annotation (position_in_routes :bottom)' do
+        expect(File).to receive(:open).with(ROUTE_FILE, 'wb')
+          .and_yield(mock_file).at_least(:once)
+
+        magic_comments_list_each do |magic_comment|
+          expect(File).to receive(:read).with(ROUTE_FILE).and_return("#{magic_comment}\nSomething")
+          expect(@mock_file).to receive(:puts).with("#{magic_comment}\nSomething\n\n# == Route Map\n#\n")
+          expect(AnnotateRoutes).to receive(:puts).with(ANNOTATION_ADDED)
+          AnnotateRoutes.do_annotations(position_in_routes: 'bottom')
+        end
+      end
+
+      it 'skips annotations if file does already contain annotation' do
+        magic_comments_list_each do |magic_comment|
+          expect(File).to receive(:read).with(ROUTE_FILE)
+            .and_return("#{magic_comment}\n\n# == Route Map\n#\n")
+          expect(AnnotateRoutes).to receive(:puts).with(FILE_UNCHANGED)
+
+          AnnotateRoutes.do_annotations
+        end
+      end
     end
   end
 


### PR DESCRIPTION
See comments at the bottom of https://github.com/ctran/annotate_models/issues/401

Added support of magic comments to `AnnotateRoutes`.