### PR TITLE
Upgrade and fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.3.x
           - 2.4.x
           - 2.5.x
           - 2.6.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         ruby:
           - 2.3.x
           - 2.4.x
+          - 2.5.x
           - 2.6.x
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby:
-          - 2.4.x
-          - 2.5.x
-          - 2.6.x
+        ruby: ['2.4.x', '2.5.x', '2.6.x']
+
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-- 2.3.8
 - 2.4.9
 - 2.5.7
 - 2.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   - rvm: ruby-head
 
 before_install:
-- gem update --system -f
+- yes | gem update --system
 - gem update bundler
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: ruby
 rvm:
 - 2.3.8
-- 2.4.7
-- 2.5.6
-- 2.6.4
+- 2.4.9
+- 2.5.7
+- 2.6.5
 - ruby-head
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   - rvm: ruby-head
 
 before_install:
-- gem update --system
+- gem update --system -f
 - gem update bundler
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-- 2.2.10
 - 2.3.8
 - 2.4.7
 - 2.5.6
@@ -13,7 +12,7 @@ matrix:
   - rvm: ruby-head
 
 before_install:
-- gem update --system || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
+- gem update --system
 - gem update bundler
 
 script:


### PR DESCRIPTION
Looks like it's breaking in Github CI because Ruby 2.3.X is no longer supported by `actions/setup-ruby@v1`. Ruby 2.3.X has stopped being supported since March of 2019, so I've removed Ruby 2.3.X versions from both Github and Travis CI.

It's also breaking in Travis CI because it's timing out in an interactive prompt when trying to do `gem update --system`. This is due to changes to [Ruby Gems 3.1.1](https://github.com/rubygems/rubygems/issues/3036). This has been fixed.

Failing Github CI build: https://github.com/ctran/annotate_models/runs/335456181
Failing Travis build: https://api.travis-ci.org/v3/job/625759725/log.txt