### PR TITLE
Handle columns from activerecord-postgis-adapter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -408,7 +408,7 @@ Lint/ShadowingOuterLocalVariable:
 
 # Offense count: 20
 Metrics/AbcSize:
-  Max: 139
+  Max: 141
 
 # Offense count: 28
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -264,7 +264,7 @@ module AnnotateModels
 
         if col_type == 'decimal'
           col_type << "(#{col.precision}, #{col.scale})"
-        elsif col_type != 'spatial'
+        elsif !%w[spatial geometry geography].include?(col_type)
           if col.limit
             if col.limit.is_a? Array
               attrs << "(#{col.limit.join(', ')})"

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1055,6 +1055,32 @@ EOS
         #
       EOS
 
+      mocked_columns_with_geometries = [
+        [:id,       :integer,  { limit: 8 }],
+        [:active,   :boolean,  { default: false, null: false }],
+        [:geometry, :geometry, {
+          geometric_type: 'Geometry', srid: 4326,
+          limit:          { srid: 4326, type: 'geometry' }
+        }],
+        [:location, :geography, {
+          geometric_type: 'Point', srid: 0,
+          limit:          { srid: 0, type: 'geometry' }
+        }]
+      ]
+
+      when_called_with with_columns: mocked_columns_with_geometries, returns:
+        <<-EOS.strip_heredoc
+        # Schema Info
+        #
+        # Table name: users
+        #
+        #  id       :integer          not null, primary key
+        #  active   :boolean          default(FALSE), not null
+        #  geometry :geometry         not null, geometry, 4326
+        #  location :geography        not null, point, 0
+        #
+      EOS
+
       it 'should get schema info as RDoc' do
         klass = mock_class(:users,
                            :id,


### PR DESCRIPTION
Same problem returned by @janosrusiczki in #430

Spatial columns with activerecord-postgis-adapter (5.2.2) are not displayed nice

```
# name           :string(3)
# active         :boolean          default(FALSE), not null
# geom           :geometry({:srid= geometry, 4326
```

That's come from activerecord-postgis-adapter, with redefined columns as such :

``` 
#<ActiveRecord::ConnectionAdapters::PostGIS::SpatialColumn 
  @sql_type="geometry(Geometry,4326)",
  @geo_type="Geometry",
  @geometric_type=RGeo::Feature::Geometry,
  @srid=4326,
  @limit={:srid=>4326, :type=>"geometry"}
  [...]
>
```

This fix displays them like this :

```
# name           :string(3)
# active         :boolean          default(FALSE), not null
# geometry       :geometry         geometry, 4326
```

Another possibility would have been to display them as below, but it involves a lot of extra-spaces for other columns.

```
# name           :string(3)
# active         :boolean                   default(FALSE), not null
# geometry       :geometry(Geometry, 4326)
```