### PR TITLE
Make AnnotateModels.resolve_filename private

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -867,13 +867,6 @@ module AnnotateModels
       puts "Removed annotations from: #{deannotated.join(', ')}"
     end
 
-    def resolve_filename(filename_template, model_name, table_name)
-      filename_template
-        .gsub('%MODEL_NAME%', model_name)
-        .gsub('%PLURALIZED_MODEL_NAME%', model_name.pluralize)
-        .gsub('%TABLE_NAME%', table_name || model_name.pluralize)
-    end
-
     def classified_sort(cols)
       rest_cols = []
       timestamps = []
@@ -897,6 +890,13 @@ module AnnotateModels
     end
 
     private
+
+    def resolve_filename(filename_template, model_name, table_name)
+      filename_template
+        .gsub('%MODEL_NAME%', model_name)
+        .gsub('%PLURALIZED_MODEL_NAME%', model_name.pluralize)
+        .gsub('%TABLE_NAME%', table_name || model_name.pluralize)
+    end
 
     def with_comments?(klass, options)
       options[:with_comment] &&

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1641,7 +1641,7 @@ end
       model_name        = 'example_model'
       table_name        = 'example_models'
 
-      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
+      filename = AnnotateModels.send(:resolve_filename, filename_template, model_name, table_name)
       expect(filename). to eq 'test/unit/example_model_test.rb'
     end
 
@@ -1650,7 +1650,7 @@ end
       model_name        = 'example_model'
       table_name        = 'example_models'
 
-      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
+      filename = AnnotateModels.send(:resolve_filename, filename_template, model_name, table_name)
       expect(filename). to eq '/foo/bar/example_model/testing.rb'
     end
 
@@ -1659,7 +1659,7 @@ end
       model_name        = 'example_model'
       table_name        = 'example_models'
 
-      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
+      filename = AnnotateModels.send(:resolve_filename, filename_template, model_name, table_name)
       expect(filename). to eq '/foo/bar/example_models/testing.rb'
     end
 
@@ -1668,7 +1668,7 @@ end
       model_name        = 'example_model'
       table_name        = 'example_models'
 
-      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
+      filename = AnnotateModels.send(:resolve_filename, filename_template, model_name, table_name)
       expect(filename). to eq 'test/fixtures/example_models.yml'
     end
 
@@ -1677,7 +1677,7 @@ end
       model_name        = 'parent/child'
       table_name        = 'parent_children'
 
-      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
+      filename = AnnotateModels.send(:resolve_filename, filename_template, model_name, table_name)
       expect(filename). to eq 'test/fixtures/parent/children.yml'
     end
   end


### PR DESCRIPTION
I moved `AnnotateModels.resolve_filename` under `private` in order to encapsulate this method and make module more robust.
