### PR TITLE
[Fix #675] Correct indentation for double-byte characters

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -920,7 +920,7 @@ module AnnotateModels
     end
 
     def width(string)
-      string.chars.inject(0) { |acc, elem| acc + (elem.bytesize == 1 ? 1 : 2) }
+      string.chars.inject(0) { |acc, elem| acc + (elem.bytesize == 3 ? 2 : 1) }
     end
 
     def mb_chars_ljust(string, length)

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1006,6 +1006,9 @@ EOS
         [:active,     :boolean, { limit: 1,  comment: 'ＡＣＴＩＶＥ' }],
         [:name,       :string,  { limit: 50, comment: 'ＮＡＭＥ' }],
         [:notes,      :text,    { limit: 55, comment: 'ＮＯＴＥＳ' }],
+        [:cyrillic,   :text,    { limit: 30, comment: 'Кириллица' }],
+        [:japanese,   :text,    { limit: 60, comment: '熊本大学　イタリア　宝島' }],
+        [:arabic,     :text,    { limit: 20, comment: 'لغة' }],
         [:no_comment, :text,    { limit: 20, comment: nil }],
         [:location,   :geometry_collection, { limit: nil, comment: nil }]
       ]
@@ -1017,12 +1020,15 @@ EOS
         #
         # Table name: users
         #
-        #  id(ＩＤ)             :integer          not null, primary key
-        #  active(ＡＣＴＩＶＥ) :boolean          not null
-        #  name(ＮＡＭＥ)       :string(50)       not null
-        #  notes(ＮＯＴＥＳ)    :text(55)         not null
-        #  no_comment           :text(20)         not null
-        #  location             :geometry_collect not null
+        #  id(ＩＤ)                           :integer          not null, primary key
+        #  active(ＡＣＴＩＶＥ)               :boolean          not null
+        #  name(ＮＡＭＥ)                     :string(50)       not null
+        #  notes(ＮＯＴＥＳ)                  :text(55)         not null
+        #  cyrillic(Кириллица)                :text(30)         not null
+        #  japanese(熊本大学　イタリア　宝島) :text(60)         not null
+        #  arabic(لغة)                        :text(20)         not null
+        #  no_comment                         :text(20)         not null
+        #  location                           :geometry_collect not null
         #
       EOS
 


### PR DESCRIPTION
Fixes https://github.com/ctran/annotate_models/issues/675