### PR TITLE
[Fix #438] model_dir option should allow multiple dirs with comma as …

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -736,8 +736,12 @@ module AnnotateModels
     end
 
     def parse_options(options = {})
-      self.model_dir = options[:model_dir] if options[:model_dir]
+      self.model_dir = split_model_dir(options[:model_dir]) if options[:model_dir]
       self.root_dir = options[:root_dir] if options[:root_dir]
+    end
+
+    def split_model_dir(option_value)
+      option_value.split(',').map(&:strip).reject(&:empty?)
     end
 
     # We're passed a name of things that might be

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -72,6 +72,31 @@ describe AnnotateModels do
   it { expect(AnnotateModels.quote(BigDecimal.new('1.2'))).to eql('1.2') }
   it { expect(AnnotateModels.quote([BigDecimal.new('1.2')])).to eql(['1.2']) }
 
+  describe '#parse_options' do
+    let(:options) do
+      {
+        root_dir: '/root',
+        model_dir: 'app/models,app/one,  app/two   ,,app/three'
+      }
+    end
+
+    it 'sets @root_dir' do
+      AnnotateModels.send(:parse_options, options)
+      expect(AnnotateModels.instance_variable_get(:@root_dir)).to eq('/root')
+    end
+
+    it 'sets @model_dir separated with a comma' do
+      AnnotateModels.send(:parse_options, options)
+      expected = [
+        'app/models',
+        'app/one',
+        'app/two',
+        'app/three'
+      ]
+      expect(AnnotateModels.instance_variable_get(:@model_dir)).to eq(expected)
+    end
+  end
+
   it 'should get schema info with default options' do
     klass = mock_class(:users,
                        :id,


### PR DESCRIPTION
…described in README

Fixes #438 