### PR TITLE
Do not add whitespace after magic comments when annotating at position after/bottom

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -529,8 +529,10 @@ module AnnotateModels
 
         new_content = if %w(after bottom).include?(options[position].to_s)
                         magic_comments_block + (old_content.rstrip + "\n\n" + wrapped_info_block)
-                      else
+                      elsif magic_comments_block.empty?
                         magic_comments_block + wrapped_info_block + "\n" + old_content
+                      else
+                        magic_comments_block + "\n" + wrapped_info_block + "\n" + old_content
                       end
       else
         # replace the old annotation with the new one
@@ -554,7 +556,7 @@ module AnnotateModels
       magic_comments = content.scan(magic_comment_matcher).flatten.compact
 
       if magic_comments.any?
-        magic_comments.join + "\n"
+        magic_comments.join
       else
         ''
       end

--- a/spec/annotate/annotate_models_spec.rb
+++ b/spec/annotate/annotate_models_spec.rb
@@ -1697,7 +1697,7 @@ end
       end
     end
 
-    it 'adds an empty line between magic comments and model file content (position :after)' do
+    it 'does not change whitespace between magic comments and model file content (position :after)' do
       content = "class User < ActiveRecord::Base\nend\n"
       magic_comments_list_each do |magic_comment|
         model_file_name, = write_model 'user.rb', "#{magic_comment}\n#{content}"
@@ -1705,7 +1705,7 @@ end
         annotate_one_file position: :after
         schema_info = AnnotateModels.get_schema_info(@klass, '== Schema Info')
 
-        expect(File.read(model_file_name)).to eq("#{magic_comment}\n\n#{content}\n#{schema_info}")
+        expect(File.read(model_file_name)).to eq("#{magic_comment}\n#{content}\n#{schema_info}")
       end
     end
 


### PR DESCRIPTION
When position is set to after or bottom the current behavior added an extra newline following magic comments. 

If the file is being annotated at position after/bottom there should be no need to make modifications after the magic comments. (Any style/formatting there is not the concern of this gem if the file is not being annotated there.)

This change fixes that behavior to only insert a newline if the file is being annotated at position before/top, i.e. between the magic comments and existing content.