### PR TITLE
Update Readme Gemfile declaration

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -55,11 +55,15 @@ Also, if you pass the -r option, it'll annotate routes.rb with the output of
 
 Into Gemfile from rubygems.org:
 
-    gem 'annotate', require: false
+    group :development do
+      gem 'annotate'
+    end
 
 Into Gemfile from Github:
 
-    gem 'annotate', git: 'https://github.com/ctran/annotate_models.git', require: false
+    group :development do
+      gem 'annotate', git: 'https://github.com/ctran/annotate_models.git'
+    end
 
 Into environment gems from rubygems.org:
 


### PR DESCRIPTION
For this `rails g annotate:install` to work (as well as rake task), the gem should be required in rails application. Otherwise, `uninitialized constant AnnotateModels (NameError)` will be thrown.