### PR TITLE
Fix alignment of multi-byte fullwidth character comments

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -301,7 +301,7 @@ module AnnotateModels
           type_remainder = (md_type_allowance - 2) - col_type.length
           info << (sprintf("# **`%s`**%#{name_remainder}s | `%s`%#{type_remainder}s | `%s`", col_name, " ", col_type, " ", attrs.join(", ").rstrip)).gsub('``', '  ').rstrip + "\n"
         else
-          info << sprintf("#  %-#{max_size}.#{max_size}s:%-#{bare_type_allowance}.#{bare_type_allowance}s %s", col_name, col_type, attrs.join(", ")).rstrip + "\n"
+          info << format_default(col_name, max_size, col_type, bare_type_allowance, attrs)
         end
       end
 
@@ -884,7 +884,7 @@ module AnnotateModels
     def max_schema_info_width(klass, options)
       if with_comments?(klass, options)
         max_size = klass.columns.map do |column|
-          column.name.size + (column.comment ? column.comment.size : 0)
+          column.name.size + (column.comment ? width(column.comment) : 0)
         end.max || 0
         max_size += 2
       else
@@ -893,6 +893,20 @@ module AnnotateModels
       max_size += options[:format_rdoc] ? 5 : 1
 
       max_size
+    end
+
+    def format_default(col_name, max_size, col_type, bare_type_allowance, attrs)
+      sprintf("#  %s:%s %s", mb_chars_ljust(col_name, max_size), mb_chars_ljust(col_type, bare_type_allowance),  attrs.join(", ")).rstrip + "\n"
+    end
+
+    def width(string)
+      string.chars.inject(0) { |acc, elem| acc + (elem.bytesize == 1 ? 1 : 2) }
+    end
+
+    def mb_chars_ljust(string, length)
+      string = string.to_s
+      padding = length - width(string)
+      string + (' ' * padding)
     end
   end
 

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -936,6 +936,29 @@ EOS
         #  notes(Notes)   :text(55)         not null
         #  no_comment     :text(20)         not null
         #
+    EOS
+
+      mocked_columns_with_multibyte_comment = [
+        [:id,         :integer, { limit: 8,  comment: 'ＩＤ' }],
+        [:active,     :boolean, { limit: 1,  comment: 'ＡＣＴＩＶＥ' }],
+        [:name,       :string,  { limit: 50, comment: 'ＮＡＭＥ' }],
+        [:notes,      :text,    { limit: 55, comment: 'ＮＯＴＥＳ' }],
+        [:no_comment, :text,    { limit: 20, comment: nil }]
+      ]
+
+      when_called_with with_comment: 'yes',
+                       with_columns: mocked_columns_with_multibyte_comment, returns:
+        <<-EOS.strip_heredoc
+        # Schema Info
+        #
+        # Table name: users
+        #
+        #  id(ＩＤ)             :integer          not null, primary key
+        #  active(ＡＣＴＩＶＥ) :boolean          not null
+        #  name(ＮＡＭＥ)       :string(50)       not null
+        #  notes(ＮＯＴＥＳ)    :text(55)         not null
+        #  no_comment           :text(20)         not null
+        #
       EOS
 
       it 'should get schema info as RDoc' do


### PR DESCRIPTION
This fixes alignment of Japanese, Korean and Chinese fullwidth character comments.

The displayed widths of multi-byte fullwidth characters are generally
twice as large as the ASCII characters, but String#size returns only the number of characters.
So if the column comment contains fullwidth multibyte characters, the alignment is broken.

Monospaced font-family supporting multi-byte isn't used in GitHub diff view, you can confirm the fixed alignment with `font-family: "Osaka-mono", "MS Gothic";`.

cf. https://gyazo.com/d878a077b7494f07bcc45ecf7c0adb62