### PR TITLE
Make --additional_file_patterns consistent by using dashes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -163,7 +163,7 @@ you can do so with a simple environment variable, instead of editing the
 == Options
 
     Usage: annotate [options] [model_file]*
-            --additional_file_patterns   Additional file paths or globs to annotate, separated by commas (e.g. `/foo/bar/%model_name%/*.rb,/baz/%model_name%.rb`)
+            --additional-file-patterns   Additional file paths or globs to annotate, separated by commas (e.g. `/foo/bar/%model_name%/*.rb,/baz/%model_name%.rb`)
         -d, --delete                     Remove annotations from all model files or the routes.rb file
         -p [before|top|after|bottom],    Place the annotations at the top (before) or the bottom (after) of the model/test/fixture/factory/route/serializer file(s)
             --position
@@ -216,10 +216,10 @@ you can do so with a simple environment variable, instead of editing the
             --ignore-unknown-models      don't display warnings for bad model files
             --with-comment               include database comments in model annotations
 
-=== Option: +additional_file_patterns+
+=== Option: +additional-file-patterns+
 
-CLI: +--additional_file_patterns+<br>
-Ruby: +:additional_file_patterns+
+CLI: +--additional-file-patterns+<br>
+Ruby: +:additional-file-patterns+
 
 Provide additional paths for the gem to annotate.  These paths can include globs.
 It is recommended to use absolute paths.  Here are some examples:

--- a/README.rdoc
+++ b/README.rdoc
@@ -225,9 +225,9 @@ Provide additional paths for the gem to annotate.  These paths can include globs
 It is recommended to use absolute paths.  Here are some examples:
 
 
-- <code>/app/lib/decorates/%MODEL_NAME%/&ast;.rb</code>
-- <code>/app/lib/forms/%PLURALIZED_MODEL_NAME%/&ast;&ast;/&ast;.rb</code>
-- <code>/app/lib/forms/%TABLE_NAME%/&ast;.rb</code>
+- <code>/app/lib/decorates/%MODEL_NAME%/*.rb</code>
+- <code>/app/lib/forms/%PLURALIZED_MODEL_NAME%/**/*.rb</code>
+- <code>/app/lib/forms/%TABLE_NAME%/*.rb</code>
 
 The appropriate model will be inferred using the <code>%*%</code> syntax, annotating any matching files.
 It works with existing filename resolutions (options for which can be found in the +resolve_filename+ method of

--- a/lib/annotate/parser.rb
+++ b/lib/annotate/parser.rb
@@ -49,16 +49,12 @@ module Annotate
 
       option_parser.banner = 'Usage: annotate [options] [model_file]*'
 
-      option_parser.on('--additional_file_patterns path1,path2,path3', Array, "Additional file paths or globs to annotate, separated by commas (e.g. `/foo/bar/%model_name%/*.rb,/baz/%model_name%.rb`)") do |additional_file_patterns|
+      option_parser.on('--additional-file-patterns path1,path2,path3', Array, "Additional file paths or globs to annotate, separated by commas (e.g. `/foo/bar/%model_name%/*.rb,/baz/%model_name%.rb`)") do |additional_file_patterns|
         ENV['additional_file_patterns'] = additional_file_patterns
       end
 
       option_parser.on('-d', '--delete', 'Remove annotations from all model files or the routes.rb file') do
         @options[:target_action] = :remove_annotations
-      end
-
-      option_parser.on('--additional_file_patterns path1,path2,path3', Array, "Additional file paths or globs to annotate") do |additional_file_patterns|
-        ENV['additional_file_patterns'] = additional_file_patterns
       end
 
       option_parser.on('-p', '--position [before|top|after|bottom]', positions,

--- a/spec/lib/annotate/parser_spec.rb
+++ b/spec/lib/annotate/parser_spec.rb
@@ -17,10 +17,6 @@ module Annotate # rubocop:disable Metrics/ModuleLength
     %w[--additional-file-patterns].each do |option|
       describe option do
         it 'sets array of paths to :additional_file_patterns' do
-          # options = "-a ${('foo/bar' 'baz')}"
-          # Parser.parse(options)
-          # expect(ENV['additional_file_patterns']).to eq(['foo/bar', 'baz'])
-
           paths = 'foo/bar,baz'
           allow(ENV).to receive(:[]=)
           Parser.parse([option, paths])

--- a/spec/lib/annotate/parser_spec.rb
+++ b/spec/lib/annotate/parser_spec.rb
@@ -14,7 +14,7 @@ module Annotate # rubocop:disable Metrics/ModuleLength
       end
     end
 
-    %w[--additional_file_patterns].each do |option|
+    %w[--additional-file-patterns].each do |option|
       describe option do
         it 'sets array of paths to :additional_file_patterns' do
           # options = "-a ${('foo/bar' 'baz')}"


### PR DESCRIPTION
Changed references to `--additional_file_patterns` to be `--additional-file-patterns` to make it consistent with other flags.