### PR TITLE
Remove AnnotateRoutes.rewrite_contents_with_header

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -66,14 +66,7 @@ module AnnotateRoutes
       content, header_position = strip_annotations(existing_text)
       new_content = annotate_routes(header, content, header_position, options)
       new_text = new_content.join("\n")
-
-      if existing_text == new_text
-        puts "#{routes_file} unchanged."
-        false
-      else
-        File.open(routes_file, 'wb') { |f| f.puts(new_text) }
-        true
-      end
+      rewrite_contents(existing_text, new_text)
     end
 
     def header(options = {})

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -30,7 +30,11 @@ module AnnotateRoutes
     def do_annotations(options = {})
       if routes_file_exist?
         existing_text = File.read(routes_file)
-        if rewrite_contents_with_header(existing_text, header(options), options)
+        content, header_position = strip_annotations(existing_text)
+        new_content = annotate_routes(header(options), content, header_position, options)
+        new_text = new_content.join("\n")
+
+        if rewrite_contents(existing_text, new_text)
           puts "#{routes_file} annotated."
         end
       else
@@ -60,13 +64,6 @@ module AnnotateRoutes
 
     def routes_file
       @routes_rb ||= File.join('config', 'routes.rb')
-    end
-
-    def rewrite_contents_with_header(existing_text, header, options = {})
-      content, header_position = strip_annotations(existing_text)
-      new_content = annotate_routes(header, content, header_position, options)
-      new_text = new_content.join("\n")
-      rewrite_contents(existing_text, new_text)
     end
 
     def header(options = {})


### PR DESCRIPTION
I removed `AnnotateRoutes.rewrite_contents_with_header` because the logic of `AnnotateRoutes.rewrite_contents_with_header` is as same as `.rewrite_contents`.
