### PR TITLE
Add columns managed by Globalize gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -5,7 +5,7 @@ require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'
 require 'files'
 
-describe AnnotateModels do # rubocop:disable Metrics/BlockLength
+describe AnnotateModels do
   MAGIC_COMMENTS = [
     '# encoding: UTF-8',
     '# coding: UTF-8',
@@ -1383,7 +1383,7 @@ EOS
     end
   end
 
-  describe '.get_model_class' do # rubocop:disable Metrics/BlockLength
+  describe '.get_model_class' do
     before :all do
       require 'tmpdir'
       AnnotateModels.model_dir = Dir.mktmpdir('annotate_models')

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -865,6 +865,39 @@ EOS
 EOS
   end
 
+  it 'should work with the Globalize gem' do
+    klass = mock_class(:posts,
+                       :id,
+                       [
+                         mock_column(:id, :integer, limit: 8),
+                         mock_column(:author_name, :string, limit: 50),
+                       ])
+
+    options = {
+      to_s: 'Post::Translation',
+      columns: [
+        mock_column(:id, :integer, limit: 8),
+        mock_column(:post_id, :integer, limit: 8),
+        mock_column(:locale, :string, limit: 50),
+        mock_column(:title, :string, limit: 50),
+      ]
+    }
+    translation_klass = double('Post::Translation', options)
+    allow(klass).to receive(:translation_class).and_return(translation_klass)
+
+    expected_schema_info = <<~EOS
+      # Schema Info
+      #
+      # Table name: posts
+      #
+      #  id          :integer          not null, primary key
+      #  author_name :string(50)       not null
+      #  title       :string(50)       not null
+      #
+    EOS
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_schema_info)
+  end
+
   describe '.set_defaults' do
     subject do
       Annotate::Helpers.true?(ENV['show_complete_foreign_keys'])

--- a/spec/lib/annotate/parser_spec.rb
+++ b/spec/lib/annotate/parser_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 
 module Annotate # rubocop:disable Metrics/ModuleLength
-  describe Parser do # rubocop:disable Metrics/BlockLength
+  describe Parser do
     before(:example) do
       ENV.clear
     end


### PR DESCRIPTION
Globalize hooks into the model and removes the translated columns
from the `klass.columns`. This commit checks if globalize is
hooked into the model and adds the necessary columns to the
annotation array.