### PR TITLE
Escape newline characters in index expression

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -374,7 +374,7 @@ module AnnotateModels
         if index.try(:orders) && index.orders[col.to_s]
           "#{col} #{index.orders[col.to_s].upcase}"
         else
-          col.to_s
+          col.to_s.gsub("\r", '\r').gsub("\n", '\n')
         end
       end
     end


### PR DESCRIPTION
If there is any newline characters in an index's expression, that piece of comment will be splitted in two lines, thus corrupting the annotated file.

This pull request fixes the issue by escaping these newline characters.
