### PR TITLE
Account for big string in models

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -909,7 +909,7 @@ module AnnotateModels
 
     def mb_chars_ljust(string, length)
       string = string.to_s
-      padding = length - width(string)
+      padding = [0, length - width(string)].max
       if padding > 0
         string + (' ' * padding)
       else


### PR DESCRIPTION
I have this spatial type column using mysql's spatial adapter. It generates col_type to be `:geometry({:type=>"polygon", :srid=>0})`
which seems to be bigger than `bare_type_allowance`  making `padding` negative and causing exception. Checking for negative for such cases.