### PR TITLE
Update .travis.yml to unblock Ruby 2.2 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
   - rvm: ruby-head
 
 before_install:
-- gem update --system
+- gem update --system || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
 - gem update bundler
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-- 2.2.7
+- 2.2.10
 - 2.3.8
 - 2.4.6
 - 2.5.5


### PR DESCRIPTION
This PR updates Ruby `2.2.X` to use `2.2.10`. It also unblocks Ruby 2.2 builds currently failing in CI. This happens because builds try updating to RubyGems 3 which does not support Ruby 2.2.