### PR TITLE
Refactor and simplify returns

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -512,7 +512,7 @@ module AnnotateModels
       new_columns = new_header && new_header.scan(column_pattern).sort
 
       return false if old_columns == new_columns && !options[:force]
-      
+
       # Replace inline the old schema info with the new schema info
       wrapper_open = options[:wrapper_open] ? "# #{options[:wrapper_open]}\n" : ""
       wrapper_close = options[:wrapper_close] ? "# #{options[:wrapper_close]}\n" : ""
@@ -543,7 +543,7 @@ module AnnotateModels
       end
 
       File.open(file_name, 'wb') { |f| f.puts new_content }
-      return true
+      true
     end
 
     def magic_comment_matcher

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -498,57 +498,52 @@ module AnnotateModels
     #                           :before, :top, :after or :bottom. Default is :before.
     #
     def annotate_one_file(file_name, info_block, position, options = {})
-      if File.exist?(file_name)
-        old_content = File.read(file_name)
-        return false if old_content =~ /#{SKIP_ANNOTATION_PREFIX}.*\n/
+      return false unless File.exist?(file_name)
+      old_content = File.read(file_name)
+      return false if old_content =~ /#{SKIP_ANNOTATION_PREFIX}.*\n/
 
-        # Ignore the Schema version line because it changes with each migration
-        header_pattern = /(^# Table name:.*?\n(#.*[\r]?\n)*[\r]?)/
-        old_header = old_content.match(header_pattern).to_s
-        new_header = info_block.match(header_pattern).to_s
+      # Ignore the Schema version line because it changes with each migration
+      header_pattern = /(^# Table name:.*?\n(#.*[\r]?\n)*[\r]?)/
+      old_header = old_content.match(header_pattern).to_s
+      new_header = info_block.match(header_pattern).to_s
 
-        column_pattern = /^#[\t ]+[\w\*`]+[\t ]+.+$/
-        old_columns = old_header && old_header.scan(column_pattern).sort
-        new_columns = new_header && new_header.scan(column_pattern).sort
+      column_pattern = /^#[\t ]+[\w\*`]+[\t ]+.+$/
+      old_columns = old_header && old_header.scan(column_pattern).sort
+      new_columns = new_header && new_header.scan(column_pattern).sort
 
-        if old_columns == new_columns && !options[:force]
-          return false
-        else
-          # Replace inline the old schema info with the new schema info
-          wrapper_open = options[:wrapper_open] ? "# #{options[:wrapper_open]}\n" : ""
-          wrapper_close = options[:wrapper_close] ? "# #{options[:wrapper_close]}\n" : ""
-          wrapped_info_block = "#{wrapper_open}#{info_block}#{wrapper_close}"
+      return false if old_columns == new_columns && !options[:force]
+      
+      # Replace inline the old schema info with the new schema info
+      wrapper_open = options[:wrapper_open] ? "# #{options[:wrapper_open]}\n" : ""
+      wrapper_close = options[:wrapper_close] ? "# #{options[:wrapper_close]}\n" : ""
+      wrapped_info_block = "#{wrapper_open}#{info_block}#{wrapper_close}"
 
-          old_annotation = old_content.match(annotate_pattern(options)).to_s
+      old_annotation = old_content.match(annotate_pattern(options)).to_s
 
-          # if there *was* no old schema info or :force was passed, we simply
-          # need to insert it in correct position
-          if old_annotation.empty? || options[:force]
-            magic_comments_block = magic_comments_as_string(old_content)
-            old_content.gsub!(magic_comment_matcher, '')
-            old_content.sub!(annotate_pattern(options), '')
+      # if there *was* no old schema info or :force was passed, we simply
+      # need to insert it in correct position
+      if old_annotation.empty? || options[:force]
+        magic_comments_block = magic_comments_as_string(old_content)
+        old_content.gsub!(magic_comment_matcher, '')
+        old_content.sub!(annotate_pattern(options), '')
 
-            new_content = if %w(after bottom).include?(options[position].to_s)
-                            magic_comments_block + (old_content.rstrip + "\n\n" + wrapped_info_block)
-                          else
-                            magic_comments_block + wrapped_info_block + "\n" + old_content
-                          end
-          else
-            # replace the old annotation with the new one
-
-            # keep the surrounding whitespace the same
-            space_match = old_annotation.match(/\A(?<start>\s*).*?\n(?<end>\s*)\z/m)
-            new_annotation = space_match[:start] + wrapped_info_block + space_match[:end]
-
-            new_content = old_content.sub(annotate_pattern(options), new_annotation)
-          end
-
-          File.open(file_name, 'wb') { |f| f.puts new_content }
-          return true
-        end
+        new_content = if %w(after bottom).include?(options[position].to_s)
+                        magic_comments_block + (old_content.rstrip + "\n\n" + wrapped_info_block)
+                      else
+                        magic_comments_block + wrapped_info_block + "\n" + old_content
+                      end
       else
-        false
+        # replace the old annotation with the new one
+
+        # keep the surrounding whitespace the same
+        space_match = old_annotation.match(/\A(?<start>\s*).*?\n(?<end>\s*)\z/m)
+        new_annotation = space_match[:start] + wrapped_info_block + space_match[:end]
+
+        new_content = old_content.sub(annotate_pattern(options), new_annotation)
       end
+
+      File.open(file_name, 'wb') { |f| f.puts new_content }
+      return true
     end
 
     def magic_comment_matcher


### PR DESCRIPTION
Refactor and simplify returns for `annotate_one_file`.   This simplifies some big if/else blocks that were wrapping significant portions of this method.  No logic is changed.

This is best viewed hiding whitespace changes (under the "Diff settings" button).

This is currently built on top of #573, because it hits the same lines of code (I split it out because the whitespace changes make it hit every line in the function). If for some reason you want to merge this one and not #573, I'll be happy to refactor.
