### PR TITLE
Make it possible to annotate models and routes together

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -89,11 +89,11 @@ To annotate all your models, tests, fixtures, and factories:
 
 To annotate just your models, tests, and factories:
 
-    annotate --exclude fixtures
+    annotate --models --exclude fixtures
 
 To annotate just your models:
 
-    annotate --exclude tests,fixtures,factories,serializers
+    annotate --models
 
 To annotate routes.rb:
 
@@ -184,6 +184,7 @@ you can do so with a simple environment variable, instead of editing the
             --wo, --wrapper-open STR     Annotation wrapper opening.
             --wc, --wrapper-close STR    Annotation wrapper closing
         -r, --routes                     Annotate routes.rb with the output of 'rake routes'
+            --models                     Annotate ActiveRecord models
         -a, --active-admin               Annotate active_admin models
         -v, --version                    Show the current version of this gem
         -m, --show-migration             Include the migration version number in the annotation

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -37,7 +37,7 @@ module Annotate
   ].freeze
   OTHER_OPTIONS = [
     :additional_file_patterns, :ignore_columns, :skip_on_db_migrate, :wrapper_open, :wrapper_close,
-    :wrapper, :routes, :hide_limit_column_types, :hide_default_column_types,
+    :wrapper, :routes, :models, :hide_limit_column_types, :hide_default_column_types,
     :ignore_routes, :active_admin
   ].freeze
   PATH_OPTIONS = [

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -115,7 +115,7 @@ module Annotate
   end
 
   def self.include_models?
-    ENV['routes'] !~ TRUE_RE
+    ENV['models'] =~ TRUE_RE
   end
 
   def self.loaded_tasks=(val)

--- a/lib/annotate/parser.rb
+++ b/lib/annotate/parser.rb
@@ -123,6 +123,10 @@ module Annotate
         env['routes'] = 'true'
       end
 
+      option_parser.on('--models', "Annotate routes.rb with the output of 'rake routes'") do
+        env['models'] = 'true'
+      end
+
       option_parser.on('-a', '--active-admin', 'Annotate active_admin models') do
         env['active_admin'] = 'true'
       end

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -9,6 +9,7 @@ if Rails.env.development?
     Annotate.set_defaults(
       'additional_file_patterns'    => [],
       'routes'                      => 'false',
+      'models'                      => 'false',
       'position_in_routes'          => 'before',
       'position_in_class'           => 'before',
       'position_in_test'            => 'before',

--- a/spec/lib/annotate/parser_spec.rb
+++ b/spec/lib/annotate/parser_spec.rb
@@ -222,6 +222,17 @@ module Annotate # rubocop:disable Metrics/ModuleLength
       end
     end
 
+    %w[--models].each do |option|
+      describe option do
+        let(:env_key) { 'models' }
+        let(:set_value) { 'true' }
+        it 'sets the ENV variable' do
+          expect(ENV).to receive(:[]=).with(env_key, set_value)
+          Parser.parse([option])
+        end
+      end
+    end
+
     %w[-a --active-admin].each do |option|
       describe option do
         let(:env_key) { 'active_admin' }


### PR DESCRIPTION
Prior to this change, `Annotate.include_models?` returned the inverse of `Annotate.include_routes?`. This made it so annotating models and routes was not possible to do together.

This PR adds an explicit `--models` flag and also adds it the option to `lib/generators/annotate/templates/auto_annotate_models.rake` with the default being set to `false`. 

Fixes #563 and undoes the bug introduced in #485.