### PR TITLE
Revert behavior of Github release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - 'release/v*'
+      - 'v*'
 
 jobs:
   release:


### PR DESCRIPTION
Reverted tag matcher to to use `v*` prefix instead of `release/v*`.