### PR TITLE
Rename FactoryGirl to FactoryBot

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -38,9 +38,9 @@ module AnnotateModels
   BLUEPRINTS_TEST_DIR   = File.join('test', "blueprints")
   BLUEPRINTS_SPEC_DIR   = File.join('spec', "blueprints")
 
-  # Factory Girl http://github.com/thoughtbot/factory_girl
-  FACTORY_GIRL_TEST_DIR = File.join('test', "factories")
-  FACTORY_GIRL_SPEC_DIR = File.join('spec', "factories")
+  # Factory Girl https://github.com/thoughtbot/factory_bot
+  FACTORY_BOT_TEST_DIR = File.join('test', "factories")
+  FACTORY_BOT_SPEC_DIR = File.join('spec', "factories")
 
   # Fabrication https://github.com/paulelliott/fabrication.git
   FABRICATORS_TEST_DIR  = File.join('test', "fabricators")

--- a/spec/integration/rails_3.2_autoloading_factory_girl/test/factories/tasks.rb
+++ b/spec/integration/rails_3.2_autoloading_factory_girl/test/factories/tasks.rb
@@ -1,4 +1,4 @@
-# Read about factories at https://github.com/thoughtbot/factory_girl
+# Read about factories at https://github.com/thoughtbot/factory_bot
 
 FactoryGirl.define do
   factory :task do


### PR DESCRIPTION
Now the gem [factory_girl](https://github.com/thoughtbot/factory_girl) have been renamed to [factory_bot](https://github.com/thoughtbot/factory_bot).

So I fixed constant names and comments.
