### PR TITLE
Try "app:" task prefix on migration annotaiton

### DIFF
--- a/lib/tasks/annotate_models_migrate.rake
+++ b/lib/tasks/annotate_models_migrate.rake
@@ -7,7 +7,12 @@
 %w(db:migrate db:migrate:up db:migrate:down db:migrate:reset db:migrate:redo db:rollback).each do |task|
   Rake::Task[task].enhance do
     Rake::Task[Rake.application.top_level_tasks.last].enhance do
-      Rake::Task['set_annotation_options'].invoke
+      annotation_options_task = if Rake::Task.task_defined?('app:set_annotation_options')
+                                  'app:set_annotation_options'
+                                else
+                                  'set_annotation_options'
+                                end
+      Rake::Task[annotation_options_task].invoke
       Annotate::Migration.update_annotations
     end
   end
@@ -37,6 +42,8 @@ module Annotate
     def self.update_routes
       if Rake::Task.task_defined?("annotate_routes")
         Rake::Task["annotate_routes"].invoke
+      elsif Rake::Task.task_defined?("app:annotate_routes")
+        Rake::Task["app:annotate_routes"].invoke
       end
     end
   end


### PR DESCRIPTION
Since Rails full engines run as non-namespaced applications
but all their app-related tasks still prefixed with app:.