### PR TITLE
Fix with_comment format in annotate_models_rake

### DIFF
--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -47,7 +47,7 @@ task annotate_models: :environment do
   options[:ignore_routes] = ENV.fetch('ignore_routes', nil)
   options[:hide_limit_column_types] = Annotate.fallback(ENV['hide_limit_column_types'], '')
   options[:hide_default_column_types] = Annotate.fallback(ENV['hide_default_column_types'], '')
-  options[:with_comment] = Annotate.fallback(ENV['with_comment'], '')
+  options[:with_comment] = Annotate.true?(ENV['with_comment'])
 
   AnnotateModels.do_annotations(options)
 end


### PR DESCRIPTION
### Summary

* :with_comment option is flag.
* It should use `true?` instead of `fallback`.

Now with_comment option is enforcely overwritten in annotate_models.rake. So I've fixed it.
