### PR TITLE
BUG #578 - fix magic_comment_matcher regexp for frozen_string_literal

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -548,7 +548,7 @@ module AnnotateModels
     end
 
     def magic_comment_matcher
-      Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/)
+      Regexp.new(/(^#\s*encoding:.*(?:\n|\r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n)?)|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n)?)/)
     end
 
     def magic_comments_as_string(content)


### PR DESCRIPTION
fix the regexp in annotate_models#magic_comment_matcher to match `# frozen_string_literal: true` 