### PR TITLE
Refactor and tidy lib/annotate.rb

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -17,8 +17,6 @@ rescue StandardError
 end
 
 module Annotate
-  TRUE_RE = Constants::TRUE_RE
-
   ##
   # The set of available options to customize the behavior of Annotate.
   #
@@ -108,15 +106,15 @@ module Annotate
   end
 
   def self.skip_on_migration?
-    ENV['ANNOTATE_SKIP_ON_DB_MIGRATE'] =~ TRUE_RE || ENV['skip_on_db_migrate'] =~ TRUE_RE
+    ENV['ANNOTATE_SKIP_ON_DB_MIGRATE'] =~ Constants::TRUE_RE || ENV['skip_on_db_migrate'] =~ Constants::TRUE_RE
   end
 
   def self.include_routes?
-    ENV['routes'] =~ TRUE_RE
+    ENV['routes'] =~ Constants::TRUE_RE
   end
 
   def self.include_models?
-    ENV['models'] =~ TRUE_RE
+    ENV['models'] =~ Constants::TRUE_RE
   end
 
   def self.loaded_tasks=(val)
@@ -200,7 +198,7 @@ module Annotate
 
   def self.true?(val)
     return false if val.blank?
-    return false unless val =~ TRUE_RE
+    return false unless val =~ Constants::TRUE_RE
     true
   end
 end

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'annotate/version'
 require 'annotate/annotate_models'
 require 'annotate/annotate_routes'
+require 'annotate/constants'
 
 begin
   # ActiveSupport 3.x...
@@ -16,7 +17,7 @@ rescue StandardError
 end
 
 module Annotate
-  TRUE_RE = /^(true|t|yes|y|1)$/i
+  TRUE_RE = Constants::TRUE_RE
 
   ##
   # The set of available options to customize the behavior of Annotate.

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -2,8 +2,10 @@
 
 require 'bigdecimal'
 
+require 'annotate/constants'
+
 module AnnotateModels
-  TRUE_RE = /^(true|t|yes|y|1)$/i
+  TRUE_RE = Annotate::Constants::TRUE_RE
 
   # Annotate Models plugin use this header
   COMPAT_PREFIX    = '== Schema Info'.freeze

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -5,8 +5,6 @@ require 'bigdecimal'
 require 'annotate/constants'
 
 module AnnotateModels
-  TRUE_RE = Annotate::Constants::TRUE_RE
-
   # Annotate Models plugin use this header
   COMPAT_PREFIX    = '== Schema Info'.freeze
   COMPAT_PREFIX_MD = '## Schema Info'.freeze
@@ -592,7 +590,7 @@ module AnnotateModels
 
     def matched_types(options)
       types = MATCHED_TYPES.dup
-      types << 'admin' if options[:active_admin] =~ TRUE_RE && !types.include?('admin')
+      types << 'admin' if options[:active_admin] =~ Annotate::Constants::TRUE_RE && !types.include?('admin')
       types << 'additional_file_patterns' if options[:additional_file_patterns].present?
 
       types

--- a/lib/annotate/constants.rb
+++ b/lib/annotate/constants.rb
@@ -1,0 +1,5 @@
+module Annotate
+  module Constants
+    TRUE_RE = /^(true|t|yes|y|1)$/i.freeze
+  end
+end

--- a/spec/lib/annotate_spec.rb
+++ b/spec/lib/annotate_spec.rb
@@ -4,4 +4,11 @@ describe Annotate do
   it 'should have a version' do
     expect(Annotate.version).to be_instance_of(String)
   end
+
+  describe '.include_routes?' do
+    it "checks ENV with 'routes'" do
+      expect(ENV).to receive(:[]).with('routes')
+      described_class.include_routes?
+    end
+  end
 end

--- a/spec/lib/annotate_spec.rb
+++ b/spec/lib/annotate_spec.rb
@@ -5,12 +5,6 @@ describe Annotate do
     expect(Annotate.version).to be_instance_of(String)
   end
 
-  describe 'TRUE_RE' do
-    it do
-      expect(Annotate::TRUE_RE).to be_a(Regexp)
-    end
-  end
-
   describe '.skip_on_migration?' do
     it "checks ENV for 'ANNOTATE_SKIP_ON_DB_MIGRATE' or 'skip_on_db_migrate'" do
       expect(ENV).to receive(:[]).twice

--- a/spec/lib/annotate_spec.rb
+++ b/spec/lib/annotate_spec.rb
@@ -5,6 +5,13 @@ describe Annotate do
     expect(Annotate.version).to be_instance_of(String)
   end
 
+  describe '.skip_on_migration?' do
+    it "checks ENV for 'ANNOTATE_SKIP_ON_DB_MIGRATE' or 'skip_on_db_migrate'" do
+      expect(ENV).to receive(:[]).twice
+      described_class.skip_on_migration?
+    end
+  end
+
   describe '.include_routes?' do
     it "checks ENV with 'routes'" do
       expect(ENV).to receive(:[]).with('routes')

--- a/spec/lib/annotate_spec.rb
+++ b/spec/lib/annotate_spec.rb
@@ -5,6 +5,12 @@ describe Annotate do
     expect(Annotate.version).to be_instance_of(String)
   end
 
+  describe 'TRUE_RE' do
+    it do
+      expect(Annotate::TRUE_RE).to be_a(Regexp)
+    end
+  end
+
   describe '.skip_on_migration?' do
     it "checks ENV for 'ANNOTATE_SKIP_ON_DB_MIGRATE' or 'skip_on_db_migrate'" do
       expect(ENV).to receive(:[]).twice

--- a/spec/lib/annotate_spec.rb
+++ b/spec/lib/annotate_spec.rb
@@ -11,4 +11,11 @@ describe Annotate do
       described_class.include_routes?
     end
   end
+
+  describe '.include_models?' do
+    it "checks ENV with 'models'" do
+      expect(ENV).to receive(:[]).with('models')
+      described_class.include_models?
+    end
+  end
 end

--- a/spec/lib/annotate_spec.rb
+++ b/spec/lib/annotate_spec.rb
@@ -1,8 +1,10 @@
 require_relative '../spec_helper'
 
 describe Annotate do
-  it 'should have a version' do
-    expect(Annotate.version).to be_instance_of(String)
+  describe '.version' do
+    it 'has version' do
+      expect(Annotate.version).to be_instance_of(String)
+    end
   end
 
   describe '.skip_on_migration?' do


### PR DESCRIPTION
Adds tests for `.include_routes?`, `.include_models?`, `.skip_on_migration?`. Also moves the `TRUE_RE` under the `Annotate::Constants` namespace.