### PR TITLE
Allow bigint annotations in rails 4.

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -362,7 +362,7 @@ module AnnotateModels
     end
 
     def get_col_type(col)
-      if col.sql_type == 'bigint'
+      if (col.respond_to?(:bigint?) && col.bigint?) || /\Abigint\b/.match?(col.sql_type)
         'bigint'
       else
         (col.type || col.sql_type).to_s

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -184,7 +184,8 @@ EOS
                        [
                          mock_column(:id, :integer),
                          mock_column(:integer, :integer, unsigned?: true),
-                         mock_column(:bigint,  :integer, unsigned?: true, sql_type: 'bigint'),
+                         mock_column(:bigint,  :integer, unsigned?: true, bigint?: true),
+                         mock_column(:bigint,  :bigint,  unsigned?: true),
                          mock_column(:float,   :float,   unsigned?: true),
                          mock_column(:decimal, :decimal, unsigned?: true, precision: 10, scale: 2),
                        ])
@@ -196,6 +197,7 @@ EOS
 #
 #  id      :integer          not null
 #  integer :integer          unsigned, not null
+#  bigint  :bigint           unsigned, not null
 #  bigint  :bigint           unsigned, not null
 #  float   :float            unsigned, not null
 #  decimal :decimal(10, 2)   unsigned, not null


### PR DESCRIPTION
In rails 4, columns do not respond to `bigint?`. However, in both rails
4 and rails 5, columns do respond to `sql_type`. This way, annotations
should work in both versions.

Very open to suggestions in specs! Should I change `mock_column`'s signature to `mock_column(name, type, sql_type, options ={})`?

If the backstory is helpful, bigint annotating was originally added in https://github.com/ctran/annotate_models/pull/515.