### PR TITLE
[Fix #624] Correct default values when ActiveRecord::Enum is used

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -211,7 +211,7 @@ module AnnotateModels
     end
 
     def schema_default(klass, column)
-      quote(klass.column_defaults[column.name])
+      quote(klass.columns.find { |x| x.name.to_s == column.name.to_s }.try(:default))
     end
 
     def retrieve_indexes_from_table(klass)

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -225,6 +225,29 @@ EOS
 EOS
   end
 
+  it 'sets correct default value for integer column when ActiveRecord::Enum is used' do
+    klass = mock_class(:users,
+                       :id,
+                       [
+                         mock_column(:id, :integer),
+                         mock_column(:status, :integer, default: 0)
+                       ])
+    # column_defaults may be overritten when ActiveRecord::Enum is used, e.g:
+    # class User < ActiveRecord::Base
+    #   enum status: [ :disabled, :enabled ]
+    # end
+    allow(klass).to receive(:column_defaults).and_return('id' => nil, 'status' => 'disabled')
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
+# Schema Info
+#
+# Table name: users
+#
+#  id     :integer          not null, primary key
+#  status :integer          default(0), not null
+#
+EOS
+  end
+
   it 'should get foreign key info' do
     klass = mock_class(:users,
                        :id,


### PR DESCRIPTION
Fixes #624 

Note: I was not able to reproduce the issue with gem enumerize (https://github.com/brainspec/enumerize), however it is reproducible with ActiveRecord::Enum.