### PR TITLE
Redirect error messages to current standard error stream

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ require 'mg'
 begin
   MG.new('annotate.gemspec')
 rescue Exception
-  STDERR.puts("WARNING: Couldn't read gemspec.  As such, a number of tasks may be unavailable to you until you run 'rake gem:gemspec' to correct the issue.")
+  $stderr.puts("WARNING: Couldn't read gemspec.  As such, a number of tasks may be unavailable to you until you run 'rake gem:gemspec' to correct the issue.")
   # Gemspec is probably in a broken state, so let's give ourselves a chance to
   # build a new one...
 end

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -169,7 +169,7 @@ module Annotate
       require 'rake/dsl_definition'
     rescue StandardError => e
       # We might just be on an old version of Rake...
-      puts e.message
+      $stderr.puts e.message
       exit e.status_code
     end
     require 'rake'

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -640,8 +640,8 @@ module AnnotateModels
             end
         end
       rescue StandardError => e
-        puts "Unable to annotate #{file}: #{e.message}"
-        puts "\t" + e.backtrace.join("\n\t") if options[:trace]
+        $stderr.puts "Unable to annotate #{file}: #{e.message}"
+        $stderr.puts "\t" + e.backtrace.join("\n\t") if options[:trace]
       end
 
       annotated
@@ -676,9 +676,9 @@ module AnnotateModels
 
       model_files
     rescue SystemCallError
-      puts "No models found in directory '#{model_dir.join("', '")}'."
-      puts "Either specify models on the command line, or use the --model-dir option."
-      puts "Call 'annotate --help' for more info."
+      $stderr.puts "No models found in directory '#{model_dir.join("', '")}'."
+      $stderr.puts "Either specify models on the command line, or use the --model-dir option."
+      $stderr.puts "Call 'annotate --help' for more info."
       exit 1
     end
 
@@ -786,12 +786,12 @@ module AnnotateModels
         annotated.concat(annotate(klass, file, header, options)) if do_annotate
       rescue BadModelFileError => e
         unless options[:ignore_unknown_models]
-          puts "Unable to annotate #{file}: #{e.message}"
-          puts "\t" + e.backtrace.join("\n\t") if options[:trace]
+          $stderr.puts "Unable to annotate #{file}: #{e.message}"
+          $stderr.puts "\t" + e.backtrace.join("\n\t") if options[:trace]
         end
       rescue StandardError => e
-        puts "Unable to annotate #{file}: #{e.message}"
-        puts "\t" + e.backtrace.join("\n\t") if options[:trace]
+        $stderr.puts "Unable to annotate #{file}: #{e.message}"
+        $stderr.puts "\t" + e.backtrace.join("\n\t") if options[:trace]
       end
     end
 
@@ -821,8 +821,8 @@ module AnnotateModels
           end
           deannotated << klass if deannotated_klass
         rescue StandardError => e
-          puts "Unable to deannotate #{File.join(file)}: #{e.message}"
-          puts "\t" + e.backtrace.join("\n\t") if options[:trace]
+          $stderr.puts "Unable to deannotate #{File.join(file)}: #{e.message}"
+          $stderr.puts "\t" + e.backtrace.join("\n\t") if options[:trace]
         end
       end
       puts "Removed annotations from: #{deannotated.join(', ')}"

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -1676,22 +1676,22 @@ end
         EOS
       end
 
-      it 'displays an error message' do
-        expect(capturing(:stdout) do
+      it 'displays just the error message with trace disabled (default)' do
+        error_output = capturing(:stderr) do
           AnnotateModels.do_annotations model_dir: @model_dir, is_rake: true
-        end).to include("Unable to annotate #{@model_dir}/user.rb: oops")
+        end
+
+        expect(error_output).to include("Unable to annotate #{@model_dir}/user.rb: oops")
+        expect(error_output).not_to include('/spec/annotate/annotate_models_spec.rb:')
       end
 
-      it 'displays the full stack trace with --trace' do
-        expect(capturing(:stdout) do
-          AnnotateModels.do_annotations model_dir: @model_dir, trace: true, is_rake: true
-        end).to include('/spec/annotate/annotate_models_spec.rb:')
-      end
+      it 'displays the error message and stacktrace with trace enabled' do
+        error_output = capturing(:stderr) do
+          AnnotateModels.do_annotations model_dir: @model_dir, is_rake: true, trace: true
+        end
 
-      it 'omits the full stack trace without --trace' do
-        expect(capturing(:stdout) do
-          AnnotateModels.do_annotations model_dir: @model_dir, trace: false, is_rake: true
-        end).not_to include('/spec/annotate/annotate_models_spec.rb:')
+        expect(error_output).to include("Unable to annotate #{@model_dir}/user.rb: oops")
+        expect(error_output).to include('/spec/annotate/annotate_models_spec.rb:')
       end
     end
 
@@ -1706,22 +1706,22 @@ end
         EOS
       end
 
-      it 'displays an error message' do
-        expect(capturing(:stdout) do
+      it 'displays just the error message with trace disabled (default)' do
+        error_output = capturing(:stderr) do
           AnnotateModels.remove_annotations model_dir: @model_dir, is_rake: true
-        end).to include("Unable to deannotate #{@model_dir}/user.rb: oops")
+        end
+
+        expect(error_output).to include("Unable to deannotate #{@model_dir}/user.rb: oops")
+        expect(error_output).not_to include("/user.rb:2:in `<class:User>'")
       end
 
-      it 'displays the full stack trace' do
-        expect(capturing(:stdout) do
-          AnnotateModels.remove_annotations model_dir: @model_dir, trace: true, is_rake: true
-        end).to include("/user.rb:2:in `<class:User>'")
-      end
+      it 'displays the error message and stacktrace with trace enabled' do
+        error_output = capturing(:stderr) do
+          AnnotateModels.remove_annotations model_dir: @model_dir, is_rake: true, trace: true
+        end
 
-      it 'omits the full stack trace without --trace' do
-        expect(capturing(:stdout) do
-          AnnotateModels.remove_annotations model_dir: @model_dir, trace: false, is_rake: true
-        end).not_to include("/user.rb:2:in `<class:User>'")
+        expect(error_output).to include("Unable to deannotate #{@model_dir}/user.rb: oops")
+        expect(error_output).to include("/user.rb:2:in `<class:User>'")
       end
     end
   end

--- a/spec/integration/rails_2.3_with_bundler/config/boot.rb
+++ b/spec/integration/rails_2.3_with_bundler/config/boot.rb
@@ -63,7 +63,7 @@ module Rails
       end
     rescue Gem::LoadError => load_error
       if load_error.message =~ /Could not find RubyGem rails/
-        STDERR.puts %(Missing the Rails #{version} gem. Please `gem install -v=#{version} rails`, update your RAILS_GEM_VERSION setting in config/environment.rb for the Rails version you do have installed, or comment out RAILS_GEM_VERSION to use the latest version installed.)
+        $stderr.puts "Missing the Rails #{version} gem. Please `gem install -v=#{version} rails`, update your RAILS_GEM_VERSION setting in config/environment.rb for the Rails version you do have installed, or comment out RAILS_GEM_VERSION to use the latest version installed."
         exit 1
       else
         raise


### PR DESCRIPTION
We had a script that ran a Rails migration. Since its output is noisy, we swallowed stdout. The exit code was `1` but there was no message because `annotate_models` puts its error messages to stdout instead of stderr.

This PR redirects error messages to the current standard error stream `$stderr`.

**Before**
```
$ bundle exec rake annotate_models >/dev/null
$ echo $?
1
```

**After**
```
$ bundle exec rake annotate_models >/dev/null
No models found in directory 'app/models'.
Either specify models on the command line, or use the --model-dir option.
Call 'annotate --help' for more info.
$ echo $?
1
```
