### PR TITLE
Fix rubocop violation (extra line added before model definition)

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -535,7 +535,7 @@ module AnnotateModels
             new_content = if %w(after bottom).include?(options[position].to_s)
                             magic_comments_block + (old_content.rstrip + "\n\n" + wrapped_info_block)
                           else
-                            magic_comments_block + wrapped_info_block + "\n" + old_content
+                            magic_comments_block + wrapped_info_block + old_content
                           end
           end
 

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -517,11 +517,7 @@ module AnnotateModels
           return false
         else
           # Replace inline the old schema info with the new schema info
-          new_content = old_content.sub(annotate_pattern(options), info_block + "\n")
-
-          if new_content.end_with?(info_block + "\n")
-            new_content = old_content.sub(annotate_pattern(options), "\n" + info_block)
-          end
+          new_content = old_content.sub(annotate_pattern(options), "\n" + info_block + "\n")
 
           wrapper_open = options[:wrapper_open] ? "# #{options[:wrapper_open]}\n" : ""
           wrapper_close = options[:wrapper_close] ? "# #{options[:wrapper_close]}\n" : ""

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -1553,7 +1553,7 @@ end
       it "should put annotation before class if :position == #{position}" do
         annotate_one_file position: position
         expect(File.read(@model_file_name))
-          .to eq("#{@schema_info}\n#{@file_content}")
+          .to eq("#{@schema_info}#{@file_content}")
       end
     end
 
@@ -1568,7 +1568,7 @@ end
     it 'should wrap annotation if wrapper is specified' do
       annotate_one_file wrapper_open: 'START', wrapper_close: 'END'
       expect(File.read(@model_file_name))
-        .to eq("# START\n#{@schema_info}# END\n\n#{@file_content}")
+        .to eq("# START\n#{@schema_info}# END\n#{@file_content}")
     end
 
     describe 'with existing annotation => :before' do
@@ -1613,7 +1613,7 @@ end
 
       it 'should change position to :before when force: true' do
         annotate_one_file position: :before, force: true
-        expect(File.read(@model_file_name)).to eq("#{@schema_info}\n#{@file_content}")
+        expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
       end
     end
 
@@ -1637,7 +1637,7 @@ end
                          ])
       schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info')
       AnnotateModels.annotate_one_file(model_file_name, schema_info, position: :before)
-      expect(File.read(model_file_name)).to eq("#{schema_info}\n#{file_content}")
+      expect(File.read(model_file_name)).to eq("#{schema_info}#{file_content}")
     end
 
     it 'should not touch magic comments' do
@@ -1667,7 +1667,7 @@ end
         annotate_one_file position: :before
         schema_info = AnnotateModels.get_schema_info(@klass, '== Schema Info')
 
-        expect(File.read(model_file_name)).to eq("#{magic_comment}\n\n#{schema_info}\n#{content}")
+        expect(File.read(model_file_name)).to eq("#{magic_comment}\n\n#{schema_info}#{content}")
       end
     end
 

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -1580,12 +1580,12 @@ end
 
       it 'should retain current position' do
         annotate_one_file
-        expect(File.read(@model_file_name)).to eq("#{@schema_info}\n#{@file_content}")
+        expect(File.read(@model_file_name)).to eq("\n#{@schema_info}\n#{@file_content}")
       end
 
       it 'should retain current position even when :position is changed to :after' do
         annotate_one_file position: :after
-        expect(File.read(@model_file_name)).to eq("#{@schema_info}\n#{@file_content}")
+        expect(File.read(@model_file_name)).to eq("\n#{@schema_info}\n#{@file_content}")
       end
 
       it 'should change position to :after when force: true' do
@@ -1603,12 +1603,12 @@ end
 
       it 'should retain current position' do
         annotate_one_file
-        expect(File.read(@model_file_name)).to eq("#{@file_content}\n#{@schema_info}")
+        expect(File.read(@model_file_name)).to eq("#{@file_content}\n#{@schema_info}\n")
       end
 
       it 'should retain current position even when :position is changed to :before' do
         annotate_one_file position: :before
-        expect(File.read(@model_file_name)).to eq("#{@file_content}\n#{@schema_info}")
+        expect(File.read(@model_file_name)).to eq("#{@file_content}\n#{@schema_info}\n")
       end
 
       it 'should change position to :before when force: true' do


### PR DESCRIPTION
Remove the extra `\n` inserted before the class causing the diff to look something like

```diff
+# **`sprite_length`**        | `integer`          |
+#
+
+
 class Video < ApplicationRecord
```
causing rubocop to complain `C: Layout/EmptyLines: Extra blank line detected.`

solution: Remove the extra line so that the diff would look like:
```diff
+# **`sprite_length`**        | `integer`          |
+#
+
 class Video < ApplicationRecord
```
