### PR TITLE
fix bundle exec annotate doesnt run on models, just routes

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -38,7 +38,7 @@ module Annotate
   OTHER_OPTIONS = [
     :ignore_columns, :skip_on_db_migrate, :wrapper_open, :wrapper_close,
     :wrapper, :routes, :hide_limit_column_types, :hide_default_column_types,
-    :ignore_routes, :active_admin
+    :ignore_routes, :active_admin, :models
   ].freeze
   PATH_OPTIONS = [
     :require, :model_dir, :root_dir
@@ -114,7 +114,7 @@ module Annotate
   end
 
   def self.include_models?
-    ENV['routes'] !~ TRUE_RE
+    ENV['models'] =~ TRUE_RE
   end
 
   def self.loaded_tasks=(val)

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -7,6 +7,7 @@ if Rails.env.development?
     # You can override any of these by setting an environment variable of the
     # same name.
     Annotate.set_defaults(
+      'models'                    => 'true',
       'routes'                    => 'false',
       'position_in_routes'        => 'before',
       'position_in_class'         => 'before',


### PR DESCRIPTION
Fix issue: bundle exec annotate doesn't run on models, just routes