### PR TITLE
Refactor AnnotateRoutes.remove_annotations

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -39,9 +39,6 @@ module AnnotateRoutes
       existing_text = File.read(routes_file)
       content, header_position = strip_annotations(existing_text)
       new_content = strip_on_removal(content, header_position)
-
-      # Make sure we end on a trailing newline.
-      new_content << '' unless new_content.last == ''
       new_text = new_content.join("\n")
 
       if rewrite_contents(existing_text, new_text)
@@ -149,6 +146,9 @@ module AnnotateRoutes
       elsif header_position == :after
         content.pop while content.last == ''
       end
+
+      # Make sure we end on a trailing newline.
+      content << '' unless content.last == ''
 
       # TODO: If the user buried it in the middle, we should probably see about
       # TODO: preserving a single line of space between the content above and

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -39,7 +39,12 @@ module AnnotateRoutes
       existing_text = File.read(routes_file)
       content, header_position = strip_annotations(existing_text)
       new_content = strip_on_removal(content, header_position)
-      if rewrite_contents(existing_text, new_content)
+
+      # Make sure we end on a trailing newline.
+      new_content << '' unless new_content.last == ''
+      new_text = new_content.join("\n")
+
+      if rewrite_contents(existing_text, new_text)
         puts "Removed annotations from #{routes_file}."
       end
     end
@@ -152,11 +157,7 @@ module AnnotateRoutes
     end
 
     # @param [String, Array<String>]
-    def rewrite_contents(existing_text, new_content)
-      # Make sure we end on a trailing newline.
-      new_content << '' unless new_content.last == ''
-      new_text = new_content.join("\n")
-
+    def rewrite_contents(existing_text, new_text)
       if existing_text == new_text
         puts "#{routes_file} unchanged."
         false


### PR DESCRIPTION
I refactored `AnnotateRoutes.remove_annotations`.

# Summary

*  Build `new_text` in `.remove_annotations`
*  Add trailing new line in `.strip_on_removal`
*  Use `.rewrite_contents` for comparing `existing_text` and `new_text`, and write `new_text` to the file.
