### PR TITLE
Use string instead of boolean

### DIFF
--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -46,7 +46,7 @@ if Rails.env.development?
       'trace'                     => 'false',
       'wrapper_open'              => nil,
       'wrapper_close'             => nil,
-      'with_comment'              => true
+      'with_comment'              => 'true'
     )
   end
 


### PR DESCRIPTION
### Summary

:with_comment option should use string instead of boolean as same as others.