### PR TITLE
Add annotation hooks for db-specific migration tasks

### DIFF
--- a/spec/integration/rails_6.0.2.1/config/application.rb
+++ b/spec/integration/rails_6.0.2.1/config/application.rb
@@ -28,5 +28,6 @@ module Rails6021
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    self.paths['config/database'] = 'config/multi-database.yml' if ENV['MULTI_DB']
   end
 end

--- a/spec/integration/rails_6.0.2.1/config/multi-database.yml
+++ b/spec/integration/rails_6.0.2.1/config/multi-database.yml
@@ -1,0 +1,37 @@
+# SQLite. Versions 3.8.0 and up are supported.
+#   gem install sqlite3
+#
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem 'sqlite3'
+#
+default: &default
+  adapter: sqlite3
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
+
+development:
+  primary:
+    <<: *default
+    database: db/development.sqlite3
+  secondary:
+    <<: *default
+    database: db/development-secondary.sqlite3
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  primary:
+    <<: *default
+    database: db/test.sqlite3
+  secondary:
+    <<: *default
+    database: db/test-secondary.sqlite3
+
+production:
+  primary:
+    <<: *default
+    database: db/production.sqlite3
+  secondary:
+    <<: *default
+    database: db/production-secondary.sqlite3


### PR DESCRIPTION
Rails 6 adds a new set of migration tasks for multi-database apps. This change makes the annotate_models_migrate hooks aware of them.

This change was a little awkward to test, but I'm happy to change my approach/use a dummy app for more robust integration tests if desired.