### PR TITLE
Refactor AnnotateRoutes.routes_file_exist?

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -52,7 +52,7 @@ module AnnotateRoutes
     private
 
     def routes_exists?
-      File.exists?(routes_file)
+      File.exist?(routes_file)
     end
 
     def routes_file

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -26,7 +26,7 @@ module AnnotateRoutes
 
   class << self
     def do_annotations(options = {})
-      if routes_exists?
+      if routes_file_exist?
         existing_text = File.read(routes_file)
         if rewrite_contents_with_header(existing_text, header(options), options)
           puts "#{routes_file} annotated."
@@ -37,7 +37,7 @@ module AnnotateRoutes
     end
 
     def remove_annotations(_options={})
-      if routes_exists?
+      if routes_file_exist?
         existing_text = File.read(routes_file)
         content, header_position = strip_annotations(existing_text)
         new_content = strip_on_removal(content, header_position)
@@ -51,7 +51,7 @@ module AnnotateRoutes
 
     private
 
-    def routes_exists?
+    def routes_file_exist?
       File.exist?(routes_file)
     end
 

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -26,31 +26,33 @@ module AnnotateRoutes
 
   class << self
     def do_annotations(options = {})
-      return unless routes_exists?
-      existing_text = File.read(routes_file)
-
-      if rewrite_contents_with_header(existing_text, header(options), options)
-        puts "#{routes_file} annotated."
+      if routes_exists?
+        existing_text = File.read(routes_file)
+        if rewrite_contents_with_header(existing_text, header(options), options)
+          puts "#{routes_file} annotated."
+        end
+      else
+        puts "Can't find routes.rb"
       end
     end
 
     def remove_annotations(_options={})
-      return unless routes_exists?
-      existing_text = File.read(routes_file)
-      content, header_position = strip_annotations(existing_text)
-      new_content = strip_on_removal(content, header_position)
-      if rewrite_contents(existing_text, new_content)
-        puts "Removed annotations from #{routes_file}."
+      if routes_exists?
+        existing_text = File.read(routes_file)
+        content, header_position = strip_annotations(existing_text)
+        new_content = strip_on_removal(content, header_position)
+        if rewrite_contents(existing_text, new_content)
+          puts "Removed annotations from #{routes_file}."
+        end
+      else
+        puts "Can't find routes.rb"
       end
     end
 
     private
 
     def routes_exists?
-      routes_exists = File.exists?(routes_file)
-      puts "Can't find routes.rb" unless routes_exists
-
-      routes_exists
+      File.exists?(routes_file)
     end
 
     def routes_file

--- a/spec/lib/annotate/annotate_routes_spec.rb
+++ b/spec/lib/annotate/annotate_routes_spec.rb
@@ -28,7 +28,7 @@ describe AnnotateRoutes do
   end
 
   it 'should check if routes.rb exists' do
-    expect(File).to receive(:exists?).with(ROUTE_FILE).and_return(false)
+    expect(File).to receive(:exist?).with(ROUTE_FILE).and_return(false)
     expect(AnnotateRoutes).to receive(:puts).with("Can't find routes.rb")
     AnnotateRoutes.do_annotations
   end
@@ -42,7 +42,7 @@ describe AnnotateRoutes do
     end
 
     before(:each) do
-      expect(File).to receive(:exists?).with(ROUTE_FILE).and_return(true).at_least(:once)
+      expect(File).to receive(:exist?).with(ROUTE_FILE).and_return(true).at_least(:once)
 
       expect(File).to receive(:read).with(ROUTE_FILE).and_return("").at_least(:once)
 
@@ -164,7 +164,7 @@ describe AnnotateRoutes do
 
   describe 'When adding' do
     before(:each) do
-      expect(File).to receive(:exists?).with(ROUTE_FILE)
+      expect(File).to receive(:exist?).with(ROUTE_FILE)
         .and_return(true).at_least(:once)
       expect(AnnotateRoutes).to receive(:`).with('rake routes')
         .and_return('').at_least(:once)
@@ -243,7 +243,7 @@ describe AnnotateRoutes do
 
   describe 'When adding with older Rake versions' do
     before(:each) do
-      expect(File).to receive(:exists?).with(ROUTE_FILE).and_return(true)
+      expect(File).to receive(:exist?).with(ROUTE_FILE).and_return(true)
       expect(AnnotateRoutes).to receive(:`).with('rake routes').and_return("(in /bad/line)\ngood line")
       expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
       expect(AnnotateRoutes).to receive(:puts).with(ANNOTATION_ADDED)
@@ -264,7 +264,7 @@ describe AnnotateRoutes do
 
   describe 'When adding with newer Rake versions' do
     before(:each) do
-      expect(File).to receive(:exists?).with(ROUTE_FILE).and_return(true)
+      expect(File).to receive(:exist?).with(ROUTE_FILE).and_return(true)
       expect(AnnotateRoutes).to receive(:`).with('rake routes').and_return("another good line\ngood line")
       expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
       expect(AnnotateRoutes).to receive(:puts).with(ANNOTATION_ADDED)
@@ -291,7 +291,7 @@ describe AnnotateRoutes do
 
   describe 'When removing' do
     before(:each) do
-      expect(File).to receive(:exists?).with(ROUTE_FILE).and_return(true)
+      expect(File).to receive(:exist?).with(ROUTE_FILE).and_return(true)
       expect(File).to receive(:open).with(ROUTE_FILE, 'wb').and_yield(mock_file)
       expect(AnnotateRoutes).to receive(:puts).with(ANNOTATION_REMOVED)
     end


### PR DESCRIPTION
I refactored `AnnotateRoutes.routes_exists?` and methods using this.
The points are as follows.

*   Removing `puts` in `AnnotateRoutes.routes_exists?`
*   Using `File.exist?` instead of `File.exists?` because `File.exists?` is deprecated
*   Renaming `AnnotateRoutes.routes_exists?` to `AnnotateRoutes.routes_file_exists?` in order to make the name of method more explanatory