### PR TITLE
Refactor RSpec for AnnotateModels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development do
   platforms :mri, :mingw do
     gem 'yard', require: false
   end
+  gem 'pry-byebug'
 end
 
 group :development, :test do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1373,7 +1373,7 @@ EOS
     end
   end
 
-  describe '#get_model_files' do
+  describe '.get_model_files' do
     subject { described_class.get_model_files(options) }
 
     before do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -946,283 +946,429 @@ EOS
     end
   end
 
-  describe '#get_schema_info with custom options' do
-    def self.when_called_with(options = {})
-      expected = options.delete(:returns)
-      default_columns = [
-        [:id, :integer, { limit: 8 }],
-        [:active, :boolean, { limit: 1 }],
-        [:name, :string, { limit: 50 }],
-        [:notes, :text, { limit: 55 }]
-      ]
+  describe '.get_schema_info' do
+    let :klass do
+      mock_class(:users, :id, columns)
+    end
 
-      it "should work with options = #{options}" do
-        with_columns = (options.delete(:with_columns) || default_columns).map do |column|
-          mock_column(column[0], column[1], column[2])
+    subject do
+      AnnotateModels.get_schema_info(klass, header, options)
+    end
+
+    context 'when header is "Schema Info"' do
+      let :header do
+        'Schema Info'
+      end
+
+      context 'with options' do
+        context 'when "hide_limit_column_types" is specified in options' do
+          let :columns do
+            [
+              mock_column(:id, :integer, limit: 8),
+              mock_column(:active, :boolean, limit: 1),
+              mock_column(:name, :string, limit: 50),
+              mock_column(:notes, :text, limit: 55)
+            ]
+          end
+
+          context 'when "hide_limit_column_types" is blank string' do
+            let :options do
+              { hide_limit_column_types: '' }
+            end
+
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  id     :integer          not null, primary key
+                #  active :boolean          not null
+                #  name   :string(50)       not null
+                #  notes  :text(55)         not null
+                #
+              EOS
+            end
+
+            it 'works with option "hide_limit_column_types"' do
+              is_expected.to eq expected_result
+            end
+          end
+
+          context 'when "hide_limit_column_types" is "integer,boolean"' do
+            let :options do
+              { hide_limit_column_types: 'integer,boolean' }
+            end
+
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  id     :integer          not null, primary key
+                #  active :boolean          not null
+                #  name   :string(50)       not null
+                #  notes  :text(55)         not null
+                #
+              EOS
+            end
+
+            it 'works with option "hide_limit_column_types"' do
+              is_expected.to eq expected_result
+            end
+          end
+
+          context 'when "hide_limit_column_types" is "integer,boolean,string,text"' do
+            let :options do
+              { hide_limit_column_types: 'integer,boolean,string,text' }
+            end
+
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  id     :integer          not null, primary key
+                #  active :boolean          not null
+                #  name   :string           not null
+                #  notes  :text             not null
+                #
+              EOS
+            end
+
+            it 'works with option "hide_limit_column_types"' do
+              is_expected.to eq expected_result
+            end
+          end
         end
 
-        klass = mock_class(:users, :id, with_columns)
+        context 'when "hide_default_column_types" is specified in options' do
+          let :columns do
+            [
+              mock_column(:profile, :json, default: {}),
+              mock_column(:settings, :jsonb, default: {}),
+              mock_column(:parameters, :hstore, default: {})
+            ]
+          end
 
-        schema_info = AnnotateModels.get_schema_info(klass, 'Schema Info', options)
-        expect(schema_info).to eql(expected)
+          context 'when "hide_default_column_types" is blank string' do
+            let :options do
+              { hide_default_column_types: '' }
+            end
+
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  profile    :json             not null
+                #  settings   :jsonb            not null
+                #  parameters :hstore           not null
+                #
+              EOS
+            end
+
+            it 'works with option "hide_default_column_types"' do
+              is_expected.to eq expected_result
+            end
+          end
+
+          context 'when "hide_default_column_types" is "skip"' do
+            let :options do
+              { hide_default_column_types: 'skip' }
+            end
+
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  profile    :json             default({}), not null
+                #  settings   :jsonb            default({}), not null
+                #  parameters :hstore           default({}), not null
+                #
+              EOS
+            end
+
+            it 'works with option "hide_default_column_types"' do
+              is_expected.to eq expected_result
+            end
+          end
+
+          context 'when "hide_default_column_types" is "json"' do
+            let :options do
+              { hide_default_column_types: 'json' }
+            end
+
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  profile    :json             not null
+                #  settings   :jsonb            default({}), not null
+                #  parameters :hstore           default({}), not null
+                #
+              EOS
+            end
+
+            it 'works with option "hide_limit_column_types"' do
+              is_expected.to eq expected_result
+            end
+          end
+        end
+
+        context 'when "classified_sort" is specified in options' do
+          let :columns do
+            [
+              mock_column(:active, :boolean, limit: 1),
+              mock_column(:name, :string, limit: 50),
+              mock_column(:notes, :text, limit: 55)
+            ]
+          end
+
+          context 'when "classified_sort" is "yes"' do
+            let :options do
+              { classified_sort: 'yes' }
+            end
+
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  active :boolean          not null
+                #  name   :string(50)       not null
+                #  notes  :text(55)         not null
+                #
+              EOS
+            end
+
+            it 'works with option "classified_sort"' do
+              is_expected.to eq expected_result
+            end
+          end
+        end
+
+        context 'when "with_comment" is specified in options' do
+          context 'when "with_comment" is "yes"' do
+            let :options do
+              { with_comment: 'yes' }
+            end
+
+            context 'when columns have comments' do
+              let :columns do
+                [
+                  mock_column(:id,         :integer, limit: 8,  comment: 'ID'),
+                  mock_column(:active,     :boolean, limit: 1,  comment: 'Active'),
+                  mock_column(:name,       :string,  limit: 50, comment: 'Name'),
+                  mock_column(:notes,      :text,    limit: 55, comment: 'Notes'),
+                  mock_column(:no_comment, :text,    limit: 20, comment: nil)
+                ]
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  id(ID)         :integer          not null, primary key
+                  #  active(Active) :boolean          not null
+                  #  name(Name)     :string(50)       not null
+                  #  notes(Notes)   :text(55)         not null
+                  #  no_comment     :text(20)         not null
+                  #
+                EOS
+              end
+
+              it 'works with option "with_comment"' do
+                is_expected.to eq expected_result
+              end
+            end
+
+            context 'when columns have multibyte comments' do
+              let :columns do
+                [
+                  mock_column(:id,         :integer, limit: 8,  comment: 'ＩＤ'),
+                  mock_column(:active,     :boolean, limit: 1,  comment: 'ＡＣＴＩＶＥ'),
+                  mock_column(:name,       :string,  limit: 50, comment: 'ＮＡＭＥ'),
+                  mock_column(:notes,      :text,    limit: 55, comment: 'ＮＯＴＥＳ'),
+                  mock_column(:cyrillic,   :text,    limit: 30, comment: 'Кириллица'),
+                  mock_column(:japanese,   :text,    limit: 60, comment: '熊本大学　イタリア　宝島'),
+                  mock_column(:arabic,     :text,    limit: 20, comment: 'لغة'),
+                  mock_column(:no_comment, :text,    limit: 20, comment: nil),
+                  mock_column(:location,   :geometry_collection, limit: nil, comment: nil)
+                ]
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  id(ＩＤ)                           :integer          not null, primary key
+                  #  active(ＡＣＴＩＶＥ)               :boolean          not null
+                  #  name(ＮＡＭＥ)                     :string(50)       not null
+                  #  notes(ＮＯＴＥＳ)                  :text(55)         not null
+                  #  cyrillic(Кириллица)                :text(30)         not null
+                  #  japanese(熊本大学　イタリア　宝島) :text(60)         not null
+                  #  arabic(لغة)                        :text(20)         not null
+                  #  no_comment                         :text(20)         not null
+                  #  location                           :geometry_collect not null
+                  #
+                EOS
+              end
+
+              it 'works with option "with_comment"' do
+                is_expected.to eq expected_result
+              end
+            end
+
+            context 'when geometry columns are included' do
+              let :columns do
+                [
+                  mock_column(:id,       :integer,  limit: 8),
+                  mock_column(:active,   :boolean,  default: false, null: false),
+                  mock_column(:geometry, :geometry,
+                              geometric_type: 'Geometry', srid: 4326,
+                              limit: { srid: 4326, type: 'geometry' }),
+                  mock_column(:location, :geography,
+                              geometric_type: 'Point', srid: 0,
+                              limit: { srid: 0, type: 'geometry' })
+                ]
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  id       :integer          not null, primary key
+                  #  active   :boolean          default(FALSE), not null
+                  #  geometry :geometry         not null, geometry, 4326
+                  #  location :geography        not null, point, 0
+                  #
+                EOS
+              end
+
+              it 'works with option "with_comment"' do
+                is_expected.to eq expected_result
+              end
+            end
+          end
+        end
       end
     end
 
-    describe 'hide_limit_column_types option' do
-      when_called_with hide_limit_column_types: '', returns: <<-EOS.strip_heredoc
-        # Schema Info
-        #
-        # Table name: users
-        #
-        #  id     :integer          not null, primary key
-        #  active :boolean          not null
-        #  name   :string(50)       not null
-        #  notes  :text(55)         not null
-        #
-      EOS
-
-      when_called_with hide_limit_column_types: 'integer,boolean', returns:
-        <<-EOS.strip_heredoc
-        # Schema Info
-        #
-        # Table name: users
-        #
-        #  id     :integer          not null, primary key
-        #  active :boolean          not null
-        #  name   :string(50)       not null
-        #  notes  :text(55)         not null
-        #
-      EOS
-
-      when_called_with hide_limit_column_types: 'integer,boolean,string,text',
-                       returns:
-        <<-EOS.strip_heredoc
-        # Schema Info
-        #
-        # Table name: users
-        #
-        #  id     :integer          not null, primary key
-        #  active :boolean          not null
-        #  name   :string           not null
-        #  notes  :text             not null
-        #
-      EOS
-    end
-
-    describe 'hide_default_column_types option' do
-      mocked_columns_without_id = [
-        [:profile, :json, default: {}],
-        [:settings, :jsonb, default: {}],
-        [:parameters, :hstore, default: {}]
-      ]
-
-      when_called_with hide_default_column_types: '',
-                       with_columns: mocked_columns_without_id,
-                       returns:
-        <<-EOS.strip_heredoc
-        # Schema Info
-        #
-        # Table name: users
-        #
-        #  profile    :json             not null
-        #  settings   :jsonb            not null
-        #  parameters :hstore           not null
-        #
-      EOS
-
-      when_called_with hide_default_column_types: 'skip',
-                       with_columns: mocked_columns_without_id,
-                       returns:
-        <<-EOS.strip_heredoc
-        # Schema Info
-        #
-        # Table name: users
-        #
-        #  profile    :json             default({}), not null
-        #  settings   :jsonb            default({}), not null
-        #  parameters :hstore           default({}), not null
-        #
-      EOS
-
-      when_called_with hide_default_column_types: 'json',
-                       with_columns: mocked_columns_without_id,
-                       returns:
-        <<-EOS.strip_heredoc
-        # Schema Info
-        #
-        # Table name: users
-        #
-        #  profile    :json             not null
-        #  settings   :jsonb            default({}), not null
-        #  parameters :hstore           default({}), not null
-        #
-      EOS
-    end
-
-    describe 'classified_sort option' do
-      mocked_columns_without_id = [
-        [:active, :boolean, { limit: 1 }],
-        [:name, :string, { limit: 50 }],
-        [:notes, :text, { limit: 55 }]
-      ]
-
-      when_called_with classified_sort: 'yes',
-                       with_columns: mocked_columns_without_id, returns:
-        <<-EOS.strip_heredoc
-        # Schema Info
-        #
-        # Table name: users
-        #
-        #  active :boolean          not null
-        #  name   :string(50)       not null
-        #  notes  :text(55)         not null
-        #
-      EOS
-    end
-
-    describe 'with_comment option' do
-      mocked_columns_with_comment = [
-        [:id,         :integer, { limit: 8,  comment: 'ID' }],
-        [:active,     :boolean, { limit: 1,  comment: 'Active' }],
-        [:name,       :string,  { limit: 50, comment: 'Name' }],
-        [:notes,      :text,    { limit: 55, comment: 'Notes' }],
-        [:no_comment, :text,    { limit: 20, comment: nil }]
-      ]
-
-      when_called_with with_comment: 'yes',
-                       with_columns: mocked_columns_with_comment, returns:
-        <<-EOS.strip_heredoc
-        # Schema Info
-        #
-        # Table name: users
-        #
-        #  id(ID)         :integer          not null, primary key
-        #  active(Active) :boolean          not null
-        #  name(Name)     :string(50)       not null
-        #  notes(Notes)   :text(55)         not null
-        #  no_comment     :text(20)         not null
-        #
-    EOS
-
-      mocked_columns_with_multibyte_comment = [
-        [:id,         :integer, { limit: 8,  comment: 'ＩＤ' }],
-        [:active,     :boolean, { limit: 1,  comment: 'ＡＣＴＩＶＥ' }],
-        [:name,       :string,  { limit: 50, comment: 'ＮＡＭＥ' }],
-        [:notes,      :text,    { limit: 55, comment: 'ＮＯＴＥＳ' }],
-        [:cyrillic,   :text,    { limit: 30, comment: 'Кириллица' }],
-        [:japanese,   :text,    { limit: 60, comment: '熊本大学　イタリア　宝島' }],
-        [:arabic,     :text,    { limit: 20, comment: 'لغة' }],
-        [:no_comment, :text,    { limit: 20, comment: nil }],
-        [:location,   :geometry_collection, { limit: nil, comment: nil }]
-      ]
-
-      when_called_with with_comment: 'yes',
-                       with_columns: mocked_columns_with_multibyte_comment, returns:
-        <<-EOS.strip_heredoc
-        # Schema Info
-        #
-        # Table name: users
-        #
-        #  id(ＩＤ)                           :integer          not null, primary key
-        #  active(ＡＣＴＩＶＥ)               :boolean          not null
-        #  name(ＮＡＭＥ)                     :string(50)       not null
-        #  notes(ＮＯＴＥＳ)                  :text(55)         not null
-        #  cyrillic(Кириллица)                :text(30)         not null
-        #  japanese(熊本大学　イタリア　宝島) :text(60)         not null
-        #  arabic(لغة)                        :text(20)         not null
-        #  no_comment                         :text(20)         not null
-        #  location                           :geometry_collect not null
-        #
-      EOS
-
-      mocked_columns_with_geometries = [
-        [:id,       :integer,  { limit: 8 }],
-        [:active,   :boolean,  { default: false, null: false }],
-        [:geometry, :geometry, {
-          geometric_type: 'Geometry', srid: 4326,
-          limit:          { srid: 4326, type: 'geometry' }
-        }],
-        [:location, :geography, {
-          geometric_type: 'Point', srid: 0,
-          limit:          { srid: 0, type: 'geometry' }
-        }]
-      ]
-
-      when_called_with with_columns: mocked_columns_with_geometries, returns:
-        <<-EOS.strip_heredoc
-        # Schema Info
-        #
-        # Table name: users
-        #
-        #  id       :integer          not null, primary key
-        #  active   :boolean          default(FALSE), not null
-        #  geometry :geometry         not null, geometry, 4326
-        #  location :geography        not null, point, 0
-        #
-      EOS
-
-      it 'should get schema info as RDoc' do
-        klass = mock_class(:users,
-                           :id,
-                           [
-                             mock_column(:id, :integer, comment: 'ID'),
-                             mock_column(:name, :string, limit: 50, comment: 'Name')
-                           ])
-        expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true, with_comment: true)).to eql(<<-EOS.strip_heredoc)
-        # #{AnnotateModels::PREFIX}
-        #
-        # Table name: users
-        #
-        # *id(ID)*::     <tt>integer, not null, primary key</tt>
-        # *name(Name)*:: <tt>string(50), not null</tt>
-        #--
-        # #{AnnotateModels::END_MARK}
-        #++
-        EOS
+    context 'when header is "== Schema Information"' do
+      let :header do
+        AnnotateModels::PREFIX
       end
 
-      it 'should get schema info as Markdown with multibyte comment' do
-        klass = mock_class(:users,
-                           :id,
-                           [
-                             mock_column(:id, :integer, comment: 'ＩＤ'),
-                             mock_column(:name, :string, limit: 50, comment: 'ＮＡＭＥ')
-                           ])
-        expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, with_comment: true)).to eql(<<-EOS.strip_heredoc)
-        # #{AnnotateModels::PREFIX}
-        #
-        # Table name: `users`
-        #
-        # ### Columns
-        #
-        # Name                  | Type               | Attributes
-        # --------------------- | ------------------ | ---------------------------
-        # **`id(ＩＤ)`**        | `integer`          | `not null, primary key`
-        # **`name(ＮＡＭＥ)`**  | `string(50)`       | `not null`
-        #
-        EOS
+      context 'when "format_doc" and "with_comment" are specified in options' do
+        subject do
+          AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true, with_comment: true)
+        end
+
+        context 'when columns are normal' do
+          let :columns do
+            [
+              mock_column(:id, :integer, comment: 'ID'),
+              mock_column(:name, :string, limit: 50, comment: 'Name')
+            ]
+          end
+
+          let :expected_result do
+            <<~EOS
+              # == Schema Information
+              #
+              # Table name: users
+              #
+              # *id(ID)*::     <tt>integer, not null, primary key</tt>
+              # *name(Name)*:: <tt>string(50), not null</tt>
+              #--
+              # == Schema Information End
+              #++
+            EOS
+          end
+
+          it 'returns schema info in RDoc format' do
+            is_expected.to eq expected_result
+          end
+        end
       end
 
-      it 'should get schema info as Markdown' do
-        klass = mock_class(:users,
-                           :id,
-                           [
-                             mock_column(:id, :integer, comment: 'ID'),
-                             mock_column(:name, :string, limit: 50, comment: 'Name')
-                           ])
-        expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, with_comment: true)).to eql(<<-EOS.strip_heredoc)
-        # #{AnnotateModels::PREFIX}
-        #
-        # Table name: `users`
-        #
-        # ### Columns
-        #
-        # Name              | Type               | Attributes
-        # ----------------- | ------------------ | ---------------------------
-        # **`id(ID)`**      | `integer`          | `not null, primary key`
-        # **`name(Name)`**  | `string(50)`       | `not null`
-        #
-        EOS
+      context 'when "format_markdown" and "with_comment" are specified in options' do
+        subject do
+          AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, with_comment: true)
+        end
+
+        context 'when columns have comments' do
+          let :columns do
+            [
+              mock_column(:id, :integer, comment: 'ID'),
+              mock_column(:name, :string, limit: 50, comment: 'Name')
+            ]
+          end
+
+          let :expected_result do
+            <<~EOS
+              # == Schema Information
+              #
+              # Table name: `users`
+              #
+              # ### Columns
+              #
+              # Name              | Type               | Attributes
+              # ----------------- | ------------------ | ---------------------------
+              # **`id(ID)`**      | `integer`          | `not null, primary key`
+              # **`name(Name)`**  | `string(50)`       | `not null`
+              #
+            EOS
+          end
+
+          it 'returns schema info in Markdown format' do
+            is_expected.to eq expected_result
+          end
+        end
+
+        context 'when columns have multibyte comments' do
+          let :columns do
+            [
+              mock_column(:id, :integer, comment: 'ＩＤ'),
+              mock_column(:name, :string, limit: 50, comment: 'ＮＡＭＥ')
+            ]
+          end
+
+          let :expected_result do
+            <<~EOS
+              # == Schema Information
+              #
+              # Table name: `users`
+              #
+              # ### Columns
+              #
+              # Name                  | Type               | Attributes
+              # --------------------- | ------------------ | ---------------------------
+              # **`id(ＩＤ)`**        | `integer`          | `not null, primary key`
+              # **`name(ＮＡＭＥ)`**  | `string(50)`       | `not null`
+              #
+            EOS
+          end
+
+          it 'returns schema info in Markdown format' do
+            is_expected.to eq expected_result
+          end
+        end
       end
     end
   end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -182,21 +182,21 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
   end
 
   describe '.get_schema_info' do # rubocop:disable Metrics/BlockLength
+    let :klass do
+      mock_class(:users, primary_key, columns, indexes, foreign_keys)
+    end
+
+    let :indexes do
+      []
+    end
+
+    let :foreign_keys do
+      []
+    end
+
     context 'when option is not present' do # rubocop:disable Metrics/BlockLength
       subject do
         AnnotateModels.get_schema_info(klass, header)
-      end
-
-      let :klass do
-        mock_class(:users, primary_key, columns, indexes, foreign_keys)
-      end
-
-      let :indexes do
-        []
-      end
-
-      let :foreign_keys do
-        []
       end
 
       context 'when header is "Schema Info"' do # rubocop:disable Metrics/BlockLength
@@ -1124,8 +1124,8 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
     end
 
     describe 'when option is present' do
-      let :klass do
-        mock_class(:users, :id, columns)
+      let :primary_key do
+        :id
       end
 
       subject do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -64,14 +64,69 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
     double('Column', stubs)
   end
 
-  it { expect(AnnotateModels.quote(nil)).to eql('NULL') }
-  it { expect(AnnotateModels.quote(true)).to eql('TRUE') }
-  it { expect(AnnotateModels.quote(false)).to eql('FALSE') }
-  it { expect(AnnotateModels.quote(25)).to eql('25') }
-  it { expect(AnnotateModels.quote(25.6)).to eql('25.6') }
-  it { expect(AnnotateModels.quote(1e-20)).to eql('1.0e-20') }
-  it { expect(AnnotateModels.quote(BigDecimal('1.2'))).to eql('1.2') }
-  it { expect(AnnotateModels.quote([BigDecimal('1.2')])).to eql(['1.2']) }
+  describe '.quote' do
+    subject do
+      AnnotateModels.quote(value)
+    end
+
+    context 'when the argument is nil' do
+      let(:value) { nil }
+      it 'returns string "NULL"' do
+        is_expected.to eq('NULL')
+      end
+    end
+
+    context 'when the argument is true' do
+      let(:value) { true }
+      it 'returns string "TRUE"' do
+        is_expected.to eq('TRUE')
+      end
+    end
+
+    context 'when the argument is false' do
+      let(:value) { false }
+      it 'returns string "FALSE"' do
+        is_expected.to eq('FALSE')
+      end
+    end
+
+    context 'when the argument is an integer' do
+      let(:value) { 25 }
+      it 'returns the integer as a string' do
+        is_expected.to eq('25')
+      end
+    end
+
+    context 'when the argument is a float number' do
+      context 'when the argument is like 25.6' do
+        let(:value) { 25.6 }
+        it 'returns the float number as a string' do
+          is_expected.to eq('25.6')
+        end
+      end
+
+      context 'when the argument is like 1e-20' do
+        let(:value) { 1e-20 }
+        it 'returns the float number as a string' do
+          is_expected.to eq('1.0e-20')
+        end
+      end
+    end
+
+    context 'when the argument is a BigDecimal number' do
+      let(:value) { BigDecimal('1.2') }
+      it 'returns the float number as a string' do
+        is_expected.to eq('1.2')
+      end
+    end
+
+    context 'when the argument is an array' do
+      let(:value) { [BigDecimal('1.2')] }
+      it 'returns an array of which elements are converted to string' do
+        is_expected.to eq(['1.2'])
+      end
+    end
+  end
 
   describe '#parse_options' do
     let(:options) do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -182,128 +182,38 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
   end
 
   describe '.get_schema_info' do # rubocop:disable Metrics/BlockLength
-    subject do
-      AnnotateModels.get_schema_info(klass, header)
-    end
-
-    let :klass do
-      mock_class(:users, primary_key, columns, indexes, foreign_keys)
-    end
-
-    let :indexes do
-      []
-    end
-
-    let :foreign_keys do
-      []
-    end
-
-    context 'when header is "Schema Info"' do # rubocop:disable Metrics/BlockLength
-      let :header do
-        'Schema Info'
+    context 'when option is not present' do # rubocop:disable Metrics/BlockLength
+      subject do
+        AnnotateModels.get_schema_info(klass, header)
       end
 
-      context 'when the primary key is not specified' do
-        let :primary_key do
-          nil
-        end
-
-        context 'when the columns are normal' do
-          let :columns do
-            [
-              mock_column(:id, :integer),
-              mock_column(:name, :string, limit: 50)
-            ]
-          end
-
-          let :expected_result do
-            <<~EOS
-              # Schema Info
-              #
-              # Table name: users
-              #
-              #  id   :integer          not null
-              #  name :string(50)       not null
-              #
-            EOS
-          end
-
-          it 'returns schema info' do
-            is_expected.to eq(expected_result)
-          end
-        end
-
-        context 'when an enum column exists' do
-          let :columns do
-            [
-              mock_column(:id, :integer),
-              mock_column(:name, :enum, limit: [:enum1, :enum2])
-            ]
-          end
-
-          let :expected_result do
-            <<~EOS
-              # Schema Info
-              #
-              # Table name: users
-              #
-              #  id   :integer          not null
-              #  name :enum             not null, (enum1, enum2)
-              #
-            EOS
-          end
-
-          it 'returns schema info' do
-            is_expected.to eq(expected_result)
-          end
-        end
-
-        context 'when unsigned columns exist' do
-          let :columns do
-            [
-              mock_column(:id, :integer),
-              mock_column(:integer, :integer, unsigned?: true),
-              mock_column(:bigint,  :integer, unsigned?: true, bigint?: true),
-              mock_column(:bigint,  :bigint,  unsigned?: true),
-              mock_column(:float,   :float,   unsigned?: true),
-              mock_column(:decimal, :decimal, unsigned?: true, precision: 10, scale: 2),
-            ]
-          end
-
-          let :expected_result do
-            <<~EOS
-              # Schema Info
-              #
-              # Table name: users
-              #
-              #  id      :integer          not null
-              #  integer :integer          unsigned, not null
-              #  bigint  :bigint           unsigned, not null
-              #  bigint  :bigint           unsigned, not null
-              #  float   :float            unsigned, not null
-              #  decimal :decimal(10, 2)   unsigned, not null
-              #
-            EOS
-          end
-
-          it 'returns schema info' do
-            is_expected.to eq(expected_result)
-          end
-        end
+      let :klass do
+        mock_class(:users, primary_key, columns, indexes, foreign_keys)
       end
 
-      context 'when the primary key is specified' do # rubocop:disable Metrics/BlockLength
-        context 'when the primary_key is :id' do # rubocop:disable Metrics/BlockLength
+      let :indexes do
+        []
+      end
+
+      let :foreign_keys do
+        []
+      end
+
+      context 'when header is "Schema Info"' do # rubocop:disable Metrics/BlockLength
+        let :header do
+          'Schema Info'
+        end
+
+        context 'when the primary key is not specified' do
           let :primary_key do
-            :id
+            nil
           end
 
-          context 'when columns are normal' do
+          context 'when the columns are normal' do
             let :columns do
               [
-                mock_column(:id, :integer, limit: 8),
-                mock_column(:name, :string, limit: 50),
-                mock_column(:notes, :text, limit: 55)
+                mock_column(:id, :integer),
+                mock_column(:name, :string, limit: 50)
               ]
             end
 
@@ -313,9 +223,8 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
                 #
                 # Table name: users
                 #
-                #  id    :integer          not null, primary key
-                #  name  :string(50)       not null
-                #  notes :text(55)         not null
+                #  id   :integer          not null
+                #  name :string(50)       not null
                 #
               EOS
             end
@@ -325,12 +234,11 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
             end
           end
 
-          context 'when columns have default values' do
+          context 'when an enum column exists' do
             let :columns do
               [
                 mock_column(:id, :integer),
-                mock_column(:size, :integer, default: 20),
-                mock_column(:flag, :boolean, default: false)
+                mock_column(:name, :enum, limit: [:enum1, :enum2])
               ]
             end
 
@@ -340,32 +248,27 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
                 #
                 # Table name: users
                 #
-                #  id   :integer          not null, primary key
-                #  size :integer          default(20), not null
-                #  flag :boolean          default(FALSE), not null
+                #  id   :integer          not null
+                #  name :enum             not null, (enum1, enum2)
                 #
               EOS
             end
 
-            it 'returns schema info with default values' do
+            it 'returns schema info' do
               is_expected.to eq(expected_result)
             end
           end
 
-          context 'when an integer column using ActiveRecord::Enum exists' do
+          context 'when unsigned columns exist' do
             let :columns do
               [
                 mock_column(:id, :integer),
-                mock_column(:status, :integer, default: 0)
+                mock_column(:integer, :integer, unsigned?: true),
+                mock_column(:bigint,  :integer, unsigned?: true, bigint?: true),
+                mock_column(:bigint,  :bigint,  unsigned?: true),
+                mock_column(:float,   :float,   unsigned?: true),
+                mock_column(:decimal, :decimal, unsigned?: true, precision: 10, scale: 2),
               ]
-            end
-
-            before :each do
-              # column_defaults may be overritten when ActiveRecord::Enum is used, e.g:
-              # class User < ActiveRecord::Base
-              #   enum status: [ :disabled, :enabled ]
-              # end
-              allow(klass).to receive(:column_defaults).and_return('id' => nil, 'status' => 'disabled')
             end
 
             let :expected_result do
@@ -374,374 +277,35 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
                 #
                 # Table name: users
                 #
-                #  id     :integer          not null, primary key
-                #  status :integer          default(0), not null
+                #  id      :integer          not null
+                #  integer :integer          unsigned, not null
+                #  bigint  :bigint           unsigned, not null
+                #  bigint  :bigint           unsigned, not null
+                #  float   :float            unsigned, not null
+                #  decimal :decimal(10, 2)   unsigned, not null
                 #
               EOS
             end
 
-            it 'returns schema info with default values' do
+            it 'returns schema info' do
               is_expected.to eq(expected_result)
             end
           end
+        end
 
-          context 'when indexes exist' do
-            context 'when option "show_indexes" is true' do
-              subject do
-                AnnotateModels.get_schema_info(klass, header, show_indexes: true)
-              end
-
-              context 'when indexes are normal' do
-                let :columns do
-                  [
-                    mock_column(:id, :integer),
-                    mock_column(:foreign_thing_id, :integer)
-                  ]
-                end
-
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # Schema Info
-                    #
-                    # Table name: users
-                    #
-                    #  id               :integer          not null, primary key
-                    #  foreign_thing_id :integer          not null
-                    #
-                    # Indexes
-                    #
-                    #  index_rails_02e851e3b7  (id)
-                    #  index_rails_02e851e3b8  (foreign_thing_id)
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information' do
-                  is_expected.to eq expected_result
-                end
-              end
-
-              context 'when one of indexes includes orderd index key' do
-                let :columns do
-                  [
-                    mock_column("id", :integer),
-                    mock_column("firstname", :string),
-                    mock_column("surname", :string),
-                    mock_column("value", :string)
-                  ]
-                end
-
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8',
-                               columns: %w(firstname surname value),
-                               orders: { 'surname' => :asc, 'value' => :desc })
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # Schema Info
-                    #
-                    # Table name: users
-                    #
-                    #  id        :integer          not null, primary key
-                    #  firstname :string           not null
-                    #  surname   :string           not null
-                    #  value     :string           not null
-                    #
-                    # Indexes
-                    #
-                    #  index_rails_02e851e3b7  (id)
-                    #  index_rails_02e851e3b8  (firstname,surname ASC,value DESC)
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information' do
-                  is_expected.to eq expected_result
-                end
-              end
-
-              context 'when one of indexes includes "where" clause' do
-                let :columns do
-                  [
-                    mock_column("id", :integer),
-                    mock_column("firstname", :string),
-                    mock_column("surname", :string),
-                    mock_column("value", :string)
-                  ]
-                end
-
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8',
-                               columns: %w(firstname surname),
-                               where: 'value IS NOT NULL')
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # Schema Info
-                    #
-                    # Table name: users
-                    #
-                    #  id        :integer          not null, primary key
-                    #  firstname :string           not null
-                    #  surname   :string           not null
-                    #  value     :string           not null
-                    #
-                    # Indexes
-                    #
-                    #  index_rails_02e851e3b7  (id)
-                    #  index_rails_02e851e3b8  (firstname,surname) WHERE value IS NOT NULL
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information' do
-                  is_expected.to eq expected_result
-                end
-              end
-
-              context 'when one of indexes includes "using" clause other than "btree"' do
-                let :columns do
-                  [
-                    mock_column("id", :integer),
-                    mock_column("firstname", :string),
-                    mock_column("surname", :string),
-                    mock_column("value", :string)
-                  ]
-                end
-
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8',
-                               columns: %w(firstname surname),
-                               using: 'hash')
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # Schema Info
-                    #
-                    # Table name: users
-                    #
-                    #  id        :integer          not null, primary key
-                    #  firstname :string           not null
-                    #  surname   :string           not null
-                    #  value     :string           not null
-                    #
-                    # Indexes
-                    #
-                    #  index_rails_02e851e3b7  (id)
-                    #  index_rails_02e851e3b8  (firstname,surname) USING hash
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information' do
-                  is_expected.to eq expected_result
-                end
-              end
-
-              context 'when index is not defined' do
-                let :columns do
-                  [
-                    mock_column(:id, :integer),
-                    mock_column(:foreign_thing_id, :integer)
-                  ]
-                end
-
-                let :indexes do
-                  []
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # Schema Info
-                    #
-                    # Table name: users
-                    #
-                    #  id               :integer          not null, primary key
-                    #  foreign_thing_id :integer          not null
-                    #
-                  EOS
-                end
-
-                it 'returns schema info without index information' do
-                  is_expected.to eq expected_result
-                end
-              end
+        context 'when the primary key is specified' do # rubocop:disable Metrics/BlockLength
+          context 'when the primary_key is :id' do # rubocop:disable Metrics/BlockLength
+            let :primary_key do
+              :id
             end
 
-            context 'when option "simple_indexes" is true' do
-              subject do
-                AnnotateModels.get_schema_info(klass, header, simple_indexes: true)
-              end
-
-              context 'when one of indexes is in string form' do
-                let :columns do
-                  [
-                    mock_column("id", :integer),
-                    mock_column("name", :string)
-                  ]
-                end
-
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8', columns: 'LOWER(name)')
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # Schema Info
-                    #
-                    # Table name: users
-                    #
-                    #  id   :integer          not null, primary key, indexed
-                    #  name :string           not null
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information' do
-                  is_expected.to eq expected_result
-                end
-              end
-
-              context 'when one of indexes includes "orders" clause' do # TODO
-                let :columns do
-                  [
-                    mock_column(:id, :integer),
-                    mock_column(:foreign_thing_id, :integer)
-                  ]
-                end
-
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8',
-                               columns: ['foreign_thing_id'],
-                               orders: { 'foreign_thing_id' => :desc })
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # Schema Info
-                    #
-                    # Table name: users
-                    #
-                    #  id               :integer          not null, primary key
-                    #  foreign_thing_id :integer          not null
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information' do
-                  is_expected.to eq expected_result
-                end
-              end
-            end
-          end
-
-          context 'when foreign keys exist' do
-            let :columns do
-              [
-                mock_column(:id, :integer),
-                mock_column(:foreign_thing_id, :integer)
-              ]
-            end
-
-            let :foreign_keys do
-              [
-                mock_foreign_key('fk_rails_cf2568e89e', 'foreign_thing_id', 'foreign_things'),
-                mock_foreign_key('custom_fk_name', 'other_thing_id', 'other_things'),
-                mock_foreign_key('fk_rails_a70234b26c', 'third_thing_id', 'third_things')
-              ]
-            end
-
-            context 'when option "show_foreign_keys" is specified' do
-              subject do
-                AnnotateModels.get_schema_info(klass, header, show_foreign_keys: true)
-              end
-
-              context 'when foreign_keys does not have option' do
-                let :expected_result do
-                  <<~EOS
-                    # Schema Info
-                    #
-                    # Table name: users
-                    #
-                    #  id               :integer          not null, primary key
-                    #  foreign_thing_id :integer          not null
-                    #
-                    # Foreign Keys
-                    #
-                    #  custom_fk_name  (other_thing_id => other_things.id)
-                    #  fk_rails_...    (foreign_thing_id => foreign_things.id)
-                    #  fk_rails_...    (third_thing_id => third_things.id)
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with foreign keys' do
-                  is_expected.to eq(expected_result)
-                end
-              end
-
-              context 'when foreign_keys have option "on_delete" and "on_update"' do
-                let :foreign_keys do
-                  [
-                    mock_foreign_key('fk_rails_02e851e3b7',
-                                     'foreign_thing_id',
-                                     'foreign_things',
-                                     'id',
-                                     on_delete: 'on_delete_value',
-                                     on_update: 'on_update_value')
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # Schema Info
-                    #
-                    # Table name: users
-                    #
-                    #  id               :integer          not null, primary key
-                    #  foreign_thing_id :integer          not null
-                    #
-                    # Foreign Keys
-                    #
-                    #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => on_delete_value ON UPDATE => on_update_value
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with foreign keys' do
-                  is_expected.to eq(expected_result)
-                end
-              end
-            end
-
-            context 'when option "show_foreign_keys" and "show_complete_foreign_keys" are specified' do
-              subject do
-                AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)
+            context 'when columns are normal' do
+              let :columns do
+                [
+                  mock_column(:id, :integer, limit: 8),
+                  mock_column(:name, :string, limit: 50),
+                  mock_column(:notes, :text, limit: 55)
+                ]
               end
 
               let :expected_result do
@@ -750,79 +314,1154 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
                   #
                   # Table name: users
                   #
-                  #  id               :integer          not null, primary key
-                  #  foreign_thing_id :integer          not null
-                  #
-                  # Foreign Keys
-                  #
-                  #  custom_fk_name       (other_thing_id => other_things.id)
-                  #  fk_rails_a70234b26c  (third_thing_id => third_things.id)
-                  #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
+                  #  id    :integer          not null, primary key
+                  #  name  :string(50)       not null
+                  #  notes :text(55)         not null
                   #
                 EOS
               end
 
-              it 'returns schema info with foreign keys' do
+              it 'returns schema info' do
                 is_expected.to eq(expected_result)
               end
             end
+
+            context 'when columns have default values' do
+              let :columns do
+                [
+                  mock_column(:id, :integer),
+                  mock_column(:size, :integer, default: 20),
+                  mock_column(:flag, :boolean, default: false)
+                ]
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  id   :integer          not null, primary key
+                  #  size :integer          default(20), not null
+                  #  flag :boolean          default(FALSE), not null
+                  #
+                EOS
+              end
+
+              it 'returns schema info with default values' do
+                is_expected.to eq(expected_result)
+              end
+            end
+
+            context 'when an integer column using ActiveRecord::Enum exists' do
+              let :columns do
+                [
+                  mock_column(:id, :integer),
+                  mock_column(:status, :integer, default: 0)
+                ]
+              end
+
+              before :each do
+                # column_defaults may be overritten when ActiveRecord::Enum is used, e.g:
+                # class User < ActiveRecord::Base
+                #   enum status: [ :disabled, :enabled ]
+                # end
+                allow(klass).to receive(:column_defaults).and_return('id' => nil, 'status' => 'disabled')
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  id     :integer          not null, primary key
+                  #  status :integer          default(0), not null
+                  #
+                EOS
+              end
+
+              it 'returns schema info with default values' do
+                is_expected.to eq(expected_result)
+              end
+            end
+
+            context 'when indexes exist' do
+              context 'when option "show_indexes" is true' do
+                subject do
+                  AnnotateModels.get_schema_info(klass, header, show_indexes: true)
+                end
+
+                context 'when indexes are normal' do
+                  let :columns do
+                    [
+                      mock_column(:id, :integer),
+                      mock_column(:foreign_thing_id, :integer)
+                    ]
+                  end
+
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id               :integer          not null, primary key
+                      #  foreign_thing_id :integer          not null
+                      #
+                      # Indexes
+                      #
+                      #  index_rails_02e851e3b7  (id)
+                      #  index_rails_02e851e3b8  (foreign_thing_id)
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
+                context 'when one of indexes includes orderd index key' do
+                  let :columns do
+                    [
+                      mock_column("id", :integer),
+                      mock_column("firstname", :string),
+                      mock_column("surname", :string),
+                      mock_column("value", :string)
+                    ]
+                  end
+
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8',
+                                 columns: %w(firstname surname value),
+                                 orders: { 'surname' => :asc, 'value' => :desc })
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id        :integer          not null, primary key
+                      #  firstname :string           not null
+                      #  surname   :string           not null
+                      #  value     :string           not null
+                      #
+                      # Indexes
+                      #
+                      #  index_rails_02e851e3b7  (id)
+                      #  index_rails_02e851e3b8  (firstname,surname ASC,value DESC)
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
+                context 'when one of indexes includes "where" clause' do
+                  let :columns do
+                    [
+                      mock_column("id", :integer),
+                      mock_column("firstname", :string),
+                      mock_column("surname", :string),
+                      mock_column("value", :string)
+                    ]
+                  end
+
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8',
+                                 columns: %w(firstname surname),
+                                 where: 'value IS NOT NULL')
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id        :integer          not null, primary key
+                      #  firstname :string           not null
+                      #  surname   :string           not null
+                      #  value     :string           not null
+                      #
+                      # Indexes
+                      #
+                      #  index_rails_02e851e3b7  (id)
+                      #  index_rails_02e851e3b8  (firstname,surname) WHERE value IS NOT NULL
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
+                context 'when one of indexes includes "using" clause other than "btree"' do
+                  let :columns do
+                    [
+                      mock_column("id", :integer),
+                      mock_column("firstname", :string),
+                      mock_column("surname", :string),
+                      mock_column("value", :string)
+                    ]
+                  end
+
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8',
+                                 columns: %w(firstname surname),
+                                 using: 'hash')
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id        :integer          not null, primary key
+                      #  firstname :string           not null
+                      #  surname   :string           not null
+                      #  value     :string           not null
+                      #
+                      # Indexes
+                      #
+                      #  index_rails_02e851e3b7  (id)
+                      #  index_rails_02e851e3b8  (firstname,surname) USING hash
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
+                context 'when index is not defined' do
+                  let :columns do
+                    [
+                      mock_column(:id, :integer),
+                      mock_column(:foreign_thing_id, :integer)
+                    ]
+                  end
+
+                  let :indexes do
+                    []
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id               :integer          not null, primary key
+                      #  foreign_thing_id :integer          not null
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info without index information' do
+                    is_expected.to eq expected_result
+                  end
+                end
+              end
+
+              context 'when option "simple_indexes" is true' do
+                subject do
+                  AnnotateModels.get_schema_info(klass, header, simple_indexes: true)
+                end
+
+                context 'when one of indexes is in string form' do
+                  let :columns do
+                    [
+                      mock_column("id", :integer),
+                      mock_column("name", :string)
+                    ]
+                  end
+
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8', columns: 'LOWER(name)')
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id   :integer          not null, primary key, indexed
+                      #  name :string           not null
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
+                context 'when one of indexes includes "orders" clause' do # TODO
+                  let :columns do
+                    [
+                      mock_column(:id, :integer),
+                      mock_column(:foreign_thing_id, :integer)
+                    ]
+                  end
+
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8',
+                                 columns: ['foreign_thing_id'],
+                                 orders: { 'foreign_thing_id' => :desc })
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id               :integer          not null, primary key
+                      #  foreign_thing_id :integer          not null
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information' do
+                    is_expected.to eq expected_result
+                  end
+                end
+              end
+            end
+
+            context 'when foreign keys exist' do
+              let :columns do
+                [
+                  mock_column(:id, :integer),
+                  mock_column(:foreign_thing_id, :integer)
+                ]
+              end
+
+              let :foreign_keys do
+                [
+                  mock_foreign_key('fk_rails_cf2568e89e', 'foreign_thing_id', 'foreign_things'),
+                  mock_foreign_key('custom_fk_name', 'other_thing_id', 'other_things'),
+                  mock_foreign_key('fk_rails_a70234b26c', 'third_thing_id', 'third_things')
+                ]
+              end
+
+              context 'when option "show_foreign_keys" is specified' do
+                subject do
+                  AnnotateModels.get_schema_info(klass, header, show_foreign_keys: true)
+                end
+
+                context 'when foreign_keys does not have option' do
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id               :integer          not null, primary key
+                      #  foreign_thing_id :integer          not null
+                      #
+                      # Foreign Keys
+                      #
+                      #  custom_fk_name  (other_thing_id => other_things.id)
+                      #  fk_rails_...    (foreign_thing_id => foreign_things.id)
+                      #  fk_rails_...    (third_thing_id => third_things.id)
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with foreign keys' do
+                    is_expected.to eq(expected_result)
+                  end
+                end
+
+                context 'when foreign_keys have option "on_delete" and "on_update"' do
+                  let :foreign_keys do
+                    [
+                      mock_foreign_key('fk_rails_02e851e3b7',
+                                       'foreign_thing_id',
+                                       'foreign_things',
+                                       'id',
+                                       on_delete: 'on_delete_value',
+                                       on_update: 'on_update_value')
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id               :integer          not null, primary key
+                      #  foreign_thing_id :integer          not null
+                      #
+                      # Foreign Keys
+                      #
+                      #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => on_delete_value ON UPDATE => on_update_value
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with foreign keys' do
+                    is_expected.to eq(expected_result)
+                  end
+                end
+              end
+
+              context 'when option "show_foreign_keys" and "show_complete_foreign_keys" are specified' do
+                subject do
+                  AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id               :integer          not null, primary key
+                    #  foreign_thing_id :integer          not null
+                    #
+                    # Foreign Keys
+                    #
+                    #  custom_fk_name       (other_thing_id => other_things.id)
+                    #  fk_rails_a70234b26c  (third_thing_id => third_things.id)
+                    #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with foreign keys' do
+                  is_expected.to eq(expected_result)
+                end
+              end
+            end
+          end
+
+          context 'when the primary key is an array (using composite_primary_keys)' do
+            let :primary_key do
+              [:a_id, :b_id]
+            end
+
+            let :columns do
+              [
+                mock_column(:a_id, :integer),
+                mock_column(:b_id, :integer),
+                mock_column(:name, :string, limit: 50)
+              ]
+            end
+
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  a_id :integer          not null, primary key
+                #  b_id :integer          not null, primary key
+                #  name :string(50)       not null
+                #
+              EOS
+            end
+
+            it 'returns schema info' do
+              is_expected.to eq(expected_result)
+            end
           end
         end
+      end
 
-        context 'when the primary key is an array (using composite_primary_keys)' do
-          let :primary_key do
-            [:a_id, :b_id]
-          end
+      context 'when header is "== Schema Information"' do
+        let :header do
+          AnnotateModels::PREFIX
+        end
 
-          let :columns do
-            [
-              mock_column(:a_id, :integer),
-              mock_column(:b_id, :integer),
-              mock_column(:name, :string, limit: 50)
-            ]
-          end
+        context 'when the primary key is specified' do
+          context 'when the primary_key is :id' do
+            let :primary_key do
+              :id
+            end
 
-          let :expected_result do
-            <<~EOS
-              # Schema Info
-              #
-              # Table name: users
-              #
-              #  a_id :integer          not null, primary key
-              #  b_id :integer          not null, primary key
-              #  name :string(50)       not null
-              #
-            EOS
-          end
+            let :columns do
+              [
+                mock_column(:id, :integer),
+                mock_column(:name, :string, limit: 50)
+              ]
+            end
 
-          it 'returns schema info' do
-            is_expected.to eq(expected_result)
+            context 'when option "format_rdoc" is true' do
+              subject do
+                AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true)
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # == Schema Information
+                  #
+                  # Table name: users
+                  #
+                  # *id*::   <tt>integer, not null, primary key</tt>
+                  # *name*:: <tt>string(50), not null</tt>
+                  #--
+                  # == Schema Information End
+                  #++
+                EOS
+              end
+
+              it 'returns schema info in RDoc format' do
+                is_expected.to eq(expected_result)
+              end
+            end
+
+            context 'when option "format_markdown" is true' do
+              context 'when other option is not specified' do
+                subject do
+                  AnnotateModels.get_schema_info(klass, header, format_markdown: true)
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # == Schema Information
+                    #
+                    # Table name: `users`
+                    #
+                    # ### Columns
+                    #
+                    # Name        | Type               | Attributes
+                    # ----------- | ------------------ | ---------------------------
+                    # **`id`**    | `integer`          | `not null, primary key`
+                    # **`name`**  | `string(50)`       | `not null`
+                    #
+                  EOS
+                end
+
+                it 'returns schema info in Markdown format' do
+                  is_expected.to eq(expected_result)
+                end
+              end
+
+              context 'when option "show_indexes" is true' do
+                subject do
+                  AnnotateModels.get_schema_info(klass, header, format_markdown: true, show_indexes: true)
+                end
+
+                context 'when indexes are normal' do
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # == Schema Information
+                      #
+                      # Table name: `users`
+                      #
+                      # ### Columns
+                      #
+                      # Name        | Type               | Attributes
+                      # ----------- | ------------------ | ---------------------------
+                      # **`id`**    | `integer`          | `not null, primary key`
+                      # **`name`**  | `string(50)`       | `not null`
+                      #
+                      # ### Indexes
+                      #
+                      # * `index_rails_02e851e3b7`:
+                      #     * **`id`**
+                      # * `index_rails_02e851e3b8`:
+                      #     * **`foreign_thing_id`**
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information in Markdown format' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
+                context 'when one of indexes includes "unique" clause' do
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8',
+                                 columns: ['foreign_thing_id'],
+                                 unique: true)
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # == Schema Information
+                      #
+                      # Table name: `users`
+                      #
+                      # ### Columns
+                      #
+                      # Name        | Type               | Attributes
+                      # ----------- | ------------------ | ---------------------------
+                      # **`id`**    | `integer`          | `not null, primary key`
+                      # **`name`**  | `string(50)`       | `not null`
+                      #
+                      # ### Indexes
+                      #
+                      # * `index_rails_02e851e3b7`:
+                      #     * **`id`**
+                      # * `index_rails_02e851e3b8` (_unique_):
+                      #     * **`foreign_thing_id`**
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information in Markdown format' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
+                context 'when one of indexes includes orderd index key' do
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8',
+                                 columns: ['foreign_thing_id'],
+                                 orders: { 'foreign_thing_id' => :desc })
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # == Schema Information
+                      #
+                      # Table name: `users`
+                      #
+                      # ### Columns
+                      #
+                      # Name        | Type               | Attributes
+                      # ----------- | ------------------ | ---------------------------
+                      # **`id`**    | `integer`          | `not null, primary key`
+                      # **`name`**  | `string(50)`       | `not null`
+                      #
+                      # ### Indexes
+                      #
+                      # * `index_rails_02e851e3b7`:
+                      #     * **`id`**
+                      # * `index_rails_02e851e3b8`:
+                      #     * **`foreign_thing_id DESC`**
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information in Markdown format' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
+                context 'when one of indexes includes "where" clause and "unique" clause' do
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8',
+                                 columns: ['foreign_thing_id'],
+                                 unique: true,
+                                 where: 'name IS NOT NULL')
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # == Schema Information
+                      #
+                      # Table name: `users`
+                      #
+                      # ### Columns
+                      #
+                      # Name        | Type               | Attributes
+                      # ----------- | ------------------ | ---------------------------
+                      # **`id`**    | `integer`          | `not null, primary key`
+                      # **`name`**  | `string(50)`       | `not null`
+                      #
+                      # ### Indexes
+                      #
+                      # * `index_rails_02e851e3b7`:
+                      #     * **`id`**
+                      # * `index_rails_02e851e3b8` (_unique_ _where_ name IS NOT NULL):
+                      #     * **`foreign_thing_id`**
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information in Markdown format' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
+                context 'when one of indexes includes "using" clause other than "btree"' do
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b7', columns: ['id']),
+                      mock_index('index_rails_02e851e3b8',
+                                 columns: ['foreign_thing_id'],
+                                 using: 'hash')
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # == Schema Information
+                      #
+                      # Table name: `users`
+                      #
+                      # ### Columns
+                      #
+                      # Name        | Type               | Attributes
+                      # ----------- | ------------------ | ---------------------------
+                      # **`id`**    | `integer`          | `not null, primary key`
+                      # **`name`**  | `string(50)`       | `not null`
+                      #
+                      # ### Indexes
+                      #
+                      # * `index_rails_02e851e3b7`:
+                      #     * **`id`**
+                      # * `index_rails_02e851e3b8` (_using_ hash):
+                      #     * **`foreign_thing_id`**
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information in Markdown format' do
+                    is_expected.to eq expected_result
+                  end
+                end
+              end
+
+              context 'when option "show_foreign_keys" is true' do
+                subject do
+                  AnnotateModels.get_schema_info(klass, header, format_markdown: true, show_foreign_keys: true)
+                end
+
+                let :columns do
+                  [
+                    mock_column(:id, :integer),
+                    mock_column(:foreign_thing_id, :integer)
+                  ]
+                end
+
+                context 'when foreign_keys have option "on_delete" and "on_update"' do
+                  let :foreign_keys do
+                    [
+                      mock_foreign_key('fk_rails_02e851e3b7',
+                                       'foreign_thing_id',
+                                       'foreign_things',
+                                       'id',
+                                       on_delete: 'on_delete_value',
+                                       on_update: 'on_update_value')
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # == Schema Information
+                      #
+                      # Table name: `users`
+                      #
+                      # ### Columns
+                      #
+                      # Name                    | Type               | Attributes
+                      # ----------------------- | ------------------ | ---------------------------
+                      # **`id`**                | `integer`          | `not null, primary key`
+                      # **`foreign_thing_id`**  | `integer`          | `not null`
+                      #
+                      # ### Foreign Keys
+                      #
+                      # * `fk_rails_...` (_ON DELETE => on_delete_value ON UPDATE => on_update_value_):
+                      #     * **`foreign_thing_id => foreign_things.id`**
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with foreign_keys in Markdown format' do
+                    is_expected.to eq(expected_result)
+                  end
+                end
+              end
+            end
           end
         end
       end
     end
 
-    context 'when header is "== Schema Information"' do
-      let :header do
-        AnnotateModels::PREFIX
+    describe 'when option is present' do
+      let :klass do
+        mock_class(:users, :id, columns)
       end
 
-      context 'when the primary key is specified' do
-        context 'when the primary_key is :id' do
-          let :primary_key do
-            :id
+      subject do
+        AnnotateModels.get_schema_info(klass, header, options)
+      end
+
+      context 'when header is "Schema Info"' do
+        let :header do
+          'Schema Info'
+        end
+
+        context 'with options' do
+          context 'when "hide_limit_column_types" is specified in options' do
+            let :columns do
+              [
+                mock_column(:id, :integer, limit: 8),
+                mock_column(:active, :boolean, limit: 1),
+                mock_column(:name, :string, limit: 50),
+                mock_column(:notes, :text, limit: 55)
+              ]
+            end
+
+            context 'when "hide_limit_column_types" is blank string' do
+              let :options do
+                { hide_limit_column_types: '' }
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  id     :integer          not null, primary key
+                  #  active :boolean          not null
+                  #  name   :string(50)       not null
+                  #  notes  :text(55)         not null
+                  #
+                EOS
+              end
+
+              it 'works with option "hide_limit_column_types"' do
+                is_expected.to eq expected_result
+              end
+            end
+
+            context 'when "hide_limit_column_types" is "integer,boolean"' do
+              let :options do
+                { hide_limit_column_types: 'integer,boolean' }
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  id     :integer          not null, primary key
+                  #  active :boolean          not null
+                  #  name   :string(50)       not null
+                  #  notes  :text(55)         not null
+                  #
+                EOS
+              end
+
+              it 'works with option "hide_limit_column_types"' do
+                is_expected.to eq expected_result
+              end
+            end
+
+            context 'when "hide_limit_column_types" is "integer,boolean,string,text"' do
+              let :options do
+                { hide_limit_column_types: 'integer,boolean,string,text' }
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  id     :integer          not null, primary key
+                  #  active :boolean          not null
+                  #  name   :string           not null
+                  #  notes  :text             not null
+                  #
+                EOS
+              end
+
+              it 'works with option "hide_limit_column_types"' do
+                is_expected.to eq expected_result
+              end
+            end
           end
 
-          let :columns do
-            [
-              mock_column(:id, :integer),
-              mock_column(:name, :string, limit: 50)
-            ]
+          context 'when "hide_default_column_types" is specified in options' do
+            let :columns do
+              [
+                mock_column(:profile, :json, default: {}),
+                mock_column(:settings, :jsonb, default: {}),
+                mock_column(:parameters, :hstore, default: {})
+              ]
+            end
+
+            context 'when "hide_default_column_types" is blank string' do
+              let :options do
+                { hide_default_column_types: '' }
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  profile    :json             not null
+                  #  settings   :jsonb            not null
+                  #  parameters :hstore           not null
+                  #
+                EOS
+              end
+
+              it 'works with option "hide_default_column_types"' do
+                is_expected.to eq expected_result
+              end
+            end
+
+            context 'when "hide_default_column_types" is "skip"' do
+              let :options do
+                { hide_default_column_types: 'skip' }
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  profile    :json             default({}), not null
+                  #  settings   :jsonb            default({}), not null
+                  #  parameters :hstore           default({}), not null
+                  #
+                EOS
+              end
+
+              it 'works with option "hide_default_column_types"' do
+                is_expected.to eq expected_result
+              end
+            end
+
+            context 'when "hide_default_column_types" is "json"' do
+              let :options do
+                { hide_default_column_types: 'json' }
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  profile    :json             not null
+                  #  settings   :jsonb            default({}), not null
+                  #  parameters :hstore           default({}), not null
+                  #
+                EOS
+              end
+
+              it 'works with option "hide_limit_column_types"' do
+                is_expected.to eq expected_result
+              end
+            end
           end
 
-          context 'when option "format_rdoc" is true' do
-            subject do
-              AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true)
+          context 'when "classified_sort" is specified in options' do
+            let :columns do
+              [
+                mock_column(:active, :boolean, limit: 1),
+                mock_column(:name, :string, limit: 50),
+                mock_column(:notes, :text, limit: 55)
+              ]
+            end
+
+            context 'when "classified_sort" is "yes"' do
+              let :options do
+                { classified_sort: 'yes' }
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  active :boolean          not null
+                  #  name   :string(50)       not null
+                  #  notes  :text(55)         not null
+                  #
+                EOS
+              end
+
+              it 'works with option "classified_sort"' do
+                is_expected.to eq expected_result
+              end
+            end
+          end
+
+          context 'when "with_comment" is specified in options' do
+            context 'when "with_comment" is "yes"' do
+              let :options do
+                { with_comment: 'yes' }
+              end
+
+              context 'when columns have comments' do
+                let :columns do
+                  [
+                    mock_column(:id,         :integer, limit: 8,  comment: 'ID'),
+                    mock_column(:active,     :boolean, limit: 1,  comment: 'Active'),
+                    mock_column(:name,       :string,  limit: 50, comment: 'Name'),
+                    mock_column(:notes,      :text,    limit: 55, comment: 'Notes'),
+                    mock_column(:no_comment, :text,    limit: 20, comment: nil)
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id(ID)         :integer          not null, primary key
+                    #  active(Active) :boolean          not null
+                    #  name(Name)     :string(50)       not null
+                    #  notes(Notes)   :text(55)         not null
+                    #  no_comment     :text(20)         not null
+                    #
+                  EOS
+                end
+
+                it 'works with option "with_comment"' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when columns have multibyte comments' do
+                let :columns do
+                  [
+                    mock_column(:id,         :integer, limit: 8,  comment: 'ＩＤ'),
+                    mock_column(:active,     :boolean, limit: 1,  comment: 'ＡＣＴＩＶＥ'),
+                    mock_column(:name,       :string,  limit: 50, comment: 'ＮＡＭＥ'),
+                    mock_column(:notes,      :text,    limit: 55, comment: 'ＮＯＴＥＳ'),
+                    mock_column(:cyrillic,   :text,    limit: 30, comment: 'Кириллица'),
+                    mock_column(:japanese,   :text,    limit: 60, comment: '熊本大学　イタリア　宝島'),
+                    mock_column(:arabic,     :text,    limit: 20, comment: 'لغة'),
+                    mock_column(:no_comment, :text,    limit: 20, comment: nil),
+                    mock_column(:location,   :geometry_collection, limit: nil, comment: nil)
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id(ＩＤ)                           :integer          not null, primary key
+                    #  active(ＡＣＴＩＶＥ)               :boolean          not null
+                    #  name(ＮＡＭＥ)                     :string(50)       not null
+                    #  notes(ＮＯＴＥＳ)                  :text(55)         not null
+                    #  cyrillic(Кириллица)                :text(30)         not null
+                    #  japanese(熊本大学　イタリア　宝島) :text(60)         not null
+                    #  arabic(لغة)                        :text(20)         not null
+                    #  no_comment                         :text(20)         not null
+                    #  location                           :geometry_collect not null
+                    #
+                  EOS
+                end
+
+                it 'works with option "with_comment"' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when geometry columns are included' do
+                let :columns do
+                  [
+                    mock_column(:id,       :integer,  limit: 8),
+                    mock_column(:active,   :boolean,  default: false, null: false),
+                    mock_column(:geometry, :geometry,
+                                geometric_type: 'Geometry', srid: 4326,
+                                limit: { srid: 4326, type: 'geometry' }),
+                    mock_column(:location, :geography,
+                                geometric_type: 'Point', srid: 0,
+                                limit: { srid: 0, type: 'geometry' })
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id       :integer          not null, primary key
+                    #  active   :boolean          default(FALSE), not null
+                    #  geometry :geometry         not null, geometry, 4326
+                    #  location :geography        not null, point, 0
+                    #
+                  EOS
+                end
+
+                it 'works with option "with_comment"' do
+                  is_expected.to eq expected_result
+                end
+              end
+            end
+          end
+        end
+      end
+
+      context 'when header is "== Schema Information"' do
+        let :header do
+          AnnotateModels::PREFIX
+        end
+
+        context 'when "format_doc" and "with_comment" are specified in options' do
+          subject do
+            AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true, with_comment: true)
+          end
+
+          context 'when columns are normal' do
+            let :columns do
+              [
+                mock_column(:id, :integer, comment: 'ID'),
+                mock_column(:name, :string, limit: 50, comment: 'Name')
+              ]
             end
 
             let :expected_result do
@@ -831,8 +1470,8 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
                 #
                 # Table name: users
                 #
-                # *id*::   <tt>integer, not null, primary key</tt>
-                # *name*:: <tt>string(50), not null</tt>
+                # *id(ID)*::     <tt>integer, not null, primary key</tt>
+                # *name(Name)*:: <tt>string(50), not null</tt>
                 #--
                 # == Schema Information End
                 #++
@@ -840,281 +1479,71 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
             end
 
             it 'returns schema info in RDoc format' do
-              is_expected.to eq(expected_result)
+              is_expected.to eq expected_result
+            end
+          end
+        end
+
+        context 'when "format_markdown" and "with_comment" are specified in options' do
+          subject do
+            AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, with_comment: true)
+          end
+
+          context 'when columns have comments' do
+            let :columns do
+              [
+                mock_column(:id, :integer, comment: 'ID'),
+                mock_column(:name, :string, limit: 50, comment: 'Name')
+              ]
+            end
+
+            let :expected_result do
+              <<~EOS
+                # == Schema Information
+                #
+                # Table name: `users`
+                #
+                # ### Columns
+                #
+                # Name              | Type               | Attributes
+                # ----------------- | ------------------ | ---------------------------
+                # **`id(ID)`**      | `integer`          | `not null, primary key`
+                # **`name(Name)`**  | `string(50)`       | `not null`
+                #
+              EOS
+            end
+
+            it 'returns schema info in Markdown format' do
+              is_expected.to eq expected_result
             end
           end
 
-          context 'when option "format_markdown" is true' do
-            context 'when other option is not specified' do
-              subject do
-                AnnotateModels.get_schema_info(klass, header, format_markdown: true)
-              end
-
-              let :expected_result do
-                <<~EOS
-                  # == Schema Information
-                  #
-                  # Table name: `users`
-                  #
-                  # ### Columns
-                  #
-                  # Name        | Type               | Attributes
-                  # ----------- | ------------------ | ---------------------------
-                  # **`id`**    | `integer`          | `not null, primary key`
-                  # **`name`**  | `string(50)`       | `not null`
-                  #
-                EOS
-              end
-
-              it 'returns schema info in Markdown format' do
-                is_expected.to eq(expected_result)
-              end
+          context 'when columns have multibyte comments' do
+            let :columns do
+              [
+                mock_column(:id, :integer, comment: 'ＩＤ'),
+                mock_column(:name, :string, limit: 50, comment: 'ＮＡＭＥ')
+              ]
             end
 
-            context 'when option "show_indexes" is true' do
-              subject do
-                AnnotateModels.get_schema_info(klass, header, format_markdown: true, show_indexes: true)
-              end
-
-              context 'when indexes are normal' do
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # == Schema Information
-                    #
-                    # Table name: `users`
-                    #
-                    # ### Columns
-                    #
-                    # Name        | Type               | Attributes
-                    # ----------- | ------------------ | ---------------------------
-                    # **`id`**    | `integer`          | `not null, primary key`
-                    # **`name`**  | `string(50)`       | `not null`
-                    #
-                    # ### Indexes
-                    #
-                    # * `index_rails_02e851e3b7`:
-                    #     * **`id`**
-                    # * `index_rails_02e851e3b8`:
-                    #     * **`foreign_thing_id`**
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information in Markdown format' do
-                  is_expected.to eq expected_result
-                end
-              end
-
-              context 'when one of indexes includes "unique" clause' do
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8',
-                               columns: ['foreign_thing_id'],
-                               unique: true)
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # == Schema Information
-                    #
-                    # Table name: `users`
-                    #
-                    # ### Columns
-                    #
-                    # Name        | Type               | Attributes
-                    # ----------- | ------------------ | ---------------------------
-                    # **`id`**    | `integer`          | `not null, primary key`
-                    # **`name`**  | `string(50)`       | `not null`
-                    #
-                    # ### Indexes
-                    #
-                    # * `index_rails_02e851e3b7`:
-                    #     * **`id`**
-                    # * `index_rails_02e851e3b8` (_unique_):
-                    #     * **`foreign_thing_id`**
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information in Markdown format' do
-                  is_expected.to eq expected_result
-                end
-              end
-
-              context 'when one of indexes includes orderd index key' do
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8',
-                               columns: ['foreign_thing_id'],
-                               orders: { 'foreign_thing_id' => :desc })
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # == Schema Information
-                    #
-                    # Table name: `users`
-                    #
-                    # ### Columns
-                    #
-                    # Name        | Type               | Attributes
-                    # ----------- | ------------------ | ---------------------------
-                    # **`id`**    | `integer`          | `not null, primary key`
-                    # **`name`**  | `string(50)`       | `not null`
-                    #
-                    # ### Indexes
-                    #
-                    # * `index_rails_02e851e3b7`:
-                    #     * **`id`**
-                    # * `index_rails_02e851e3b8`:
-                    #     * **`foreign_thing_id DESC`**
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information in Markdown format' do
-                  is_expected.to eq expected_result
-                end
-              end
-
-              context 'when one of indexes includes "where" clause and "unique" clause' do
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8',
-                               columns: ['foreign_thing_id'],
-                               unique: true,
-                               where: 'name IS NOT NULL')
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # == Schema Information
-                    #
-                    # Table name: `users`
-                    #
-                    # ### Columns
-                    #
-                    # Name        | Type               | Attributes
-                    # ----------- | ------------------ | ---------------------------
-                    # **`id`**    | `integer`          | `not null, primary key`
-                    # **`name`**  | `string(50)`       | `not null`
-                    #
-                    # ### Indexes
-                    #
-                    # * `index_rails_02e851e3b7`:
-                    #     * **`id`**
-                    # * `index_rails_02e851e3b8` (_unique_ _where_ name IS NOT NULL):
-                    #     * **`foreign_thing_id`**
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information in Markdown format' do
-                  is_expected.to eq expected_result
-                end
-              end
-
-              context 'when one of indexes includes "using" clause other than "btree"' do
-                let :indexes do
-                  [
-                    mock_index('index_rails_02e851e3b7', columns: ['id']),
-                    mock_index('index_rails_02e851e3b8',
-                               columns: ['foreign_thing_id'],
-                               using: 'hash')
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # == Schema Information
-                    #
-                    # Table name: `users`
-                    #
-                    # ### Columns
-                    #
-                    # Name        | Type               | Attributes
-                    # ----------- | ------------------ | ---------------------------
-                    # **`id`**    | `integer`          | `not null, primary key`
-                    # **`name`**  | `string(50)`       | `not null`
-                    #
-                    # ### Indexes
-                    #
-                    # * `index_rails_02e851e3b7`:
-                    #     * **`id`**
-                    # * `index_rails_02e851e3b8` (_using_ hash):
-                    #     * **`foreign_thing_id`**
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with index information in Markdown format' do
-                  is_expected.to eq expected_result
-                end
-              end
+            let :expected_result do
+              <<~EOS
+                # == Schema Information
+                #
+                # Table name: `users`
+                #
+                # ### Columns
+                #
+                # Name                  | Type               | Attributes
+                # --------------------- | ------------------ | ---------------------------
+                # **`id(ＩＤ)`**        | `integer`          | `not null, primary key`
+                # **`name(ＮＡＭＥ)`**  | `string(50)`       | `not null`
+                #
+              EOS
             end
 
-            context 'when option "show_foreign_keys" is true' do
-              subject do
-                AnnotateModels.get_schema_info(klass, header, format_markdown: true, show_foreign_keys: true)
-              end
-
-              let :columns do
-                [
-                  mock_column(:id, :integer),
-                  mock_column(:foreign_thing_id, :integer)
-                ]
-              end
-
-              context 'when foreign_keys have option "on_delete" and "on_update"' do
-                let :foreign_keys do
-                  [
-                    mock_foreign_key('fk_rails_02e851e3b7',
-                                     'foreign_thing_id',
-                                     'foreign_things',
-                                     'id',
-                                     on_delete: 'on_delete_value',
-                                     on_update: 'on_update_value')
-                  ]
-                end
-
-                let :expected_result do
-                  <<~EOS
-                    # == Schema Information
-                    #
-                    # Table name: `users`
-                    #
-                    # ### Columns
-                    #
-                    # Name                    | Type               | Attributes
-                    # ----------------------- | ------------------ | ---------------------------
-                    # **`id`**                | `integer`          | `not null, primary key`
-                    # **`foreign_thing_id`**  | `integer`          | `not null`
-                    #
-                    # ### Foreign Keys
-                    #
-                    # * `fk_rails_...` (_ON DELETE => on_delete_value ON UPDATE => on_update_value_):
-                    #     * **`foreign_thing_id => foreign_things.id`**
-                    #
-                  EOS
-                end
-
-                it 'returns schema info with foreign_keys in Markdown format' do
-                  is_expected.to eq(expected_result)
-                end
-              end
+            it 'returns schema info in Markdown format' do
+              is_expected.to eq expected_result
             end
           end
         end
@@ -1206,433 +1635,6 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
 
         it 'returns an empty array' do
           expect(subject).to eq([])
-        end
-      end
-    end
-  end
-
-  describe '.get_schema_info' do
-    let :klass do
-      mock_class(:users, :id, columns)
-    end
-
-    subject do
-      AnnotateModels.get_schema_info(klass, header, options)
-    end
-
-    context 'when header is "Schema Info"' do
-      let :header do
-        'Schema Info'
-      end
-
-      context 'with options' do
-        context 'when "hide_limit_column_types" is specified in options' do
-          let :columns do
-            [
-              mock_column(:id, :integer, limit: 8),
-              mock_column(:active, :boolean, limit: 1),
-              mock_column(:name, :string, limit: 50),
-              mock_column(:notes, :text, limit: 55)
-            ]
-          end
-
-          context 'when "hide_limit_column_types" is blank string' do
-            let :options do
-              { hide_limit_column_types: '' }
-            end
-
-            let :expected_result do
-              <<~EOS
-                # Schema Info
-                #
-                # Table name: users
-                #
-                #  id     :integer          not null, primary key
-                #  active :boolean          not null
-                #  name   :string(50)       not null
-                #  notes  :text(55)         not null
-                #
-              EOS
-            end
-
-            it 'works with option "hide_limit_column_types"' do
-              is_expected.to eq expected_result
-            end
-          end
-
-          context 'when "hide_limit_column_types" is "integer,boolean"' do
-            let :options do
-              { hide_limit_column_types: 'integer,boolean' }
-            end
-
-            let :expected_result do
-              <<~EOS
-                # Schema Info
-                #
-                # Table name: users
-                #
-                #  id     :integer          not null, primary key
-                #  active :boolean          not null
-                #  name   :string(50)       not null
-                #  notes  :text(55)         not null
-                #
-              EOS
-            end
-
-            it 'works with option "hide_limit_column_types"' do
-              is_expected.to eq expected_result
-            end
-          end
-
-          context 'when "hide_limit_column_types" is "integer,boolean,string,text"' do
-            let :options do
-              { hide_limit_column_types: 'integer,boolean,string,text' }
-            end
-
-            let :expected_result do
-              <<~EOS
-                # Schema Info
-                #
-                # Table name: users
-                #
-                #  id     :integer          not null, primary key
-                #  active :boolean          not null
-                #  name   :string           not null
-                #  notes  :text             not null
-                #
-              EOS
-            end
-
-            it 'works with option "hide_limit_column_types"' do
-              is_expected.to eq expected_result
-            end
-          end
-        end
-
-        context 'when "hide_default_column_types" is specified in options' do
-          let :columns do
-            [
-              mock_column(:profile, :json, default: {}),
-              mock_column(:settings, :jsonb, default: {}),
-              mock_column(:parameters, :hstore, default: {})
-            ]
-          end
-
-          context 'when "hide_default_column_types" is blank string' do
-            let :options do
-              { hide_default_column_types: '' }
-            end
-
-            let :expected_result do
-              <<~EOS
-                # Schema Info
-                #
-                # Table name: users
-                #
-                #  profile    :json             not null
-                #  settings   :jsonb            not null
-                #  parameters :hstore           not null
-                #
-              EOS
-            end
-
-            it 'works with option "hide_default_column_types"' do
-              is_expected.to eq expected_result
-            end
-          end
-
-          context 'when "hide_default_column_types" is "skip"' do
-            let :options do
-              { hide_default_column_types: 'skip' }
-            end
-
-            let :expected_result do
-              <<~EOS
-                # Schema Info
-                #
-                # Table name: users
-                #
-                #  profile    :json             default({}), not null
-                #  settings   :jsonb            default({}), not null
-                #  parameters :hstore           default({}), not null
-                #
-              EOS
-            end
-
-            it 'works with option "hide_default_column_types"' do
-              is_expected.to eq expected_result
-            end
-          end
-
-          context 'when "hide_default_column_types" is "json"' do
-            let :options do
-              { hide_default_column_types: 'json' }
-            end
-
-            let :expected_result do
-              <<~EOS
-                # Schema Info
-                #
-                # Table name: users
-                #
-                #  profile    :json             not null
-                #  settings   :jsonb            default({}), not null
-                #  parameters :hstore           default({}), not null
-                #
-              EOS
-            end
-
-            it 'works with option "hide_limit_column_types"' do
-              is_expected.to eq expected_result
-            end
-          end
-        end
-
-        context 'when "classified_sort" is specified in options' do
-          let :columns do
-            [
-              mock_column(:active, :boolean, limit: 1),
-              mock_column(:name, :string, limit: 50),
-              mock_column(:notes, :text, limit: 55)
-            ]
-          end
-
-          context 'when "classified_sort" is "yes"' do
-            let :options do
-              { classified_sort: 'yes' }
-            end
-
-            let :expected_result do
-              <<~EOS
-                # Schema Info
-                #
-                # Table name: users
-                #
-                #  active :boolean          not null
-                #  name   :string(50)       not null
-                #  notes  :text(55)         not null
-                #
-              EOS
-            end
-
-            it 'works with option "classified_sort"' do
-              is_expected.to eq expected_result
-            end
-          end
-        end
-
-        context 'when "with_comment" is specified in options' do
-          context 'when "with_comment" is "yes"' do
-            let :options do
-              { with_comment: 'yes' }
-            end
-
-            context 'when columns have comments' do
-              let :columns do
-                [
-                  mock_column(:id,         :integer, limit: 8,  comment: 'ID'),
-                  mock_column(:active,     :boolean, limit: 1,  comment: 'Active'),
-                  mock_column(:name,       :string,  limit: 50, comment: 'Name'),
-                  mock_column(:notes,      :text,    limit: 55, comment: 'Notes'),
-                  mock_column(:no_comment, :text,    limit: 20, comment: nil)
-                ]
-              end
-
-              let :expected_result do
-                <<~EOS
-                  # Schema Info
-                  #
-                  # Table name: users
-                  #
-                  #  id(ID)         :integer          not null, primary key
-                  #  active(Active) :boolean          not null
-                  #  name(Name)     :string(50)       not null
-                  #  notes(Notes)   :text(55)         not null
-                  #  no_comment     :text(20)         not null
-                  #
-                EOS
-              end
-
-              it 'works with option "with_comment"' do
-                is_expected.to eq expected_result
-              end
-            end
-
-            context 'when columns have multibyte comments' do
-              let :columns do
-                [
-                  mock_column(:id,         :integer, limit: 8,  comment: 'ＩＤ'),
-                  mock_column(:active,     :boolean, limit: 1,  comment: 'ＡＣＴＩＶＥ'),
-                  mock_column(:name,       :string,  limit: 50, comment: 'ＮＡＭＥ'),
-                  mock_column(:notes,      :text,    limit: 55, comment: 'ＮＯＴＥＳ'),
-                  mock_column(:cyrillic,   :text,    limit: 30, comment: 'Кириллица'),
-                  mock_column(:japanese,   :text,    limit: 60, comment: '熊本大学　イタリア　宝島'),
-                  mock_column(:arabic,     :text,    limit: 20, comment: 'لغة'),
-                  mock_column(:no_comment, :text,    limit: 20, comment: nil),
-                  mock_column(:location,   :geometry_collection, limit: nil, comment: nil)
-                ]
-              end
-
-              let :expected_result do
-                <<~EOS
-                  # Schema Info
-                  #
-                  # Table name: users
-                  #
-                  #  id(ＩＤ)                           :integer          not null, primary key
-                  #  active(ＡＣＴＩＶＥ)               :boolean          not null
-                  #  name(ＮＡＭＥ)                     :string(50)       not null
-                  #  notes(ＮＯＴＥＳ)                  :text(55)         not null
-                  #  cyrillic(Кириллица)                :text(30)         not null
-                  #  japanese(熊本大学　イタリア　宝島) :text(60)         not null
-                  #  arabic(لغة)                        :text(20)         not null
-                  #  no_comment                         :text(20)         not null
-                  #  location                           :geometry_collect not null
-                  #
-                EOS
-              end
-
-              it 'works with option "with_comment"' do
-                is_expected.to eq expected_result
-              end
-            end
-
-            context 'when geometry columns are included' do
-              let :columns do
-                [
-                  mock_column(:id,       :integer,  limit: 8),
-                  mock_column(:active,   :boolean,  default: false, null: false),
-                  mock_column(:geometry, :geometry,
-                              geometric_type: 'Geometry', srid: 4326,
-                              limit: { srid: 4326, type: 'geometry' }),
-                  mock_column(:location, :geography,
-                              geometric_type: 'Point', srid: 0,
-                              limit: { srid: 0, type: 'geometry' })
-                ]
-              end
-
-              let :expected_result do
-                <<~EOS
-                  # Schema Info
-                  #
-                  # Table name: users
-                  #
-                  #  id       :integer          not null, primary key
-                  #  active   :boolean          default(FALSE), not null
-                  #  geometry :geometry         not null, geometry, 4326
-                  #  location :geography        not null, point, 0
-                  #
-                EOS
-              end
-
-              it 'works with option "with_comment"' do
-                is_expected.to eq expected_result
-              end
-            end
-          end
-        end
-      end
-    end
-
-    context 'when header is "== Schema Information"' do
-      let :header do
-        AnnotateModels::PREFIX
-      end
-
-      context 'when "format_doc" and "with_comment" are specified in options' do
-        subject do
-          AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true, with_comment: true)
-        end
-
-        context 'when columns are normal' do
-          let :columns do
-            [
-              mock_column(:id, :integer, comment: 'ID'),
-              mock_column(:name, :string, limit: 50, comment: 'Name')
-            ]
-          end
-
-          let :expected_result do
-            <<~EOS
-              # == Schema Information
-              #
-              # Table name: users
-              #
-              # *id(ID)*::     <tt>integer, not null, primary key</tt>
-              # *name(Name)*:: <tt>string(50), not null</tt>
-              #--
-              # == Schema Information End
-              #++
-            EOS
-          end
-
-          it 'returns schema info in RDoc format' do
-            is_expected.to eq expected_result
-          end
-        end
-      end
-
-      context 'when "format_markdown" and "with_comment" are specified in options' do
-        subject do
-          AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, with_comment: true)
-        end
-
-        context 'when columns have comments' do
-          let :columns do
-            [
-              mock_column(:id, :integer, comment: 'ID'),
-              mock_column(:name, :string, limit: 50, comment: 'Name')
-            ]
-          end
-
-          let :expected_result do
-            <<~EOS
-              # == Schema Information
-              #
-              # Table name: `users`
-              #
-              # ### Columns
-              #
-              # Name              | Type               | Attributes
-              # ----------------- | ------------------ | ---------------------------
-              # **`id(ID)`**      | `integer`          | `not null, primary key`
-              # **`name(Name)`**  | `string(50)`       | `not null`
-              #
-            EOS
-          end
-
-          it 'returns schema info in Markdown format' do
-            is_expected.to eq expected_result
-          end
-        end
-
-        context 'when columns have multibyte comments' do
-          let :columns do
-            [
-              mock_column(:id, :integer, comment: 'ＩＤ'),
-              mock_column(:name, :string, limit: 50, comment: 'ＮＡＭＥ')
-            ]
-          end
-
-          let :expected_result do
-            <<~EOS
-              # == Schema Information
-              #
-              # Table name: `users`
-              #
-              # ### Columns
-              #
-              # Name                  | Type               | Attributes
-              # --------------------- | ------------------ | ---------------------------
-              # **`id(ＩＤ)`**        | `integer`          | `not null, primary key`
-              # **`name(ＮＡＭＥ)`**  | `string(50)`       | `not null`
-              #
-            EOS
-          end
-
-          it 'returns schema info in Markdown format' do
-            is_expected.to eq expected_result
-          end
         end
       end
     end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2708,12 +2708,14 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
       allow(Foo).to receive(:table_exists?) { false }
     end
 
+    subject do
+      AnnotateModels.annotate_model_file([], 'foo.rb', nil, {})
+    end
+
     after { Object.send :remove_const, 'Foo' }
 
     it 'skips attempt to annotate if no table exists for model' do
-      annotate_model_file = AnnotateModels.annotate_model_file([], 'foo.rb', nil, {})
-
-      expect(annotate_model_file).to eq nil
+      is_expected.to eq nil
     end
   end
 end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -181,694 +181,945 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  it 'should get schema info with default options' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer, limit: 8),
-                         mock_column(:name, :string, limit: 50),
-                         mock_column(:notes, :text, limit: 55)
-                       ])
+  describe '.get_schema_info' do # rubocop:disable Metrics/BlockLength
+    subject do
+      AnnotateModels.get_schema_info(klass, header)
+    end
 
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id    :integer          not null, primary key
-#  name  :string(50)       not null
-#  notes :text(55)         not null
-#
-EOS
-  end
+    let :klass do
+      mock_class(:users, primary_key, columns, indexes, foreign_keys)
+    end
 
-  it 'should get schema info even if the primary key is not set' do
-    klass = mock_class(:users,
-                       nil,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:name, :string, limit: 50)
-                       ])
+    let :indexes do
+      []
+    end
 
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id   :integer          not null
-#  name :string(50)       not null
-#
-EOS
-  end
+    let :foreign_keys do
+      []
+    end
 
-  it 'should get schema info even if the primary key is array, if using composite_primary_keys' do
-    klass = mock_class(:users,
-                       [:a_id, :b_id],
-                       [
-                         mock_column(:a_id, :integer),
-                         mock_column(:b_id, :integer),
-                         mock_column(:name, :string, limit: 50)
-                       ])
+    context 'when header is "Schema Info"' do # rubocop:disable Metrics/BlockLength
+      let :header do
+        'Schema Info'
+      end
 
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  a_id :integer          not null, primary key
-#  b_id :integer          not null, primary key
-#  name :string(50)       not null
-#
-EOS
-  end
+      context 'when the primary key is not specified' do
+        let :primary_key do
+          nil
+        end
 
-  it 'should get schema info with enum type' do
-    klass = mock_class(:users,
-                       nil,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:name, :enum, limit: [:enum1, :enum2])
-                       ])
+        context 'when the columns are normal' do
+          let :columns do
+            [
+              mock_column(:id, :integer),
+              mock_column(:name, :string, limit: 50)
+            ]
+          end
 
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id   :integer          not null
-#  name :enum             not null, (enum1, enum2)
-#
-EOS
-  end
+          let :expected_result do
+            <<~EOS
+              # Schema Info
+              #
+              # Table name: users
+              #
+              #  id   :integer          not null
+              #  name :string(50)       not null
+              #
+            EOS
+          end
 
-  it 'should get schema info with unsigned' do
-    klass = mock_class(:users,
-                       nil,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:integer, :integer, unsigned?: true),
-                         mock_column(:bigint,  :integer, unsigned?: true, bigint?: true),
-                         mock_column(:bigint,  :bigint,  unsigned?: true),
-                         mock_column(:float,   :float,   unsigned?: true),
-                         mock_column(:decimal, :decimal, unsigned?: true, precision: 10, scale: 2),
-                       ])
+          it 'returns schema info' do
+            is_expected.to eq(expected_result)
+          end
+        end
 
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id      :integer          not null
-#  integer :integer          unsigned, not null
-#  bigint  :bigint           unsigned, not null
-#  bigint  :bigint           unsigned, not null
-#  float   :float            unsigned, not null
-#  decimal :decimal(10, 2)   unsigned, not null
-#
-EOS
-  end
+        context 'when an enum column exists' do
+          let :columns do
+            [
+              mock_column(:id, :integer),
+              mock_column(:name, :enum, limit: [:enum1, :enum2])
+            ]
+          end
 
-  it 'should get schema info for integer and boolean with default' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:size, :integer, default: 20),
-                         mock_column(:flag, :boolean, default: false)
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id   :integer          not null, primary key
-#  size :integer          default(20), not null
-#  flag :boolean          default(FALSE), not null
-#
-EOS
-  end
+          let :expected_result do
+            <<~EOS
+              # Schema Info
+              #
+              # Table name: users
+              #
+              #  id   :integer          not null
+              #  name :enum             not null, (enum1, enum2)
+              #
+            EOS
+          end
 
-  it 'sets correct default value for integer column when ActiveRecord::Enum is used' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:status, :integer, default: 0)
-                       ])
-    # column_defaults may be overritten when ActiveRecord::Enum is used, e.g:
-    # class User < ActiveRecord::Base
-    #   enum status: [ :disabled, :enabled ]
-    # end
-    allow(klass).to receive(:column_defaults).and_return('id' => nil, 'status' => 'disabled')
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id     :integer          not null, primary key
-#  status :integer          default(0), not null
-#
-EOS
-  end
+          it 'returns schema info' do
+            is_expected.to eq(expected_result)
+          end
+        end
 
-  it 'should get foreign key info' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ],
-                       [],
-                       [
-                         mock_foreign_key('fk_rails_cf2568e89e',
-                                          'foreign_thing_id',
-                                          'foreign_things'),
-                         mock_foreign_key('custom_fk_name',
-                                          'other_thing_id',
-                                          'other_things'),
-                         mock_foreign_key('fk_rails_a70234b26c',
-                                          'third_thing_id',
-                                          'third_things')
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-# Foreign Keys
-#
-#  custom_fk_name  (other_thing_id => other_things.id)
-#  fk_rails_...    (foreign_thing_id => foreign_things.id)
-#  fk_rails_...    (third_thing_id => third_things.id)
-#
-EOS
-  end
+        context 'when unsigned columns exist' do
+          let :columns do
+            [
+              mock_column(:id, :integer),
+              mock_column(:integer, :integer, unsigned?: true),
+              mock_column(:bigint,  :integer, unsigned?: true, bigint?: true),
+              mock_column(:bigint,  :bigint,  unsigned?: true),
+              mock_column(:float,   :float,   unsigned?: true),
+              mock_column(:decimal, :decimal, unsigned?: true, precision: 10, scale: 2),
+            ]
+          end
 
-  it 'should get complete foreign key info' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ],
-                       [],
-                       [
-                         mock_foreign_key('fk_rails_cf2568e89e',
-                                          'foreign_thing_id',
-                                          'foreign_things'),
-                         mock_foreign_key('custom_fk_name',
-                                          'other_thing_id',
-                                          'other_things'),
-                         mock_foreign_key('fk_rails_a70234b26c',
-                                          'third_thing_id',
-                                          'third_things')
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-# Foreign Keys
-#
-#  custom_fk_name       (other_thing_id => other_things.id)
-#  fk_rails_a70234b26c  (third_thing_id => third_things.id)
-#  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
-#
-    EOS
-  end
+          let :expected_result do
+            <<~EOS
+              # Schema Info
+              #
+              # Table name: users
+              #
+              #  id      :integer          not null
+              #  integer :integer          unsigned, not null
+              #  bigint  :bigint           unsigned, not null
+              #  bigint  :bigint           unsigned, not null
+              #  float   :float            unsigned, not null
+              #  decimal :decimal(10, 2)   unsigned, not null
+              #
+            EOS
+          end
 
-  it 'should get foreign key info if on_delete/on_update options present' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ],
-                       [],
-                       [
-                         mock_foreign_key('fk_rails_02e851e3b7',
-                                          'foreign_thing_id',
-                                          'foreign_things',
-                                          'id',
-                                          on_delete: 'on_delete_value',
-                                          on_update: 'on_update_value')
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-# Foreign Keys
-#
-#  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => on_delete_value ON UPDATE => on_update_value
-#
-EOS
-  end
+          it 'returns schema info' do
+            is_expected.to eq(expected_result)
+          end
+        end
+      end
 
-  it 'should get indexes keys' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ], [mock_index('index_rails_02e851e3b7', columns: ['id']),
-                       mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-# Indexes
-#
-#  index_rails_02e851e3b7  (id)
-#  index_rails_02e851e3b8  (foreign_thing_id)
-#
-EOS
-  end
+      context 'when the primary key is specified' do # rubocop:disable Metrics/BlockLength
+        context 'when the primary_key is :id' do # rubocop:disable Metrics/BlockLength
+          let :primary_key do
+            :id
+          end
 
-  it 'should get ordered indexes keys' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column("id", :integer),
-                         mock_column("firstname", :string),
-                         mock_column("surname", :string),
-                         mock_column("value", :string)
-                       ],
-                       [
-                         mock_index('index_rails_02e851e3b7', columns: ['id']),
-                         mock_index('index_rails_02e851e3b8',
-                                    columns: %w(firstname surname value),
-                                    orders: { 'surname' => :asc, 'value' => :desc })
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id        :integer          not null, primary key
-#  firstname :string           not null
-#  surname   :string           not null
-#  value     :string           not null
-#
-# Indexes
-#
-#  index_rails_02e851e3b7  (id)
-#  index_rails_02e851e3b8  (firstname,surname ASC,value DESC)
-#
-EOS
-  end
+          context 'when columns are normal' do
+            let :columns do
+              [
+                mock_column(:id, :integer, limit: 8),
+                mock_column(:name, :string, limit: 50),
+                mock_column(:notes, :text, limit: 55)
+              ]
+            end
 
-  it 'should get indexes keys with where clause' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column("id", :integer),
-                         mock_column("firstname", :string),
-                         mock_column("surname", :string),
-                         mock_column("value", :string)
-                       ],
-                       [
-                         mock_index('index_rails_02e851e3b7', columns: ['id']),
-                         mock_index('index_rails_02e851e3b8',
-                                    columns: %w(firstname surname),
-                                    where: 'value IS NOT NULL')
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id        :integer          not null, primary key
-#  firstname :string           not null
-#  surname   :string           not null
-#  value     :string           not null
-#
-# Indexes
-#
-#  index_rails_02e851e3b7  (id)
-#  index_rails_02e851e3b8  (firstname,surname) WHERE value IS NOT NULL
-#
-EOS
-  end
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  id    :integer          not null, primary key
+                #  name  :string(50)       not null
+                #  notes :text(55)         not null
+                #
+              EOS
+            end
 
-  it 'should get indexes keys with using clause other than btree' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column("id", :integer),
-                         mock_column("firstname", :string),
-                         mock_column("surname", :string),
-                         mock_column("value", :string)
-                       ],
-                       [
-                         mock_index('index_rails_02e851e3b7', columns: ['id']),
-                         mock_index('index_rails_02e851e3b8',
-                                    columns: %w(firstname surname),
-                                    using: 'hash')
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id        :integer          not null, primary key
-#  firstname :string           not null
-#  surname   :string           not null
-#  value     :string           not null
-#
-# Indexes
-#
-#  index_rails_02e851e3b7  (id)
-#  index_rails_02e851e3b8  (firstname,surname) USING hash
-#
-EOS
-  end
+            it 'returns schema info' do
+              is_expected.to eq(expected_result)
+            end
+          end
 
-  it 'should get simple indexes keys' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ],
-                       [
-                         mock_index('index_rails_02e851e3b7', columns: ['id']),
-                         mock_index('index_rails_02e851e3b8',
-                                    columns: ['foreign_thing_id'],
-                                    orders: { 'foreign_thing_id' => :desc })
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', simple_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-EOS
-  end
+          context 'when columns have default values' do
+            let :columns do
+              [
+                mock_column(:id, :integer),
+                mock_column(:size, :integer, default: 20),
+                mock_column(:flag, :boolean, default: false)
+              ]
+            end
 
-  it 'should get simple indexes keys if one is in string form' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column("id", :integer),
-                         mock_column("name", :string)
-                       ], [mock_index('index_rails_02e851e3b7', columns: ['id']),
-                       mock_index('index_rails_02e851e3b8', columns: 'LOWER(name)')])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', simple_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id   :integer          not null, primary key, indexed
-#  name :string           not null
-#
-EOS
-  end
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  id   :integer          not null, primary key
+                #  size :integer          default(20), not null
+                #  flag :boolean          default(FALSE), not null
+                #
+              EOS
+            end
 
-  it 'should not crash getting indexes keys' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ], [])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-EOS
-  end
+            it 'returns schema info with default values' do
+              is_expected.to eq(expected_result)
+            end
+          end
 
-  it 'should get schema info as RDoc' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:name, :string, limit: 50)
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: users
-#
-# *id*::   <tt>integer, not null, primary key</tt>
-# *name*:: <tt>string(50), not null</tt>
-#--
-# #{AnnotateModels::END_MARK}
-#++
-EOS
-  end
+          context 'when an integer column using ActiveRecord::Enum exists' do
+            let :columns do
+              [
+                mock_column(:id, :integer),
+                mock_column(:status, :integer, default: 0)
+              ]
+            end
 
-  it 'should get schema info as Markdown' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:name, :string, limit: 50)
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-EOS
-  end
+            before :each do
+              # column_defaults may be overritten when ActiveRecord::Enum is used, e.g:
+              # class User < ActiveRecord::Base
+              #   enum status: [ :disabled, :enabled ]
+              # end
+              allow(klass).to receive(:column_defaults).and_return('id' => nil, 'status' => 'disabled')
+            end
 
-  it 'should get schema info as Markdown with foreign keys' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ],
-                       [],
-                       [
-                         mock_foreign_key('fk_rails_02e851e3b7',
-                                          'foreign_thing_id',
-                                          'foreign_things',
-                                          'id',
-                                          on_delete: 'on_delete_value',
-                                          on_update: 'on_update_value')
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_foreign_keys: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name                    | Type               | Attributes
-# ----------------------- | ------------------ | ---------------------------
-# **`id`**                | `integer`          | `not null, primary key`
-# **`foreign_thing_id`**  | `integer`          | `not null`
-#
-# ### Foreign Keys
-#
-# * `fk_rails_...` (_ON DELETE => on_delete_value ON UPDATE => on_update_value_):
-#     * **`foreign_thing_id => foreign_things.id`**
-#
-EOS
-  end
+            let :expected_result do
+              <<~EOS
+                # Schema Info
+                #
+                # Table name: users
+                #
+                #  id     :integer          not null, primary key
+                #  status :integer          default(0), not null
+                #
+              EOS
+            end
 
-  it 'should get schema info as Markdown with indexes' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:name, :string, limit: 50)
-                       ],
-                       [
-                         mock_index('index_rails_02e851e3b7', columns: ['id']),
-                         mock_index('index_rails_02e851e3b8',
-                                    columns: ['foreign_thing_id'])
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-# ### Indexes
-#
-# * `index_rails_02e851e3b7`:
-#     * **`id`**
-# * `index_rails_02e851e3b8`:
-#     * **`foreign_thing_id`**
-#
-EOS
-  end
+            it 'returns schema info with default values' do
+              is_expected.to eq(expected_result)
+            end
+          end
 
-  it 'should get schema info as Markdown with unique indexes' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:name, :string, limit: 50)
-                       ],
-                       [
-                         mock_index('index_rails_02e851e3b7', columns: ['id']),
-                         mock_index('index_rails_02e851e3b8',
-                                    columns: ['foreign_thing_id'],
-                                    unique: true)
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-# ### Indexes
-#
-# * `index_rails_02e851e3b7`:
-#     * **`id`**
-# * `index_rails_02e851e3b8` (_unique_):
-#     * **`foreign_thing_id`**
-#
-EOS
-  end
+          context 'when indexes exist' do
+            context 'when option "show_indexes" is true' do
+              subject do
+                AnnotateModels.get_schema_info(klass, header, show_indexes: true)
+              end
 
-  it 'should get schema info as Markdown with ordered indexes' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:name, :string, limit: 50)
-                       ],
-                       [
-                         mock_index('index_rails_02e851e3b7', columns: ['id']),
-                         mock_index('index_rails_02e851e3b8',
-                                    columns: ['foreign_thing_id'],
-                                    orders: { 'foreign_thing_id' => :desc })
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-# ### Indexes
-#
-# * `index_rails_02e851e3b7`:
-#     * **`id`**
-# * `index_rails_02e851e3b8`:
-#     * **`foreign_thing_id DESC`**
-#
-EOS
-  end
+              context 'when indexes are normal' do
+                let :columns do
+                  [
+                    mock_column(:id, :integer),
+                    mock_column(:foreign_thing_id, :integer)
+                  ]
+                end
 
-  it 'should get schema info as Markdown with indexes with WHERE clause' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:name, :string, limit: 50)
-                       ],
-                       [
-                         mock_index('index_rails_02e851e3b7', columns: ['id']),
-                         mock_index('index_rails_02e851e3b8',
-                                    columns: ['foreign_thing_id'],
-                                    unique: true,
-                                    where: 'name IS NOT NULL')
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-# ### Indexes
-#
-# * `index_rails_02e851e3b7`:
-#     * **`id`**
-# * `index_rails_02e851e3b8` (_unique_ _where_ name IS NOT NULL):
-#     * **`foreign_thing_id`**
-#
-EOS
-  end
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
+                  ]
+                end
 
-  it 'should get schema info as Markdown with indexes with using clause other than btree' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:name, :string, limit: 50)
-                       ],
-                       [
-                         mock_index('index_rails_02e851e3b7', columns: ['id']),
-                         mock_index('index_rails_02e851e3b8',
-                                    columns: ['foreign_thing_id'],
-                                    using: 'hash')
-                       ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-# ### Indexes
-#
-# * `index_rails_02e851e3b7`:
-#     * **`id`**
-# * `index_rails_02e851e3b8` (_using_ hash):
-#     * **`foreign_thing_id`**
-#
-EOS
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id               :integer          not null, primary key
+                    #  foreign_thing_id :integer          not null
+                    #
+                    # Indexes
+                    #
+                    #  index_rails_02e851e3b7  (id)
+                    #  index_rails_02e851e3b8  (foreign_thing_id)
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when one of indexes includes orderd index key' do
+                let :columns do
+                  [
+                    mock_column("id", :integer),
+                    mock_column("firstname", :string),
+                    mock_column("surname", :string),
+                    mock_column("value", :string)
+                  ]
+                end
+
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: %w(firstname surname value),
+                               orders: { 'surname' => :asc, 'value' => :desc })
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id        :integer          not null, primary key
+                    #  firstname :string           not null
+                    #  surname   :string           not null
+                    #  value     :string           not null
+                    #
+                    # Indexes
+                    #
+                    #  index_rails_02e851e3b7  (id)
+                    #  index_rails_02e851e3b8  (firstname,surname ASC,value DESC)
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when one of indexes includes "where" clause' do
+                let :columns do
+                  [
+                    mock_column("id", :integer),
+                    mock_column("firstname", :string),
+                    mock_column("surname", :string),
+                    mock_column("value", :string)
+                  ]
+                end
+
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: %w(firstname surname),
+                               where: 'value IS NOT NULL')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id        :integer          not null, primary key
+                    #  firstname :string           not null
+                    #  surname   :string           not null
+                    #  value     :string           not null
+                    #
+                    # Indexes
+                    #
+                    #  index_rails_02e851e3b7  (id)
+                    #  index_rails_02e851e3b8  (firstname,surname) WHERE value IS NOT NULL
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when one of indexes includes "using" clause other than "btree"' do
+                let :columns do
+                  [
+                    mock_column("id", :integer),
+                    mock_column("firstname", :string),
+                    mock_column("surname", :string),
+                    mock_column("value", :string)
+                  ]
+                end
+
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: %w(firstname surname),
+                               using: 'hash')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id        :integer          not null, primary key
+                    #  firstname :string           not null
+                    #  surname   :string           not null
+                    #  value     :string           not null
+                    #
+                    # Indexes
+                    #
+                    #  index_rails_02e851e3b7  (id)
+                    #  index_rails_02e851e3b8  (firstname,surname) USING hash
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when index is not defined' do
+                let :columns do
+                  [
+                    mock_column(:id, :integer),
+                    mock_column(:foreign_thing_id, :integer)
+                  ]
+                end
+
+                let :indexes do
+                  []
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id               :integer          not null, primary key
+                    #  foreign_thing_id :integer          not null
+                    #
+                  EOS
+                end
+
+                it 'returns schema info without index information' do
+                  is_expected.to eq expected_result
+                end
+              end
+            end
+
+            context 'when option "simple_indexes" is true' do
+              subject do
+                AnnotateModels.get_schema_info(klass, header, simple_indexes: true)
+              end
+
+              context 'when one of indexes is in string form' do
+                let :columns do
+                  [
+                    mock_column("id", :integer),
+                    mock_column("name", :string)
+                  ]
+                end
+
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8', columns: 'LOWER(name)')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id   :integer          not null, primary key, indexed
+                    #  name :string           not null
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when one of indexes includes "orders" clause' do # TODO
+                let :columns do
+                  [
+                    mock_column(:id, :integer),
+                    mock_column(:foreign_thing_id, :integer)
+                  ]
+                end
+
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: ['foreign_thing_id'],
+                               orders: { 'foreign_thing_id' => :desc })
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id               :integer          not null, primary key
+                    #  foreign_thing_id :integer          not null
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
+                end
+              end
+            end
+          end
+
+          context 'when foreign keys exist' do
+            let :columns do
+              [
+                mock_column(:id, :integer),
+                mock_column(:foreign_thing_id, :integer)
+              ]
+            end
+
+            let :foreign_keys do
+              [
+                mock_foreign_key('fk_rails_cf2568e89e', 'foreign_thing_id', 'foreign_things'),
+                mock_foreign_key('custom_fk_name', 'other_thing_id', 'other_things'),
+                mock_foreign_key('fk_rails_a70234b26c', 'third_thing_id', 'third_things')
+              ]
+            end
+
+            context 'when option "show_foreign_keys" is specified' do
+              subject do
+                AnnotateModels.get_schema_info(klass, header, show_foreign_keys: true)
+              end
+
+              context 'when foreign_keys does not have option' do
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id               :integer          not null, primary key
+                    #  foreign_thing_id :integer          not null
+                    #
+                    # Foreign Keys
+                    #
+                    #  custom_fk_name  (other_thing_id => other_things.id)
+                    #  fk_rails_...    (foreign_thing_id => foreign_things.id)
+                    #  fk_rails_...    (third_thing_id => third_things.id)
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with foreign keys' do
+                  is_expected.to eq(expected_result)
+                end
+              end
+
+              context 'when foreign_keys have option "on_delete" and "on_update"' do
+                let :foreign_keys do
+                  [
+                    mock_foreign_key('fk_rails_02e851e3b7',
+                                     'foreign_thing_id',
+                                     'foreign_things',
+                                     'id',
+                                     on_delete: 'on_delete_value',
+                                     on_update: 'on_update_value')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # Schema Info
+                    #
+                    # Table name: users
+                    #
+                    #  id               :integer          not null, primary key
+                    #  foreign_thing_id :integer          not null
+                    #
+                    # Foreign Keys
+                    #
+                    #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => on_delete_value ON UPDATE => on_update_value
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with foreign keys' do
+                  is_expected.to eq(expected_result)
+                end
+              end
+            end
+
+            context 'when option "show_foreign_keys" and "show_complete_foreign_keys" are specified' do
+              subject do
+                AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # Schema Info
+                  #
+                  # Table name: users
+                  #
+                  #  id               :integer          not null, primary key
+                  #  foreign_thing_id :integer          not null
+                  #
+                  # Foreign Keys
+                  #
+                  #  custom_fk_name       (other_thing_id => other_things.id)
+                  #  fk_rails_a70234b26c  (third_thing_id => third_things.id)
+                  #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
+                  #
+                EOS
+              end
+
+              it 'returns schema info with foreign keys' do
+                is_expected.to eq(expected_result)
+              end
+            end
+          end
+        end
+
+        context 'when the primary key is an array (using composite_primary_keys)' do
+          let :primary_key do
+            [:a_id, :b_id]
+          end
+
+          let :columns do
+            [
+              mock_column(:a_id, :integer),
+              mock_column(:b_id, :integer),
+              mock_column(:name, :string, limit: 50)
+            ]
+          end
+
+          let :expected_result do
+            <<~EOS
+              # Schema Info
+              #
+              # Table name: users
+              #
+              #  a_id :integer          not null, primary key
+              #  b_id :integer          not null, primary key
+              #  name :string(50)       not null
+              #
+            EOS
+          end
+
+          it 'returns schema info' do
+            is_expected.to eq(expected_result)
+          end
+        end
+      end
+    end
+
+    context 'when header is "== Schema Information"' do
+      let :header do
+        AnnotateModels::PREFIX
+      end
+
+      context 'when the primary key is specified' do
+        context 'when the primary_key is :id' do
+          let :primary_key do
+            :id
+          end
+
+          let :columns do
+            [
+              mock_column(:id, :integer),
+              mock_column(:name, :string, limit: 50)
+            ]
+          end
+
+          context 'when option "format_rdoc" is true' do
+            subject do
+              AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true)
+            end
+
+            let :expected_result do
+              <<~EOS
+                # == Schema Information
+                #
+                # Table name: users
+                #
+                # *id*::   <tt>integer, not null, primary key</tt>
+                # *name*:: <tt>string(50), not null</tt>
+                #--
+                # == Schema Information End
+                #++
+              EOS
+            end
+
+            it 'returns schema info in RDoc format' do
+              is_expected.to eq(expected_result)
+            end
+          end
+
+          context 'when option "format_markdown" is true' do
+            context 'when other option is not specified' do
+              subject do
+                AnnotateModels.get_schema_info(klass, header, format_markdown: true)
+              end
+
+              let :expected_result do
+                <<~EOS
+                  # == Schema Information
+                  #
+                  # Table name: `users`
+                  #
+                  # ### Columns
+                  #
+                  # Name        | Type               | Attributes
+                  # ----------- | ------------------ | ---------------------------
+                  # **`id`**    | `integer`          | `not null, primary key`
+                  # **`name`**  | `string(50)`       | `not null`
+                  #
+                EOS
+              end
+
+              it 'returns schema info in Markdown format' do
+                is_expected.to eq(expected_result)
+              end
+            end
+
+            context 'when option "show_indexes" is true' do
+              subject do
+                AnnotateModels.get_schema_info(klass, header, format_markdown: true, show_indexes: true)
+              end
+
+              context 'when indexes are normal' do
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # == Schema Information
+                    #
+                    # Table name: `users`
+                    #
+                    # ### Columns
+                    #
+                    # Name        | Type               | Attributes
+                    # ----------- | ------------------ | ---------------------------
+                    # **`id`**    | `integer`          | `not null, primary key`
+                    # **`name`**  | `string(50)`       | `not null`
+                    #
+                    # ### Indexes
+                    #
+                    # * `index_rails_02e851e3b7`:
+                    #     * **`id`**
+                    # * `index_rails_02e851e3b8`:
+                    #     * **`foreign_thing_id`**
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information in Markdown format' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when one of indexes includes "unique" clause' do
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: ['foreign_thing_id'],
+                               unique: true)
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # == Schema Information
+                    #
+                    # Table name: `users`
+                    #
+                    # ### Columns
+                    #
+                    # Name        | Type               | Attributes
+                    # ----------- | ------------------ | ---------------------------
+                    # **`id`**    | `integer`          | `not null, primary key`
+                    # **`name`**  | `string(50)`       | `not null`
+                    #
+                    # ### Indexes
+                    #
+                    # * `index_rails_02e851e3b7`:
+                    #     * **`id`**
+                    # * `index_rails_02e851e3b8` (_unique_):
+                    #     * **`foreign_thing_id`**
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information in Markdown format' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when one of indexes includes orderd index key' do
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: ['foreign_thing_id'],
+                               orders: { 'foreign_thing_id' => :desc })
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # == Schema Information
+                    #
+                    # Table name: `users`
+                    #
+                    # ### Columns
+                    #
+                    # Name        | Type               | Attributes
+                    # ----------- | ------------------ | ---------------------------
+                    # **`id`**    | `integer`          | `not null, primary key`
+                    # **`name`**  | `string(50)`       | `not null`
+                    #
+                    # ### Indexes
+                    #
+                    # * `index_rails_02e851e3b7`:
+                    #     * **`id`**
+                    # * `index_rails_02e851e3b8`:
+                    #     * **`foreign_thing_id DESC`**
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information in Markdown format' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when one of indexes includes "where" clause and "unique" clause' do
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: ['foreign_thing_id'],
+                               unique: true,
+                               where: 'name IS NOT NULL')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # == Schema Information
+                    #
+                    # Table name: `users`
+                    #
+                    # ### Columns
+                    #
+                    # Name        | Type               | Attributes
+                    # ----------- | ------------------ | ---------------------------
+                    # **`id`**    | `integer`          | `not null, primary key`
+                    # **`name`**  | `string(50)`       | `not null`
+                    #
+                    # ### Indexes
+                    #
+                    # * `index_rails_02e851e3b7`:
+                    #     * **`id`**
+                    # * `index_rails_02e851e3b8` (_unique_ _where_ name IS NOT NULL):
+                    #     * **`foreign_thing_id`**
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information in Markdown format' do
+                  is_expected.to eq expected_result
+                end
+              end
+
+              context 'when one of indexes includes "using" clause other than "btree"' do
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: ['foreign_thing_id'],
+                               using: 'hash')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # == Schema Information
+                    #
+                    # Table name: `users`
+                    #
+                    # ### Columns
+                    #
+                    # Name        | Type               | Attributes
+                    # ----------- | ------------------ | ---------------------------
+                    # **`id`**    | `integer`          | `not null, primary key`
+                    # **`name`**  | `string(50)`       | `not null`
+                    #
+                    # ### Indexes
+                    #
+                    # * `index_rails_02e851e3b7`:
+                    #     * **`id`**
+                    # * `index_rails_02e851e3b8` (_using_ hash):
+                    #     * **`foreign_thing_id`**
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with index information in Markdown format' do
+                  is_expected.to eq expected_result
+                end
+              end
+            end
+
+            context 'when option "show_foreign_keys" is true' do
+              subject do
+                AnnotateModels.get_schema_info(klass, header, format_markdown: true, show_foreign_keys: true)
+              end
+
+              let :columns do
+                [
+                  mock_column(:id, :integer),
+                  mock_column(:foreign_thing_id, :integer)
+                ]
+              end
+
+              context 'when foreign_keys have option "on_delete" and "on_update"' do
+                let :foreign_keys do
+                  [
+                    mock_foreign_key('fk_rails_02e851e3b7',
+                                     'foreign_thing_id',
+                                     'foreign_things',
+                                     'id',
+                                     on_delete: 'on_delete_value',
+                                     on_update: 'on_update_value')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
+                    # == Schema Information
+                    #
+                    # Table name: `users`
+                    #
+                    # ### Columns
+                    #
+                    # Name                    | Type               | Attributes
+                    # ----------------------- | ------------------ | ---------------------------
+                    # **`id`**                | `integer`          | `not null, primary key`
+                    # **`foreign_thing_id`**  | `integer`          | `not null`
+                    #
+                    # ### Foreign Keys
+                    #
+                    # * `fk_rails_...` (_ON DELETE => on_delete_value ON UPDATE => on_update_value_):
+                    #     * **`foreign_thing_id => foreign_things.id`**
+                    #
+                  EOS
+                end
+
+                it 'returns schema info with foreign_keys in Markdown format' do
+                  is_expected.to eq(expected_result)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
   describe '.set_defaults' do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1942,187 +1942,236 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  describe '#remove_annotation_of_file' do
-    require 'tmpdir'
-
-    def create(file, body = 'hi')
-      path = File.join(@dir, file)
-      File.open(path, 'w') do |f|
-        f.puts(body)
-      end
-
-      path
+  describe '.remove_annotation_of_file' do
+    subject do
+      AnnotateModels.remove_annotation_of_file(path)
     end
 
-    def content(path)
+    let :tmpdir do
+      require 'tmpdir'
+      Dir.mktmpdir('annotate_models')
+    end
+
+    let :path do
+      File.join(tmpdir, filename).tap do |path|
+        File.open(path, 'w') do |f|
+          f.puts(file_content)
+        end
+      end
+    end
+
+    let :file_content_after_removal do
+      subject
       File.read(path)
     end
 
-    before :each do
-      @dir = Dir.mktmpdir 'annotate_models'
-    end
-
-    it 'should remove before annotate' do
-      path = create 'before.rb', <<-EOS
-# == Schema Information
-#
-# Table name: foo
-#
-#  id                  :integer         not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#
-
-class Foo < ActiveRecord::Base
-end
-      EOS
-
-      AnnotateModels.remove_annotation_of_file(path)
-
-      expect(content(path)).to eq <<-EOS
-class Foo < ActiveRecord::Base
-end
+    let :expected_result do
+      <<~EOS
+        class Foo < ActiveRecord::Base
+        end
       EOS
     end
 
-    it 'should remove annotate if CRLF is used for line breaks' do
-      path = create 'before.rb', <<-EOS
-# == Schema Information
-#
-# Table name: foo\r\n#
-#  id                  :integer         not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#
-\r\n
-class Foo < ActiveRecord::Base
-end
-      EOS
+    context 'when annotation is before main content' do
+      let :filename do
+        'before.rb'
+      end
 
-      AnnotateModels.remove_annotation_of_file(path)
+      let :file_content do
+        <<~EOS
+          # == Schema Information
+          #
+          # Table name: foo
+          #
+          #  id                  :integer         not null, primary key
+          #  created_at          :datetime
+          #  updated_at          :datetime
+          #
 
-      expect(content(path)).to eq <<-EOS
-class Foo < ActiveRecord::Base
-end
-      EOS
+          class Foo < ActiveRecord::Base
+          end
+        EOS
+      end
+
+      it 'removes annotation' do
+        expect(file_content_after_removal).to eq expected_result
+      end
     end
 
-    it 'should remove after annotate' do
-      path = create 'after.rb', <<-EOS
-class Foo < ActiveRecord::Base
-end
+    context 'when annotation is before main content and CRLF is used for line breaks' do
+      let :filename do
+        'before.rb'
+      end
 
-# == Schema Information
-#
-# Table name: foo
-#
-#  id                  :integer         not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#
+      let :file_content do
+        <<~EOS
+          # == Schema Information
+          #
+          # Table name: foo\r\n#
+          #  id                  :integer         not null, primary key
+          #  created_at          :datetime
+          #  updated_at          :datetime
+          #
+          \r\n
+          class Foo < ActiveRecord::Base
+          end
+        EOS
+      end
 
-      EOS
-
-      AnnotateModels.remove_annotation_of_file(path)
-
-      expect(content(path)).to eq <<-EOS
-class Foo < ActiveRecord::Base
-end
-      EOS
+      it 'removes annotation' do
+        expect(file_content_after_removal).to eq expected_result
+      end
     end
 
-    it 'should remove opening wrapper' do
-      path = create 'opening_wrapper.rb', <<-EOS
-# wrapper
-# == Schema Information
-#
-# Table name: foo
-#
-#  id                  :integer         not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#
+    context 'when annotation is before main content and with opening wrapper' do
+      let :filename do
+        'opening_wrapper.rb'
+      end
 
-class Foo < ActiveRecord::Base
-end
-      EOS
+      let :file_content do
+        <<~EOS
+          # wrapper
+          # == Schema Information
+          #
+          # Table name: foo
+          #
+          #  id                  :integer         not null, primary key
+          #  created_at          :datetime
+          #  updated_at          :datetime
+          #
 
-      AnnotateModels.remove_annotation_of_file(path, wrapper_open: 'wrapper')
+          class Foo < ActiveRecord::Base
+          end
+        EOS
+      end
 
-      expect(content(path)).to eq <<-EOS
-class Foo < ActiveRecord::Base
-end
-      EOS
+      subject do
+        AnnotateModels.remove_annotation_of_file(path, wrapper_open: 'wrapper')
+      end
+
+      it 'removes annotation' do
+        expect(file_content_after_removal).to eq expected_result
+      end
     end
 
-    it 'should remove wrapper if CRLF is used for line breaks' do
-      path = create 'opening_wrapper.rb', <<-EOS
-# wrapper\r\n# == Schema Information
-#
-# Table name: foo
-#
-#  id                  :integer         not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#
+    context 'when annotation is before main content and with opening wrapper' do
+      let :filename do
+        'opening_wrapper.rb'
+      end
 
-class Foo < ActiveRecord::Base
-end
-      EOS
+      let :file_content do
+        <<~EOS
+          # wrapper\r\n# == Schema Information
+          #
+          # Table name: foo
+          #
+          #  id                  :integer         not null, primary key
+          #  created_at          :datetime
+          #  updated_at          :datetime
+          #
 
-      AnnotateModels.remove_annotation_of_file(path, wrapper_open: 'wrapper')
+          class Foo < ActiveRecord::Base
+          end
+        EOS
+      end
 
-      expect(content(path)).to eq <<-EOS
-class Foo < ActiveRecord::Base
-end
-      EOS
+      subject do
+        AnnotateModels.remove_annotation_of_file(path, wrapper_open: 'wrapper')
+      end
+
+      it 'removes annotation' do
+        expect(file_content_after_removal).to eq expected_result
+      end
     end
 
-    it 'should remove closing wrapper' do
-      path = create 'closing_wrapper.rb', <<-EOS
-class Foo < ActiveRecord::Base
-end
+    context 'when annotation is after main content' do
+      let :filename do
+        'after.rb'
+      end
 
-# == Schema Information
-#
-# Table name: foo
-#
-#  id                  :integer         not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#
-# wrapper
+      let :file_content do
+        <<~EOS
+          class Foo < ActiveRecord::Base
+          end
 
-      EOS
+          # == Schema Information
+          #
+          # Table name: foo
+          #
+          #  id                  :integer         not null, primary key
+          #  created_at          :datetime
+          #  updated_at          :datetime
+          #
 
-      AnnotateModels.remove_annotation_of_file(path, wrapper_close: 'wrapper')
+        EOS
+      end
 
-      expect(content(path)).to eq <<-EOS
-class Foo < ActiveRecord::Base
-end
-      EOS
+      it 'removes annotation' do
+        expect(file_content_after_removal).to eq expected_result
+      end
     end
 
-    it 'does not change file with #SkipSchemaAnnotations' do
-      content = <<-EOS
-# -*- SkipSchemaAnnotations
-# == Schema Information
-#
-# Table name: foo
-#
-#  id                  :integer         not null, primary key
-#  created_at          :datetime
-#  updated_at          :datetime
-#
+    context 'when annotation is after main content and with closing wrapper' do
+      let :filename do
+        'closing_wrapper.rb'
+      end
 
-class Foo < ActiveRecord::Base
-end
-      EOS
+      let :file_content do
+        <<~EOS
+          class Foo < ActiveRecord::Base
+          end
 
-      path = create 'skip.rb', content
+          # == Schema Information
+          #
+          # Table name: foo
+          #
+          #  id                  :integer         not null, primary key
+          #  created_at          :datetime
+          #  updated_at          :datetime
+          #
+          # wrapper
 
-      AnnotateModels.remove_annotation_of_file(path)
-      expect(content(path)).to eq(content)
+        EOS
+      end
+
+      subject do
+        AnnotateModels.remove_annotation_of_file(path, wrapper_close: 'wrapper')
+      end
+
+      it 'removes annotation' do
+        expect(file_content_after_removal).to eq expected_result
+      end
+    end
+
+    context 'when annotation is before main content and with comment "-*- SkipSchemaAnnotations"' do
+      let :filename do
+        'skip.rb'
+      end
+
+      let :file_content do
+        <<~EOS
+          # -*- SkipSchemaAnnotations
+          # == Schema Information
+          #
+          # Table name: foo
+          #
+          #  id                  :integer         not null, primary key
+          #  created_at          :datetime
+          #  updated_at          :datetime
+          #
+
+          class Foo < ActiveRecord::Base
+          end
+        EOS
+      end
+
+      let :expected_result do
+        file_content
+      end
+
+      it 'does not remove annotation' do
+        expect(file_content_after_removal).to eq expected_result
+      end
     end
   end
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2234,9 +2234,9 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
   describe 'annotating a file' do
     before do
       @model_dir = Dir.mktmpdir('annotate_models')
-      (@model_file_name, @file_content) = write_model 'user.rb', <<-EOS
-class User < ActiveRecord::Base
-end
+      (@model_file_name, @file_content) = write_model 'user.rb', <<~EOS
+        class User < ActiveRecord::Base
+        end
       EOS
 
       @klass = mock_class(:users,
@@ -2387,9 +2387,9 @@ end
     end
 
     it 'works with namespaced models (i.e. models inside modules/subdirectories)' do
-      (model_file_name, file_content) = write_model 'foo/user.rb', <<-EOS
-class Foo::User < ActiveRecord::Base
-end
+      (model_file_name, file_content) = write_model 'foo/user.rb', <<~EOS
+        class Foo::User < ActiveRecord::Base
+        end
       EOS
 
       klass = mock_class(:'foo_users',
@@ -2405,10 +2405,10 @@ end
 
     it 'should not touch magic comments' do
       MAGIC_COMMENTS.each do |magic_comment|
-        write_model 'user.rb', <<-EOS
-#{magic_comment}
-class User < ActiveRecord::Base
-end
+        write_model 'user.rb', <<~EOS
+          #{magic_comment}
+          class User < ActiveRecord::Base
+          end
         EOS
 
         annotate_one_file position: :before
@@ -2462,7 +2462,7 @@ end
       before do
         allow(AnnotateModels).to receive(:get_loaded_model_by_path).with('user').and_return(nil)
 
-        write_model('user.rb', <<-EOS)
+        write_model('user.rb', <<~EOS)
           class User < ActiveRecord::Base
             raise "oops"
           end
@@ -2492,7 +2492,7 @@ end
       before do
         allow(AnnotateModels).to receive(:get_loaded_model_by_path).with('user').and_return(nil)
 
-        write_model('user.rb', <<-EOS)
+        write_model('user.rb', <<~EOS)
           class User < ActiveRecord::Base
             raise "oops"
           end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1861,50 +1861,59 @@ end
     end
   end
 
-  describe '#resolve_filename' do
-    it 'should return the test path for a model' do
-      filename_template = 'test/unit/%MODEL_NAME%_test.rb'
-      model_name        = 'example_model'
-      table_name        = 'example_models'
-
-      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
-      expect(filename). to eq 'test/unit/example_model_test.rb'
+  describe '.resolve_filename' do
+    subject do
+      AnnotateModels.resolve_filename(filename_template, model_name, table_name)
     end
 
-    it 'should return the additional glob' do
-      filename_template = '/foo/bar/%MODEL_NAME%/testing.rb'
-      model_name        = 'example_model'
-      table_name        = 'example_models'
+    context 'When model_name is "example_model" and table_name is "example_models"' do
+      let(:model_name) { 'example_model' }
+      let(:table_name) { 'example_models' }
 
-      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
-      expect(filename). to eq '/foo/bar/example_model/testing.rb'
+      context "when filename_template is 'test/unit/%MODEL_NAME%_test.rb'" do
+        let(:filename_template) { 'test/unit/%MODEL_NAME%_test.rb' }
+
+        it 'returns the test path for a model' do
+          is_expected.to eq 'test/unit/example_model_test.rb'
+        end
+      end
+
+      context "when filename_template is '/foo/bar/%MODEL_NAME%/testing.rb'" do
+        let(:filename_template) { '/foo/bar/%MODEL_NAME%/testing.rb' }
+
+        it 'returns the additional glob' do
+          is_expected.to eq '/foo/bar/example_model/testing.rb'
+        end
+      end
+
+      context "when filename_template is '/foo/bar/%PLURALIZED_MODEL_NAME%/testing.rb'" do
+        let(:filename_template) { '/foo/bar/%PLURALIZED_MODEL_NAME%/testing.rb' }
+
+        it 'returns the additional glob' do
+          is_expected.to eq '/foo/bar/example_models/testing.rb'
+        end
+      end
+
+      context "when filename_template is 'test/fixtures/%TABLE_NAME%.yml'" do
+        let(:filename_template) { 'test/fixtures/%TABLE_NAME%.yml' }
+
+        it 'returns the fixture path for a model' do
+          is_expected.to eq 'test/fixtures/example_models.yml'
+        end
+      end
     end
 
-    it 'should return the additional glob' do
-      filename_template = '/foo/bar/%PLURALIZED_MODEL_NAME%/testing.rb'
-      model_name        = 'example_model'
-      table_name        = 'example_models'
+    context 'When model_name is "parent/child" and table_name is "parent_children"' do
+      let(:model_name) { 'parent/child' }
+      let(:table_name) { 'parent_children' }
 
-      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
-      expect(filename). to eq '/foo/bar/example_models/testing.rb'
-    end
+      context "when filename_template is 'test/fixtures/%PLURALIZED_MODEL_NAME%.yml'" do
+        let(:filename_template) { 'test/fixtures/%PLURALIZED_MODEL_NAME%.yml' }
 
-    it 'should return the fixture path for a model' do
-      filename_template = 'test/fixtures/%TABLE_NAME%.yml'
-      model_name        = 'example_model'
-      table_name        = 'example_models'
-
-      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
-      expect(filename). to eq 'test/fixtures/example_models.yml'
-    end
-
-    it 'should return the fixture path for a nested model' do
-      filename_template = 'test/fixtures/%PLURALIZED_MODEL_NAME%.yml'
-      model_name        = 'parent/child'
-      table_name        = 'parent_children'
-
-      filename = AnnotateModels.resolve_filename(filename_template, model_name, table_name)
-      expect(filename). to eq 'test/fixtures/parent/children.yml'
+        it 'returns the fixture path for a nested model' do
+          is_expected.to eq 'test/fixtures/parent/children.yml'
+        end
+      end
     end
   end
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -857,14 +857,25 @@ EOS
 EOS
   end
 
-  describe '#set_defaults' do
-    it 'should default show_complete_foreign_keys to false' do
-      expect(Annotate::Helpers.true?(ENV['show_complete_foreign_keys'])).to be(false)
+  describe '.set_defaults' do
+    subject do
+      Annotate::Helpers.true?(ENV['show_complete_foreign_keys'])
     end
 
-    it 'should be able to set show_complete_foreign_keys to true' do
-      Annotate.set_defaults('show_complete_foreign_keys' => 'true')
-      expect(Annotate::Helpers.true?(ENV['show_complete_foreign_keys'])).to be(true)
+    context 'when default value of "show_complete_foreign_keys" is not set' do
+      it 'returns false' do
+        is_expected.to be(false)
+      end
+    end
+
+    context 'when default value of "show_complete_foreign_keys" is set' do
+      before do
+        Annotate.set_defaults('show_complete_foreign_keys' => 'true')
+      end
+
+      it 'returns true' do
+        is_expected.to be(true)
+      end
     end
 
     after :each do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -6,6 +6,20 @@ require 'active_support/core_ext/string'
 require 'files'
 
 describe AnnotateModels do # rubocop:disable Metrics/BlockLength
+  MAGIC_COMMENTS = [
+    '# encoding: UTF-8',
+    '# coding: UTF-8',
+    '# -*- coding: UTF-8 -*-',
+    '#encoding: utf-8',
+    '# encoding: utf-8',
+    '# -*- encoding : utf-8 -*-',
+    "# encoding: utf-8\n# frozen_string_literal: true",
+    "# frozen_string_literal: true\n# encoding: utf-8",
+    '# frozen_string_literal: true',
+    '#frozen_string_literal: false',
+    '# -*- frozen_string_literal : true -*-'
+  ].freeze
+
   def mock_index(name, params = {})
     double('IndexKeyDefinition',
            name:          name,
@@ -1955,22 +1969,6 @@ end
       Annotate::Constants::PATH_OPTIONS.each { |key| ENV[key.to_s] = '' }
     end
 
-    def magic_comments_list_each
-      [
-        '# encoding: UTF-8',
-        '# coding: UTF-8',
-        '# -*- coding: UTF-8 -*-',
-        '#encoding: utf-8',
-        '# encoding: utf-8',
-        '# -*- encoding : utf-8 -*-',
-        "# encoding: utf-8\n# frozen_string_literal: true",
-        "# frozen_string_literal: true\n# encoding: utf-8",
-        '# frozen_string_literal: true',
-        '#frozen_string_literal: false',
-        '# -*- frozen_string_literal : true -*-'
-      ].each { |magic_comment| yield magic_comment }
-    end
-
     ['before', :before, 'top', :top].each do |position|
       it "should put annotation before class if :position == #{position}" do
         annotate_one_file position: position
@@ -2106,7 +2104,7 @@ end
     end
 
     it 'should not touch magic comments' do
-      magic_comments_list_each do |magic_comment|
+      MAGIC_COMMENTS.each do |magic_comment|
         write_model 'user.rb', <<-EOS
 #{magic_comment}
 class User < ActiveRecord::Base
@@ -2126,7 +2124,7 @@ end
 
     it 'adds an empty line between magic comments and annotation (position :before)' do
       content = "class User < ActiveRecord::Base\nend\n"
-      magic_comments_list_each do |magic_comment|
+      MAGIC_COMMENTS.each do |magic_comment|
         model_file_name, = write_model 'user.rb', "#{magic_comment}\n#{content}"
 
         annotate_one_file position: :before
@@ -2138,7 +2136,7 @@ end
 
     it 'only keeps a single empty line around the annotation (position :before)' do
       content = "class User < ActiveRecord::Base\nend\n"
-      magic_comments_list_each do |magic_comment|
+      MAGIC_COMMENTS.each do |magic_comment|
         schema_info = AnnotateModels.get_schema_info(@klass, '== Schema Info')
         model_file_name, = write_model 'user.rb', "#{magic_comment}\n\n\n\n#{content}"
 
@@ -2150,7 +2148,7 @@ end
 
     it 'does not change whitespace between magic comments and model file content (position :after)' do
       content = "class User < ActiveRecord::Base\nend\n"
-      magic_comments_list_each do |magic_comment|
+      MAGIC_COMMENTS.each do |magic_comment|
         model_file_name, = write_model 'user.rb', "#{magic_comment}\n#{content}"
 
         annotate_one_file position: :after

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1753,192 +1753,355 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  describe '#get_model_class' do
-    require 'tmpdir'
-
-    # TODO: use 'files' gem instead
-    def create(file, body = 'hi')
-      file_path = File.join(AnnotateModels.model_dir[0], file)
-      FileUtils.mkdir_p(File.dirname(file_path))
-      File.open(file_path, 'wb') do |f|
-        f.puts(body)
-      end
-      file_path
+  describe '.get_model_class' do # rubocop:disable Metrics/BlockLength
+    before :all do
+      require 'tmpdir'
+      AnnotateModels.model_dir = Dir.mktmpdir('annotate_models')
     end
 
-    def check_class_name(file, class_name)
-      klass = AnnotateModels.get_model_class(File.join(AnnotateModels.model_dir[0], file))
-
-      expect(klass).not_to eq(nil)
-      expect(klass.name).to eq(class_name)
+    # TODO: use 'files' gem instead
+    def create(filename, file_content)
+      File.join(AnnotateModels.model_dir[0], filename).tap do |path|
+        FileUtils.mkdir_p(File.dirname(path))
+        File.open(path, 'wb') do |f|
+          f.puts(file_content)
+        end
+      end
     end
 
     before :each do
-      AnnotateModels.model_dir = Dir.mktmpdir 'annotate_models'
+      create(filename, file_content)
     end
 
-    it 'should work' do
-      create 'foo.rb', <<-EOS
-        class Foo < ActiveRecord::Base
-        end
-      EOS
-      check_class_name 'foo.rb', 'Foo'
+    let :klass do
+      AnnotateModels.get_model_class(File.join(AnnotateModels.model_dir[0], filename))
     end
 
-    it 'should find models with non standard capitalization' do
-      create 'foo_with_capitals.rb', <<-EOS
-        class FooWithCAPITALS < ActiveRecord::Base
-        end
-      EOS
-      check_class_name 'foo_with_capitals.rb', 'FooWithCAPITALS'
-    end
+    context 'when class Foo is defined in "foo.rb"' do
+      let :filename do
+        'foo.rb'
+      end
 
-    it 'should find models inside modules' do
-      create 'bar/foo_inside_bar.rb', <<-EOS
-        module Bar
-          class FooInsideBar < ActiveRecord::Base
-          end
-        end
-      EOS
-      check_class_name 'bar/foo_inside_bar.rb', 'Bar::FooInsideBar'
-    end
-
-    it 'should find AR model when duplicated by a nested model' do
-      create 'foo.rb', <<-EOS
-        class Foo < ActiveRecord::Base
-        end
-      EOS
-
-      create 'bar/foo.rb', <<-EOS
-        class Bar::Foo
-        end
-      EOS
-      check_class_name 'bar/foo.rb', 'Bar::Foo'
-      check_class_name 'foo.rb', 'Foo'
-    end
-
-    it 'should find AR model nested inside a class' do
-      create 'voucher.rb', <<-EOS
-        class Voucher < ActiveRecord::Base
-        end
-      EOS
-
-      create 'voucher/foo.rb', <<-EOS
-        class Voucher
-          class Foo
-          end
-        end
-      EOS
-
-      check_class_name 'voucher.rb', 'Voucher'
-      check_class_name 'voucher/foo.rb', 'Voucher::Foo'
-    end
-
-    it 'should not care about unknown macros' do
-      create 'foo_with_macro.rb', <<-EOS
-        class FooWithMacro < ActiveRecord::Base
-          acts_as_awesome :yah
-        end
-      EOS
-      check_class_name 'foo_with_macro.rb', 'FooWithMacro'
-    end
-
-    it 'should not care about known macros' do
-      create('foo_with_known_macro.rb', <<-EOS)
-        class FooWithKnownMacro < ActiveRecord::Base
-          has_many :yah
-        end
-      EOS
-      check_class_name 'foo_with_known_macro.rb', 'FooWithKnownMacro'
-    end
-
-    it 'should work with class names with ALL CAPS segments' do
-      create('foo_with_capitals.rb', <<-EOS)
-        class FooWithCAPITALS < ActiveRecord::Base
-          acts_as_awesome :yah
+      let :file_content do
+        <<~EOS
+          class Foo < ActiveRecord::Base
           end
         EOS
-      check_class_name 'foo_with_capitals.rb', 'FooWithCAPITALS'
+      end
+
+      it 'works' do
+        expect(klass.name).to eq('Foo')
+      end
     end
 
-    it 'should not complain of invalid multibyte char (USASCII)' do
-      create 'foo_with_utf8.rb', <<-EOS
-        #encoding: utf-8
-        class FooWithUtf8 < ActiveRecord::Base
-          UTF8STRINGS = %w[résumé façon âge]
+    context 'when class name is not capitalized normally' do
+      context 'when class FooWithCAPITALS is defined in "foo_with_capitals.rb"' do
+        let :filename do
+          'foo_with_capitals.rb'
         end
-      EOS
-      check_class_name 'foo_with_utf8.rb', 'FooWithUtf8'
+
+        let :file_content do
+          <<~EOS
+            class FooWithCAPITALS < ActiveRecord::Base
+            end
+          EOS
+        end
+
+        it 'works' do
+          expect(klass.name).to eq('FooWithCAPITALS')
+        end
+      end
     end
 
-    it 'should find models inside modules with non standard capitalization' do
-      create 'bar/foo_inside_capitals_bar.rb', <<-EOS
-        module BAR
-          class FooInsideCapitalsBAR < ActiveRecord::Base
+    context 'when class is defined inside module' do
+      context 'when class Bar::FooInsideBar is defined in "bar/foo_inside_bar.rb"' do
+        let :filename do
+          'bar/foo_inside_bar.rb'
+        end
+
+        let :file_content do
+          <<~EOS
+            module Bar
+              class FooInsideBar < ActiveRecord::Base
+              end
+            end
+          EOS
+        end
+
+        it 'works' do
+          expect(klass.name).to eq('Bar::FooInsideBar')
+        end
+      end
+    end
+
+    context 'when class is defined inside module and class name is not capitalized normally' do
+      context 'when class Bar::FooInsideCapitalsBAR is defined in "bar/foo_inside_capitals_bar.rb"' do
+        let :filename do
+          'bar/foo_inside_capitals_bar.rb'
+        end
+
+        let :file_content do
+          <<~EOS
+            module BAR
+              class FooInsideCapitalsBAR < ActiveRecord::Base
+              end
+            end
+          EOS
+        end
+
+        it 'works' do
+          expect(klass.name).to eq('BAR::FooInsideCapitalsBAR')
+        end
+      end
+    end
+
+    context 'when unknown macros exist in class' do
+      context 'when class FooWithMacro is defined in "foo_with_macro.rb"' do
+        let :filename do
+          'foo_with_macro.rb'
+        end
+
+        let :file_content do
+          <<~EOS
+            class FooWithMacro < ActiveRecord::Base
+              acts_as_awesome :yah
+            end
+          EOS
+        end
+
+        it 'works and does not care about known macros' do
+          expect(klass.name).to eq('FooWithMacro')
+        end
+      end
+
+      context 'when class name is with ALL CAPS segments' do
+        context 'when class is "FooWithCAPITALS" is defined in "foo_with_capitals.rb"' do
+          let :filename do
+            'foo_with_capitals.rb'
+          end
+
+          let :file_content do
+            <<~EOS
+              class FooWithCAPITALS < ActiveRecord::Base
+                acts_as_awesome :yah
+              end
+            EOS
+          end
+
+          it 'works' do
+            expect(klass.name).to eq('FooWithCAPITALS')
           end
         end
-      EOS
-      check_class_name 'bar/foo_inside_capitals_bar.rb', 'BAR::FooInsideCapitalsBAR'
+      end
     end
 
-    it 'should find non-namespaced models inside subdirectories' do
-      create 'bar/non_namespaced_foo_inside_bar.rb', <<-EOS
-        class NonNamespacedFooInsideBar < ActiveRecord::Base
+    context 'when known macros exist in class' do
+      context 'when class FooWithKnownMacro is defined in "foo_with_known_macro.rb"' do
+        let :filename do
+          'foo_with_known_macro.rb'
         end
-      EOS
-      check_class_name 'bar/non_namespaced_foo_inside_bar.rb', 'NonNamespacedFooInsideBar'
+
+        let :file_content do
+          <<~EOS
+            class FooWithKnownMacro < ActiveRecord::Base
+              has_many :yah
+            end
+          EOS
+        end
+
+        it 'works and does not care about known macros' do
+          expect(klass.name).to eq('FooWithKnownMacro')
+        end
+      end
     end
 
-    it 'should find non-namespaced models with non standard capitalization inside subdirectories' do
-      create 'bar/non_namespaced_foo_with_capitals_inside_bar.rb', <<-EOS
-        class NonNamespacedFooWithCapitalsInsideBar < ActiveRecord::Base
+    context 'when the file includes invlaid multibyte chars (USASCII)' do
+      context 'when class FooWithUtf8 is defined in "foo_with_utf8.rb"' do
+        let :filename do
+          'foo_with_utf8.rb'
         end
-      EOS
-      check_class_name 'bar/non_namespaced_foo_with_capitals_inside_bar.rb', 'NonNamespacedFooWithCapitalsInsideBar'
+
+        let :file_content do
+          <<~EOS
+            # encoding: utf-8
+            class FooWithUtf8 < ActiveRecord::Base
+              UTF8STRINGS = %w[résumé façon âge]
+            end
+          EOS
+        end
+
+        it 'works without complaining of invalid multibyte chars' do
+          expect(klass.name).to eq('FooWithUtf8')
+        end
+      end
     end
 
-    it 'should allow known macros' do
-      create('foo_with_known_macro.rb', <<-EOS)
-        class FooWithKnownMacro < ActiveRecord::Base
-          has_many :yah
+    context 'when non-namespaced model is inside subdirectory' do
+      context 'when class NonNamespacedFooInsideBar is defined in "bar/non_namespaced_foo_inside_bar.rb"' do
+        let :filename do
+          'bar/non_namespaced_foo_inside_bar.rb'
         end
-      EOS
-      expect(capturing(:stderr) do
-        check_class_name 'foo_with_known_macro.rb', 'FooWithKnownMacro'
-      end).to eq('')
+
+        let :file_content do
+          <<~EOS
+            class NonNamespacedFooInsideBar < ActiveRecord::Base
+            end
+          EOS
+        end
+
+        it 'works' do
+          expect(klass.name).to eq('NonNamespacedFooInsideBar')
+        end
+      end
+
+      context 'when class name is not capitalized normally' do
+        context 'when class NonNamespacedFooWithCapitalsInsideBar is defined in "bar/non_namespaced_foo_with_capitals_inside_bar.rb"' do
+          let :filename do
+            'bar/non_namespaced_foo_with_capitals_inside_bar.rb'
+          end
+
+          let :file_content do
+            <<~EOS
+              class NonNamespacedFooWithCapitalsInsideBar < ActiveRecord::Base
+              end
+            EOS
+          end
+
+          it 'works' do
+            expect(klass.name).to eq('NonNamespacedFooWithCapitalsInsideBar')
+          end
+        end
+      end
     end
 
-    it 'should not require model files twice' do
-      create 'loaded_class.rb', <<-EOS
-        class LoadedClass < ActiveRecord::Base
-          CONSTANT = 1
+    context 'when class file is loaded twice' do
+      context 'when class LoadedClass is defined in "loaded_class.rb"' do
+        let :filename do
+          'loaded_class.rb'
         end
-      EOS
-      path = File.expand_path('loaded_class', AnnotateModels.model_dir[0])
-      Kernel.load "#{path}.rb"
-      expect(Kernel).not_to receive(:require)
 
-      expect(capturing(:stderr) do
-        check_class_name 'loaded_class.rb', 'LoadedClass'
-      end).to be_blank
+        let :file_content do
+          <<~EOS
+            class LoadedClass < ActiveRecord::Base
+              CONSTANT = 1
+            end
+          EOS
+        end
+
+        before :each do
+          path = File.expand_path(filename, AnnotateModels.model_dir[0])
+          Kernel.load(path)
+          expect(Kernel).not_to receive(:require)
+        end
+
+        it 'does not require model file twice' do
+          expect(klass.name).to eq('LoadedClass')
+        end
+      end
+
+      context 'when class is defined in a subdirectory' do
+        dir = Array.new(8) { (0..9).to_a.sample(random: Random.new) }.join
+
+        context "when class SubdirLoadedClass is defined in \"#{dir}/subdir_loaded_class.rb\"" do
+          before :each do
+            $LOAD_PATH.unshift(File.join(AnnotateModels.model_dir[0], dir))
+
+            path = File.expand_path(filename, AnnotateModels.model_dir[0])
+            Kernel.load(path)
+            expect(Kernel).not_to receive(:require)
+          end
+
+          let :filename do
+            "#{dir}/subdir_loaded_class.rb"
+          end
+
+          let :file_content do
+            <<~EOS
+              class SubdirLoadedClass < ActiveRecord::Base
+                CONSTANT = 1
+              end
+            EOS
+          end
+
+          it 'does not require model file twice' do
+            expect(klass.name).to eq('SubdirLoadedClass')
+          end
+        end
+      end
     end
 
-    it 'should not require model files twice which is inside a subdirectory' do
-      dir = Array.new(8) { (0..9).to_a.sample(random: Random.new) }.join
-      $LOAD_PATH.unshift(File.join(AnnotateModels.model_dir[0], dir))
+    context 'when two class exist' do
+      before :each do
+        create(filename_2, file_content_2)
+      end
 
-      create "#{dir}/subdir_loaded_class.rb", <<-EOS
-        class SubdirLoadedClass < ActiveRecord::Base
-          CONSTANT = 1
+      context 'the base names are duplicated' do
+        let :filename do
+          'foo.rb'
         end
-      EOS
-      path = File.expand_path("#{dir}/subdir_loaded_class", AnnotateModels.model_dir[0])
-      Kernel.load "#{path}.rb"
-      expect(Kernel).not_to receive(:require)
 
-      expect(capturing(:stderr) do
-        check_class_name "#{dir}/subdir_loaded_class.rb", 'SubdirLoadedClass'
-      end).to be_blank
+        let :file_content do
+          <<-EOS
+            class Foo < ActiveRecord::Base
+            end
+          EOS
+        end
+
+        let :filename_2 do
+          'bar/foo.rb'
+        end
+
+        let :file_content_2 do
+          <<-EOS
+            class Bar::Foo
+            end
+          EOS
+        end
+
+        let :klass_2 do
+          AnnotateModels.get_model_class(File.join(AnnotateModels.model_dir[0], filename_2))
+        end
+
+        it 'finds valid model' do
+          expect(klass.name).to eq('Foo')
+          expect(klass_2.name).to eq('Bar::Foo')
+        end
+      end
+
+      context 'one of the classes is nested in another class' do
+        let :filename do
+          'voucher.rb'
+        end
+
+        let :file_content do
+          <<-EOS
+            class Voucher < ActiveRecord::Base
+            end
+          EOS
+        end
+
+        let :filename_2 do
+          'voucher/foo.rb'
+        end
+
+        let :file_content_2 do
+          <<~EOS
+            class Voucher
+              class Foo
+              end
+            end
+          EOS
+        end
+
+        let :klass_2 do
+          AnnotateModels.get_model_class(File.join(AnnotateModels.model_dir[0], filename_2))
+        end
+
+        it 'finds valid model' do
+          expect(klass.name).to eq('Voucher')
+          expect(klass_2.name).to eq('Voucher::Foo')
+        end
+      end
     end
   end
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -883,14 +883,14 @@ EOS
     end
   end
 
-  describe '#files_by_pattern' do
+  describe '.files_by_pattern' do
     subject { AnnotateModels.files_by_pattern(root_directory, pattern_type, options) }
 
-    context 'when pattern_type=additional_file_patterns' do
-      let(:pattern_type) { 'additional_file_patterns' }
+    context 'when pattern_type is "additional_file_patterns"' do
       let(:root_directory) { nil }
+      let(:pattern_type) { 'additional_file_patterns' }
 
-      context 'with additional_file_patterns' do
+      context 'when additional_file_patterns is specified is the options' do
         let(:additional_file_patterns) do
           [
             '%PLURALIZED_MODEL_NAME%/**/*.rb',
@@ -900,16 +900,16 @@ EOS
 
         let(:options) { { additional_file_patterns: additional_file_patterns } }
 
-        it do
-          expect(subject).to eq(additional_file_patterns)
+        it 'returns additional_file_patterns in the argument "options"' do
+          is_expected.to eq(additional_file_patterns)
         end
       end
 
-      context 'without additional_file_patterns' do
+      context 'when additional_file_patterns is not specified is the options' do
         let(:options) { {} }
 
-        it do
-          expect(subject).to eq([])
+        it 'returns an empty array' do
+          is_expected.to eq([])
         end
       end
     end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -915,13 +915,13 @@ EOS
     end
   end
 
-  describe '#get_patterns' do
+  describe '.get_patterns' do
     subject { AnnotateModels.get_patterns(options, pattern_type) }
 
-    context 'when pattern_type=additional_file_patterns' do
+    context 'when pattern_type is "additional_file_patterns"' do
       let(:pattern_type) { 'additional_file_patterns' }
 
-      context 'with additional_file_patterns' do
+      context 'when additional_file_patterns is specified is the options' do
         let(:additional_file_patterns) do
           [
             '/%PLURALIZED_MODEL_NAME%/**/*.rb',
@@ -931,15 +931,15 @@ EOS
 
         let(:options) { { additional_file_patterns: additional_file_patterns } }
 
-        it do
-          expect(subject).to eq(additional_file_patterns)
+        it 'returns additional_file_patterns in the argument "options"' do
+          is_expected.to eq(additional_file_patterns)
         end
       end
 
-      context 'without additional_file_patterns' do
+      context 'when additional_file_patterns is not specified is the options' do
         let(:options) { {} }
 
-        it do
+        it 'returns an empty array' do
           expect(subject).to eq([])
         end
       end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -128,7 +128,7 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  describe '#parse_options' do
+  describe '.parse_options' do
     let(:options) do
       {
         root_dir: '/root',
@@ -136,20 +136,34 @@ describe AnnotateModels do # rubocop:disable Metrics/BlockLength
       }
     end
 
-    it 'sets @root_dir' do
+    before :each do
       AnnotateModels.send(:parse_options, options)
-      expect(AnnotateModels.instance_variable_get(:@root_dir)).to eq('/root')
     end
 
-    it 'sets @model_dir separated with a comma' do
-      AnnotateModels.send(:parse_options, options)
-      expected = [
-        'app/models',
-        'app/one',
-        'app/two',
-        'app/three'
-      ]
-      expect(AnnotateModels.instance_variable_get(:@model_dir)).to eq(expected)
+    describe '@root_dir' do
+      subject do
+        AnnotateModels.instance_variable_get(:@root_dir)
+      end
+
+      it 'sets @root_dir' do
+        expect(AnnotateModels.instance_variable_get(:@root_dir)).to eq('/root')
+      end
+    end
+
+    describe '@model_dir' do
+      subject do
+        AnnotateModels.instance_variable_get(:@model_dir)
+      end
+
+      it 'separates option "model_dir" with commas and sets @model_dir as an array of string' do
+        expected = [
+          'app/models',
+          'app/one',
+          'app/two',
+          'app/three'
+        ]
+        expect(subject).to eq(expected)
+      end
     end
   end
 


### PR DESCRIPTION
I refactored and structuralized RSpec test cases of AnnotateModels for readability and scalability because it was too complex to read.
