### PR TITLE
Additional new line between magic comment and annotation (AnnotateRou…

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -39,11 +39,13 @@ module AnnotateRoutes
       routes_map = app_routes_map(options)
 
       magic_comments_map, routes_map = extract_magic_comments_from_array(routes_map)
+
       out = []
 
       magic_comments_map.each do |magic_comment|
         out << magic_comment
       end
+      out << '' if magic_comments_map.any?
 
       out += ["# #{options[:wrapper_open]}"] if options[:wrapper_open]
 
@@ -174,6 +176,7 @@ module AnnotateRoutes
     magic_comments_map, content = extract_magic_comments_from_array(content)
     if %w(before top).include?(options[:position_in_routes])
       header = header << '' if content.first != ''
+      magic_comments_map << '' if magic_comments_map.any?
       new_content = magic_comments_map + header + content
     else
       # Ensure we have adequate trailing newlines at the end of the file to

--- a/spec/annotate/annotate_routes_spec.rb
+++ b/spec/annotate/annotate_routes_spec.rb
@@ -106,6 +106,7 @@ describe AnnotateRoutes do
           expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
           expect(@mock_file).to receive(:puts).with("
 #{magic_comment}
+
 # == Route Map
 #
 #                                       Prefix Verb       URI Pattern                                               Controller#Action
@@ -125,6 +126,7 @@ describe AnnotateRoutes do
           expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
           expect(@mock_file).to receive(:puts).with("
 #{magic_comment}
+
 # ## Route Map
 #
 # Prefix    | Verb       | URI Pattern     | Controller#Action   
@@ -144,6 +146,7 @@ describe AnnotateRoutes do
           expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
           expect(@mock_file).to receive(:puts).with("
 #{magic_comment}
+
 # START
 # == Route Map
 #
@@ -208,7 +211,7 @@ describe AnnotateRoutes do
 
         magic_comments_list_each do |magic_comment|
           expect(File).to receive(:read).with(ROUTE_FILE).and_return("#{magic_comment}\nSomething")
-          expect(@mock_file).to receive(:puts).with("#{magic_comment}\n# == Route Map\n#\n\nSomething\n")
+          expect(@mock_file).to receive(:puts).with("#{magic_comment}\n\n# == Route Map\n#\n\nSomething\n")
           expect(AnnotateRoutes).to receive(:puts).with(ANNOTATION_ADDED)
           AnnotateRoutes.do_annotations(position_in_routes: 'top')
         end


### PR DESCRIPTION
…tes)

This is addition to PR https://github.com/ctran/annotate_models/pull/520

It adds additional new line between magic comments and annotation in `AnnotateRoutes` to align with how it works in `AnnotateModels`.