### PR TITLE
Use a less error-prone way of specifying gem files

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email = ['alex@stinky.com', 'cuong.tran@gmail.com', 'x@nofxx.com', 'turadg@aleahmad.net', 'jon@cloudability.com']
   s.executables = ['annotate']
   s.extra_rdoc_files = ['README.rdoc', 'CHANGELOG.rdoc', 'TODO.rdoc']
-  s.files = `git ls-files -z *.rdoc *.gemspec bin lib`.split("\x0")
+  s.files = `git ls-files -z LICENSE.txt *.rdoc *.gemspec bin lib`.split("\x0")
   s.homepage = 'http://github.com/ctran/annotate_models'
   s.licenses = ['Ruby']
   s.require_paths = ['lib']

--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -14,29 +14,7 @@ Gem::Specification.new do |s|
   s.email = ['alex@stinky.com', 'cuong.tran@gmail.com', 'x@nofxx.com', 'turadg@aleahmad.net', 'jon@cloudability.com']
   s.executables = ['annotate']
   s.extra_rdoc_files = ['README.rdoc', 'CHANGELOG.rdoc', 'TODO.rdoc']
-  s.files = [
-    'AUTHORS.rdoc',
-    'CHANGELOG.rdoc',
-    'LICENSE.txt',
-    'README.rdoc',
-    'TODO.rdoc',
-    'annotate.gemspec',
-    'bin/annotate',
-    'lib/annotate.rb',
-    'lib/annotate/active_record_patch.rb',
-    'lib/annotate/annotate_models.rb',
-    'lib/annotate/annotate_routes.rb',
-    'lib/annotate/constants.rb',
-    'lib/annotate/parser.rb',
-    'lib/annotate/tasks.rb',
-    'lib/annotate/version.rb',
-    'lib/generators/annotate/USAGE',
-    'lib/generators/annotate/install_generator.rb',
-    'lib/generators/annotate/templates/auto_annotate_models.rake',
-    'lib/tasks/annotate_models.rake',
-    'lib/tasks/annotate_routes.rake',
-    'lib/tasks/annotate_models_migrate.rake'
-  ]
+  s.files = `git ls-files -z *.rdoc *.gemspec bin lib`.split("\x0")
   s.homepage = 'http://github.com/ctran/annotate_models'
   s.licenses = ['Ruby']
   s.require_paths = ['lib']


### PR DESCRIPTION
Before, whenever a new file is added to `lib`, the contributor or maintainer has to remember to explicitly add it to the gemspec. If this step is forgotten, it results in a broken release, like #657.

This commit makes this process less error prone by using `git ls-files` to automatically include all appropriate files in the gem. This is in line with what is advocated by Bundler's gem template:

https://github.com/bundler/bundler/blob/2a4d88a7044528209321fd4441e995ec66f604b9/lib/bundler/templates/newgem/newgem.gemspec.tt#L26

To test this PR I ran `rake gem` and verified that the list of files included in the gem is the same as before:

```
AUTHORS.rdoc
CHANGELOG.rdoc
README.rdoc
RELEASE.rdoc
TODO.rdoc
annotate.gemspec
bin/annotate
lib/annotate.rb
lib/annotate/active_record_patch.rb
lib/annotate/annotate_models.rb
lib/annotate/annotate_routes.rb
lib/annotate/constants.rb
lib/annotate/parser.rb
lib/annotate/tasks.rb
lib/annotate/version.rb
lib/generators/annotate/USAGE
lib/generators/annotate/install_generator.rb
lib/generators/annotate/templates/auto_annotate_models.rake
lib/tasks/annotate_models.rake
lib/tasks/annotate_models_migrate.rake
lib/tasks/annotate_routes.rake
```