### PR TITLE
FIX: Ensure only one line is around the annotation

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -540,9 +540,9 @@ module AnnotateModels
         new_content = if %w(after bottom).include?(options[position].to_s)
                         magic_comments_block + (old_content.rstrip + "\n\n" + wrapped_info_block)
                       elsif magic_comments_block.empty?
-                        magic_comments_block + wrapped_info_block + "\n" + old_content
+                        magic_comments_block + wrapped_info_block + "\n" + old_content.lstrip
                       else
-                        magic_comments_block + "\n" + wrapped_info_block + "\n" + old_content
+                        magic_comments_block + "\n" + wrapped_info_block + "\n" + old_content.lstrip
                       end
       else
         # replace the old annotation with the new one

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1781,6 +1781,18 @@ end
       end
     end
 
+    it 'only keeps a single empty line around the annotation (position :before)' do
+      content = "class User < ActiveRecord::Base\nend\n"
+      magic_comments_list_each do |magic_comment|
+        schema_info = AnnotateModels.get_schema_info(@klass, '== Schema Info')
+        model_file_name, = write_model 'user.rb', "#{magic_comment}\n\n\n\n#{content}"
+
+        annotate_one_file position: :before
+
+        expect(File.read(model_file_name)).to eq("#{magic_comment}\n\n#{schema_info}\n#{content}")
+      end
+    end
+
     it 'does not change whitespace between magic comments and model file content (position :after)' do
       content = "class User < ActiveRecord::Base\nend\n"
       magic_comments_list_each do |magic_comment|


### PR DESCRIPTION
When there are already a blank line between the magic comment and the class definition, generating annotation would insert an additional blank line after itself, leaving two blank lines between itself and the class definition.

This closes #591.