### PR TITLE
Fix AnnotateRoutes.extract_magic_comments_from_array

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -211,7 +211,7 @@ module AnnotateRoutes
       magic_comments = []
       new_content = []
 
-      content_array.map do |row|
+      content_array.each do |row|
         if row =~ magic_comment_matcher
           magic_comments << row.strip
         else


### PR DESCRIPTION
I replaced `Array#map` to `Array#each` because the mapped array is not used.
