### PR TITLE
Refactor namespace Annotate

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -72,17 +72,9 @@ module Annotate
     options
   end
 
-  def self.loaded_tasks=(val)
-    @loaded_tasks = val
-  end
-
-  def self.loaded_tasks
-    @loaded_tasks
-  end
-
   def self.load_tasks
-    return if loaded_tasks
-    self.loaded_tasks = true
+    return if @loaded_tasks
+    @loaded_tasks = true
 
     Dir[File.join(File.dirname(__FILE__), 'tasks', '**/*.rake')].each do |rake|
       load rake

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -79,11 +79,6 @@ module Annotate
     end
   end
 
-  def self.load_requires(options)
-    options[:require].count > 0 &&
-      options[:require].each { |path| require path }
-  end
-
   def self.eager_load(options)
     load_requires(options)
     require 'annotate/active_record_patch'
@@ -135,5 +130,14 @@ module Annotate
 
     load_tasks
     Rake::Task[:set_annotation_options].invoke
+  end
+
+  class << self
+    private
+
+    def load_requires(options)
+      options[:require].count > 0 &&
+        options[:require].each { |path| require path }
+    end
   end
 end

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -71,12 +71,13 @@ module Annotate
   end
 
   def self.load_tasks
-    return if @loaded_tasks
-    @loaded_tasks = true
+    return if @tasks_loaded
 
     Dir[File.join(File.dirname(__FILE__), 'tasks', '**/*.rake')].each do |rake|
       load rake
     end
+
+    @tasks_loaded = true
   end
 
   def self.eager_load(options)

--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -1,5 +1,3 @@
-# rubocop:disable  Metrics/ModuleLength
-
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'annotate/version'
 require 'annotate/annotate_models'


### PR DESCRIPTION
#   Summary

*   Remove redundant `Annotate.loaded_tasks=` and `Annotate.loaded_tasks`
*   Remove unnecessary comment for Rubocop
*   Make Annotate.load_requires private
*   Refactor `Annotate.load_tasks`
