### PR TITLE
Add GitHub Actions badge for CI workflow

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -3,6 +3,7 @@
 {<img src="https://badge.fury.io/rb/annotate.svg" alt="Gem Version" />}[http://badge.fury.io/rb/annotate]
 {<img src="https://img.shields.io/gem/dt/annotate.svg?style=flat" />}[https://rubygems.org/gems/annotate]
 {<img src="https://travis-ci.org/ctran/annotate_models.svg?branch=develop" />}[https://travis-ci.org/ctran/annotate_models]
+{<img src="https://github.com/ctran/annotate_models/workflows/CI/badge.svg" />}[https://github.com/ctran/annotate_models/actions?workflow=CI]
 {<img src="https://coveralls.io/repos/ctran/annotate_models/badge.svg?branch=develop" />}[https://coveralls.io/r/ctran/annotate_models?branch=develop]
 {<img src="https://codeclimate.com/github/ctran/annotate_models/badges/gpa.svg" />}[https://codeclimate.com/github/ctran/annotate_models]
 {<img src="http://inch-ci.org/github/ctran/annotate_models.svg?branch=develop" alt="Inline docs" />}[http://inch-ci.org/github/ctran/annotate_models]


### PR DESCRIPTION
Based on the official docs:

https://help.github.com/en/articles/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository