### PR TITLE
allow annotate to work with Jets, at least for models

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -143,7 +143,9 @@ module Annotate
     load_requires(options)
     require 'annotate/active_record_patch'
 
-    if defined?(Rails::Application)
+    if defined?(Jets)
+      Jets::Autoloaders.main.eager_load
+    elsif defined?(Rails::Application)
       if Rails.version.split('.').first.to_i < 3
         Rails.configuration.eager_load_paths.each do |load_path|
           matcher = /\A#{Regexp.escape(load_path)}(.*)\.rb\Z/


### PR DESCRIPTION
Allows annotate to work with models for Jets. It won't work for Jets routes though.

Context: https://community.rubyonjets.com/t/using-annotate-with-jets/184