### PR TITLE
Add constants.rb and parser.rb files to gemspec

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |s|
     'lib/annotate/active_record_patch.rb',
     'lib/annotate/annotate_models.rb',
     'lib/annotate/annotate_routes.rb',
+    'lib/annotate/constants.rb',
+    'lib/annotate/parser.rb',
     'lib/annotate/tasks.rb',
     'lib/annotate/version.rb',
     'lib/generators/annotate/USAGE',


### PR DESCRIPTION
Currently the gem released as version 3.0.0 is broken. Fixes #657 

The gem is missing constants.rb and parser.rb file