### PR TITLE
Allow ignore_unknown_models to be overridden by an environment variable

### DIFF
--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -48,6 +48,7 @@ task annotate_models: :environment do
   options[:hide_limit_column_types] = Annotate.fallback(ENV['hide_limit_column_types'], '')
   options[:hide_default_column_types] = Annotate.fallback(ENV['hide_default_column_types'], '')
   options[:with_comment] = Annotate.true?(ENV['with_comment'])
+  options[:ignore_unknown_models] = Annotate.true?(ENV.fetch('ignore_unknown_models', 'false'))
 
   AnnotateModels.do_annotations(options)
 end


### PR DESCRIPTION
Allow ignore_unknown_models to be overridden by an environment variable. This allows people to silence errors from non-AR models present in the `models` folder.