### PR TITLE
Freeze constant AnnotateRoutes::HEADER_ROW

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -22,7 +22,7 @@
 module AnnotateRoutes
   PREFIX = '== Route Map'.freeze
   PREFIX_MD = '## Route Map'.freeze
-  HEADER_ROW = ['Prefix', 'Verb', 'URI Pattern', 'Controller#Action']
+  HEADER_ROW = ['Prefix', 'Verb', 'URI Pattern', 'Controller#Action'].freeze
 
   class << self
     def do_annotations(options = {})


### PR DESCRIPTION
As the change log shows, I froze the constant `HEADER_ROW` in accordance with the normal Ruby style regulation.
