### PR TITLE
Add ActiveAdmin option to template

### DIFF
--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -7,6 +7,7 @@ if Rails.env.development?
     # You can override any of these by setting an environment variable of the
     # same name.
     Annotate.set_defaults(
+      'active_admin'                => 'false',
       'additional_file_patterns'    => [],
       'routes'                      => 'false',
       'models'                      => 'true',


### PR DESCRIPTION
Add's the `active_admin` option to the auto annotate rake task template.  