### PR TITLE
Fix foreign key issue with Rails 6 and Sqlite3

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -472,7 +472,10 @@ module AnnotateModels
       foreign_keys = klass.connection.foreign_keys(klass.table_name)
       return '' if foreign_keys.empty?
 
-      format_name = ->(fk) { options[:show_complete_foreign_keys] ? fk.name : fk.name.gsub(/(?<=^fk_rails_)[0-9a-f]{10}$/, '...') }
+      format_name = lambda do |fk|
+        return fk.options[:column] if fk.name.blank?
+        options[:show_complete_foreign_keys] ? fk.name : fk.name.gsub(/(?<=^fk_rails_)[0-9a-f]{10}$/, '...')
+      end
 
       max_size = foreign_keys.map(&format_name).map(&:size).max + 1
       foreign_keys.sort_by {|fk| [format_name.call(fk), fk.column]}.each do |fk|


### PR DESCRIPTION
Rails 6 has dropped name from options for ActiveRecord::ConnectionAdapters::ForeignKeyDefinition
for Sqlite3 adapter:

https://github.com/rails/rails/blob/f2df77709f7e536aaf4d6f984ff21a49d44d34c1/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L305-L311

This has caused issues with getting foreign key info and blowing up
when trying to annotate models with foreign keys. This commit
adds one additional check for name presence and uses column
attribute from options instead.

Closes #620.