### PR TITLE
Replace soft-deprecated constant `HashWithIndifferentAccess` to `ActiveSupport::HashWithIndifferentAccess`

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -54,7 +54,7 @@ module Annotate
     return if @has_set_defaults
     @has_set_defaults = true
 
-    options = HashWithIndifferentAccess.new(options)
+    options = ActiveSupport::HashWithIndifferentAccess.new(options)
 
     all_options.flatten.each do |key|
       if options.key?(key)


### PR DESCRIPTION
`HashWithIndifferentAccess` is soft-deprecated from https://github.com/rails/rails/pull/28157 (since Rails 5.1)
But there are still no deprecation warnings, please merge if necessary :)