### PR TITLE
Add constants MAGIC_COMMENT_MATCHER

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -82,6 +82,8 @@ module AnnotateModels
     }
   }.freeze
 
+  MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/).freeze
+
   class << self
     def annotate_pattern(options = {})
       if options[:wrapper_open]
@@ -537,7 +539,7 @@ module AnnotateModels
       # need to insert it in correct position
       if old_annotation.empty? || options[:force]
         magic_comments_block = magic_comments_as_string(old_content)
-        old_content.gsub!(magic_comment_matcher, '')
+        old_content.gsub!(MAGIC_COMMENT_MATCHER, '')
         old_content.sub!(annotate_pattern(options), '')
 
         new_content = if %w(after bottom).include?(options[position].to_s)
@@ -561,12 +563,8 @@ module AnnotateModels
       true
     end
 
-    def magic_comment_matcher
-      Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/)
-    end
-
     def magic_comments_as_string(content)
-      magic_comments = content.scan(magic_comment_matcher).flatten.compact
+      magic_comments = content.scan(MAGIC_COMMENT_MATCHER).flatten.compact
 
       if magic_comments.any?
         magic_comments.join

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -24,6 +24,8 @@ module AnnotateRoutes
   PREFIX_MD = '## Route Map'.freeze
   HEADER_ROW = ['Prefix', 'Verb', 'URI Pattern', 'Controller#Action']
 
+  MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*)|(^# coding:.*)|(^# -\*- coding:.*)|(^# -\*- encoding\s?:.*)|(^#\s*frozen_string_literal:.+)|(^# -\*- frozen_string_literal\s*:.+-\*-)/).freeze
+
   class << self
     def do_annotations(options = {})
       return unless routes_exists?
@@ -212,7 +214,7 @@ module AnnotateRoutes
       new_content = []
 
       content_array.map do |row|
-        if row =~ magic_comment_matcher
+        if row =~ MAGIC_COMMENT_MATCHER
           magic_comments << row.strip
         else
           new_content << row
@@ -243,10 +245,6 @@ module AnnotateRoutes
 
       # and the default
       return real_content, header_position
-    end
-
-    def magic_comment_matcher
-      Regexp.new(/(^#\s*encoding:.*)|(^# coding:.*)|(^# -\*- coding:.*)|(^# -\*- encoding\s?:.*)|(^#\s*frozen_string_literal:.+)|(^# -\*- frozen_string_literal\s*:.+-\*-)/)
     end
   end
 end


### PR DESCRIPTION
I added `AnnotateModels::MAGIC_COMMENT_MATCHER` and `AnnotateRoutes::MAGIC_COMMENT_MATCHER` instad of `AnnotateModels.magic_comment_matcher` and `AnnotateRoutes.magic_comment_matcher`.

I think that they should be constants because the result of Regexp is always fixed.