### PR TITLE
Fix shifted when format_markdown option enabled and used non-ascii

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -408,7 +408,7 @@ Lint/ShadowingOuterLocalVariable:
 
 # Offense count: 20
 Metrics/AbcSize:
-  Max: 138
+  Max: 139
 
 # Offense count: 28
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -305,7 +305,7 @@ module AnnotateModels
         if options[:format_rdoc]
           info << sprintf("# %-#{max_size}.#{max_size}s<tt>%s</tt>", "*#{col_name}*::", attrs.unshift(col_type).join(", ")).rstrip + "\n"
         elsif options[:format_markdown]
-          name_remainder = max_size - col_name.length
+          name_remainder = max_size - col_name.length - non_ascii_length(col_name)
           type_remainder = (md_type_allowance - 2) - col_type.length
           info << (sprintf("# **`%s`**%#{name_remainder}s | `%s`%#{type_remainder}s | `%s`", col_name, " ", col_type, " ", attrs.join(", ").rstrip)).gsub('``', '  ').rstrip + "\n"
         else
@@ -931,6 +931,10 @@ module AnnotateModels
       else
         string[0..length-1]
       end
+    end
+
+    def non_ascii_length(string)
+      string.to_s.chars.reject(&:ascii_only?).length
     end
   end
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1046,6 +1046,28 @@ EOS
         EOS
       end
 
+      it 'should get schema info as Markdown with multibyte comment' do
+        klass = mock_class(:users,
+                           :id,
+                           [
+                             mock_column(:id, :integer, comment: 'ＩＤ'),
+                             mock_column(:name, :string, limit: 50, comment: 'ＮＡＭＥ')
+                           ])
+        expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, with_comment: true)).to eql(<<-EOS.strip_heredoc)
+        # #{AnnotateModels::PREFIX}
+        #
+        # Table name: `users`
+        #
+        # ### Columns
+        #
+        # Name                  | Type               | Attributes
+        # --------------------- | ------------------ | ---------------------------
+        # **`id(ＩＤ)`**        | `integer`          | `not null, primary key`
+        # **`name(ＮＡＭＥ)`**  | `string(50)`       | `not null`
+        #
+        EOS
+      end
+
       it 'should get schema info as Markdown' do
         klass = mock_class(:users,
                            :id,


### PR DESCRIPTION
**before**
![Screen Shot 2019-09-04 at 19 19 06](https://user-images.githubusercontent.com/3026585/64866591-b30d7780-d676-11e9-9964-d6fcaf133d69.jpg)

**after**
![Screen Shot 2019-09-04 at 19 41 23](https://user-images.githubusercontent.com/3026585/64866601-b6a0fe80-d676-11e9-8504-180692b22f68.jpg)
