### PR TITLE
Defaults annotate models to true

### DIFF
--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -9,7 +9,7 @@ if Rails.env.development?
     Annotate.set_defaults(
       'additional_file_patterns'    => [],
       'routes'                      => 'false',
-      'models'                      => 'false',
+      'models'                      => 'true',
       'position_in_routes'          => 'before',
       'position_in_class'           => 'before',
       'position_in_test'            => 'before',


### PR DESCRIPTION
Setting the default to annotate models as it is the main feature of the gem.
Solves #663