### PR TITLE
Refactor RSpec for AnnotateModels (4) - AnnotateModels.get_schema_info (without custom options)

### DIFF
--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -453,6 +453,27 @@ describe AnnotateModels do
     expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
   end
 
+  it 'should not crash getting indexes keys' do
+    klass = mock_class(:users,
+                       :id,
+                       [
+                         mock_column(:id, :integer),
+                         mock_column(:foreign_thing_id, :integer)
+                       ], [])
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id               :integer          not null, primary key
+      #  foreign_thing_id :integer          not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
+  end
+
   it 'should get simple indexes keys' do
     klass = mock_class(:users,
                        :id,
@@ -500,27 +521,6 @@ describe AnnotateModels do
     EOS
 
     expect(AnnotateModels.get_schema_info(klass, 'Schema Info', simple_indexes: true)).to eql(expected_result)
-  end
-
-  it 'should not crash getting indexes keys' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ], [])
-
-    expected_result = <<~EOS
-      # Schema Info
-      #
-      # Table name: users
-      #
-      #  id               :integer          not null, primary key
-      #  foreign_thing_id :integer          not null
-      #
-    EOS
-
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
   end
 
   it 'should get foreign key info' do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -357,40 +357,6 @@ describe AnnotateModels do
     expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(expected_result)
   end
 
-  it 'should get foreign key info if on_delete/on_update options present' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ],
-                       [],
-                       [
-                         mock_foreign_key('fk_rails_02e851e3b7',
-                                          'foreign_thing_id',
-                                          'foreign_things',
-                                          'id',
-                                          on_delete: 'on_delete_value',
-                                          on_update: 'on_update_value')
-                       ])
-
-    expected_result = <<~EOS
-      # Schema Info
-      #
-      # Table name: users
-      #
-      #  id               :integer          not null, primary key
-      #  foreign_thing_id :integer          not null
-      #
-      # Foreign Keys
-      #
-      #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => on_delete_value ON UPDATE => on_update_value
-      #
-    EOS
-
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(expected_result)
-  end
-
   it 'should get indexes keys' do
     klass = mock_class(:users,
                        :id,
@@ -594,6 +560,40 @@ describe AnnotateModels do
     EOS
 
     expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
+  end
+
+  it 'should get foreign key info if on_delete/on_update options present' do
+    klass = mock_class(:users,
+                       :id,
+                       [
+                         mock_column(:id, :integer),
+                         mock_column(:foreign_thing_id, :integer)
+                       ],
+                       [],
+                       [
+                         mock_foreign_key('fk_rails_02e851e3b7',
+                                          'foreign_thing_id',
+                                          'foreign_things',
+                                          'id',
+                                          on_delete: 'on_delete_value',
+                                          on_update: 'on_update_value')
+                       ])
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id               :integer          not null, primary key
+      #  foreign_thing_id :integer          not null
+      #
+      # Foreign Keys
+      #
+      #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => on_delete_value ON UPDATE => on_update_value
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(expected_result)
   end
 
   it 'should get complete foreign key info' do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -667,14 +667,14 @@ describe AnnotateModels do
                        ])
 
     expected_result = <<~EOS
-      # #{AnnotateModels::PREFIX}
+      # == Schema Information
       #
       # Table name: users
       #
       # *id*::   <tt>integer, not null, primary key</tt>
       # *name*:: <tt>string(50), not null</tt>
       #--
-      # #{AnnotateModels::END_MARK}
+      # == Schema Information End
       #++
     EOS
 
@@ -690,7 +690,7 @@ describe AnnotateModels do
                        ])
 
     expected_result = <<~EOS
-      # #{AnnotateModels::PREFIX}
+      # == Schema Information
       #
       # Table name: `users`
       #
@@ -724,7 +724,7 @@ describe AnnotateModels do
                        ])
 
     expected_result = <<~EOS
-      # #{AnnotateModels::PREFIX}
+      # == Schema Information
       #
       # Table name: `users`
       #
@@ -759,7 +759,7 @@ describe AnnotateModels do
                        ])
 
     expected_result = <<~EOS
-      # #{AnnotateModels::PREFIX}
+      # == Schema Information
       #
       # Table name: `users`
       #
@@ -797,7 +797,7 @@ describe AnnotateModels do
                        ])
 
     expected_result = <<~EOS
-      # #{AnnotateModels::PREFIX}
+      # == Schema Information
       #
       # Table name: `users`
       #
@@ -835,7 +835,7 @@ describe AnnotateModels do
                        ])
 
     expected_result = <<~EOS
-      # #{AnnotateModels::PREFIX}
+      # == Schema Information
       #
       # Table name: `users`
       #
@@ -874,7 +874,7 @@ describe AnnotateModels do
                        ])
 
     expected_result = <<~EOS
-      # #{AnnotateModels::PREFIX}
+      # == Schema Information
       #
       # Table name: `users`
       #
@@ -912,7 +912,7 @@ describe AnnotateModels do
                        ])
 
     expected_result = <<~EOS
-      # #{AnnotateModels::PREFIX}
+      # == Schema Information
       #
       # Table name: `users`
       #

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -184,16 +184,18 @@ describe AnnotateModels do
                          mock_column(:notes, :text, limit: 55)
                        ])
 
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id    :integer          not null, primary key
-#  name  :string(50)       not null
-#  notes :text(55)         not null
-#
-EOS
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id    :integer          not null, primary key
+      #  name  :string(50)       not null
+      #  notes :text(55)         not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
   end
 
   it 'should get schema info even if the primary key is not set' do
@@ -204,15 +206,17 @@ EOS
                          mock_column(:name, :string, limit: 50)
                        ])
 
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id   :integer          not null
-#  name :string(50)       not null
-#
-EOS
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id   :integer          not null
+      #  name :string(50)       not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
   end
 
   it 'should get schema info even if the primary key is array, if using composite_primary_keys' do
@@ -224,16 +228,18 @@ EOS
                          mock_column(:name, :string, limit: 50)
                        ])
 
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  a_id :integer          not null, primary key
-#  b_id :integer          not null, primary key
-#  name :string(50)       not null
-#
-EOS
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  a_id :integer          not null, primary key
+      #  b_id :integer          not null, primary key
+      #  name :string(50)       not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
   end
 
   it 'should get schema info with enum type' do
@@ -244,15 +250,17 @@ EOS
                          mock_column(:name, :enum, limit: [:enum1, :enum2])
                        ])
 
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id   :integer          not null
-#  name :enum             not null, (enum1, enum2)
-#
-EOS
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id   :integer          not null
+      #  name :enum             not null, (enum1, enum2)
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
   end
 
   it 'should get schema info with unsigned' do
@@ -267,19 +275,21 @@ EOS
                          mock_column(:decimal, :decimal, unsigned?: true, precision: 10, scale: 2),
                        ])
 
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id      :integer          not null
-#  integer :integer          unsigned, not null
-#  bigint  :bigint           unsigned, not null
-#  bigint  :bigint           unsigned, not null
-#  float   :float            unsigned, not null
-#  decimal :decimal(10, 2)   unsigned, not null
-#
-EOS
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id      :integer          not null
+      #  integer :integer          unsigned, not null
+      #  bigint  :bigint           unsigned, not null
+      #  bigint  :bigint           unsigned, not null
+      #  float   :float            unsigned, not null
+      #  decimal :decimal(10, 2)   unsigned, not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
   end
 
   it 'should get schema info for integer and boolean with default' do
@@ -290,16 +300,19 @@ EOS
                          mock_column(:size, :integer, default: 20),
                          mock_column(:flag, :boolean, default: false)
                        ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id   :integer          not null, primary key
-#  size :integer          default(20), not null
-#  flag :boolean          default(FALSE), not null
-#
-EOS
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id   :integer          not null, primary key
+      #  size :integer          default(20), not null
+      #  flag :boolean          default(FALSE), not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
   end
 
   it 'sets correct default value for integer column when ActiveRecord::Enum is used' do
@@ -309,20 +322,23 @@ EOS
                          mock_column(:id, :integer),
                          mock_column(:status, :integer, default: 0)
                        ])
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id     :integer          not null, primary key
+      #  status :integer          default(0), not null
+      #
+    EOS
+
     # column_defaults may be overritten when ActiveRecord::Enum is used, e.g:
     # class User < ActiveRecord::Base
     #   enum status: [ :disabled, :enabled ]
     # end
     allow(klass).to receive(:column_defaults).and_return('id' => nil, 'status' => 'disabled')
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id     :integer          not null, primary key
-#  status :integer          default(0), not null
-#
-EOS
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
   end
 
   it 'should get foreign key info' do
@@ -344,21 +360,24 @@ EOS
                                           'third_thing_id',
                                           'third_things')
                        ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-# Foreign Keys
-#
-#  custom_fk_name  (other_thing_id => other_things.id)
-#  fk_rails_...    (foreign_thing_id => foreign_things.id)
-#  fk_rails_...    (third_thing_id => third_things.id)
-#
-EOS
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id               :integer          not null, primary key
+      #  foreign_thing_id :integer          not null
+      #
+      # Foreign Keys
+      #
+      #  custom_fk_name  (other_thing_id => other_things.id)
+      #  fk_rails_...    (foreign_thing_id => foreign_things.id)
+      #  fk_rails_...    (third_thing_id => third_things.id)
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(expected_result)
   end
 
   it 'should get complete foreign key info' do
@@ -380,21 +399,24 @@ EOS
                                           'third_thing_id',
                                           'third_things')
                        ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-# Foreign Keys
-#
-#  custom_fk_name       (other_thing_id => other_things.id)
-#  fk_rails_a70234b26c  (third_thing_id => third_things.id)
-#  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
-#
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id               :integer          not null, primary key
+      #  foreign_thing_id :integer          not null
+      #
+      # Foreign Keys
+      #
+      #  custom_fk_name       (other_thing_id => other_things.id)
+      #  fk_rails_a70234b26c  (third_thing_id => third_things.id)
+      #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
+      #
     EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)).to eql(expected_result)
   end
 
   it 'should get foreign key info if on_delete/on_update options present' do
@@ -413,19 +435,22 @@ EOS
                                           on_delete: 'on_delete_value',
                                           on_update: 'on_update_value')
                        ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-# Foreign Keys
-#
-#  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => on_delete_value ON UPDATE => on_update_value
-#
-EOS
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id               :integer          not null, primary key
+      #  foreign_thing_id :integer          not null
+      #
+      # Foreign Keys
+      #
+      #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => on_delete_value ON UPDATE => on_update_value
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(expected_result)
   end
 
   it 'should get indexes keys' do
@@ -436,20 +461,23 @@ EOS
                          mock_column(:foreign_thing_id, :integer)
                        ], [mock_index('index_rails_02e851e3b7', columns: ['id']),
                        mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-# Indexes
-#
-#  index_rails_02e851e3b7  (id)
-#  index_rails_02e851e3b8  (foreign_thing_id)
-#
-EOS
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id               :integer          not null, primary key
+      #  foreign_thing_id :integer          not null
+      #
+      # Indexes
+      #
+      #  index_rails_02e851e3b7  (id)
+      #  index_rails_02e851e3b8  (foreign_thing_id)
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
   end
 
   it 'should get ordered indexes keys' do
@@ -467,22 +495,25 @@ EOS
                                     columns: %w(firstname surname value),
                                     orders: { 'surname' => :asc, 'value' => :desc })
                        ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id        :integer          not null, primary key
-#  firstname :string           not null
-#  surname   :string           not null
-#  value     :string           not null
-#
-# Indexes
-#
-#  index_rails_02e851e3b7  (id)
-#  index_rails_02e851e3b8  (firstname,surname ASC,value DESC)
-#
-EOS
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id        :integer          not null, primary key
+      #  firstname :string           not null
+      #  surname   :string           not null
+      #  value     :string           not null
+      #
+      # Indexes
+      #
+      #  index_rails_02e851e3b7  (id)
+      #  index_rails_02e851e3b8  (firstname,surname ASC,value DESC)
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
   end
 
   it 'should get indexes keys with where clause' do
@@ -500,22 +531,25 @@ EOS
                                     columns: %w(firstname surname),
                                     where: 'value IS NOT NULL')
                        ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id        :integer          not null, primary key
-#  firstname :string           not null
-#  surname   :string           not null
-#  value     :string           not null
-#
-# Indexes
-#
-#  index_rails_02e851e3b7  (id)
-#  index_rails_02e851e3b8  (firstname,surname) WHERE value IS NOT NULL
-#
-EOS
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id        :integer          not null, primary key
+      #  firstname :string           not null
+      #  surname   :string           not null
+      #  value     :string           not null
+      #
+      # Indexes
+      #
+      #  index_rails_02e851e3b7  (id)
+      #  index_rails_02e851e3b8  (firstname,surname) WHERE value IS NOT NULL
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
   end
 
   it 'should get indexes keys with using clause other than btree' do
@@ -533,22 +567,25 @@ EOS
                                     columns: %w(firstname surname),
                                     using: 'hash')
                        ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id        :integer          not null, primary key
-#  firstname :string           not null
-#  surname   :string           not null
-#  value     :string           not null
-#
-# Indexes
-#
-#  index_rails_02e851e3b7  (id)
-#  index_rails_02e851e3b8  (firstname,surname) USING hash
-#
-EOS
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id        :integer          not null, primary key
+      #  firstname :string           not null
+      #  surname   :string           not null
+      #  value     :string           not null
+      #
+      # Indexes
+      #
+      #  index_rails_02e851e3b7  (id)
+      #  index_rails_02e851e3b8  (firstname,surname) USING hash
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
   end
 
   it 'should get simple indexes keys' do
@@ -564,15 +601,18 @@ EOS
                                     columns: ['foreign_thing_id'],
                                     orders: { 'foreign_thing_id' => :desc })
                        ])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', simple_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-EOS
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id               :integer          not null, primary key
+      #  foreign_thing_id :integer          not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', simple_indexes: true)).to eql(expected_result)
   end
 
   it 'should get simple indexes keys if one is in string form' do
@@ -583,15 +623,18 @@ EOS
                          mock_column("name", :string)
                        ], [mock_index('index_rails_02e851e3b7', columns: ['id']),
                        mock_index('index_rails_02e851e3b8', columns: 'LOWER(name)')])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', simple_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id   :integer          not null, primary key, indexed
-#  name :string           not null
-#
-EOS
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id   :integer          not null, primary key, indexed
+      #  name :string           not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', simple_indexes: true)).to eql(expected_result)
   end
 
   it 'should not crash getting indexes keys' do
@@ -601,15 +644,18 @@ EOS
                          mock_column(:id, :integer),
                          mock_column(:foreign_thing_id, :integer)
                        ], [])
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(<<-EOS)
-# Schema Info
-#
-# Table name: users
-#
-#  id               :integer          not null, primary key
-#  foreign_thing_id :integer          not null
-#
-EOS
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id               :integer          not null, primary key
+      #  foreign_thing_id :integer          not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
   end
 
   it 'should get schema info as RDoc' do
@@ -619,17 +665,20 @@ EOS
                          mock_column(:id, :integer),
                          mock_column(:name, :string, limit: 50)
                        ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: users
-#
-# *id*::   <tt>integer, not null, primary key</tt>
-# *name*:: <tt>string(50), not null</tt>
-#--
-# #{AnnotateModels::END_MARK}
-#++
-EOS
+
+    expected_result = <<~EOS
+      # #{AnnotateModels::PREFIX}
+      #
+      # Table name: users
+      #
+      # *id*::   <tt>integer, not null, primary key</tt>
+      # *name*:: <tt>string(50), not null</tt>
+      #--
+      # #{AnnotateModels::END_MARK}
+      #++
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true)).to eql(expected_result)
   end
 
   it 'should get schema info as Markdown' do
@@ -639,19 +688,22 @@ EOS
                          mock_column(:id, :integer),
                          mock_column(:name, :string, limit: 50)
                        ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-EOS
+
+    expected_result = <<~EOS
+      # #{AnnotateModels::PREFIX}
+      #
+      # Table name: `users`
+      #
+      # ### Columns
+      #
+      # Name        | Type               | Attributes
+      # ----------- | ------------------ | ---------------------------
+      # **`id`**    | `integer`          | `not null, primary key`
+      # **`name`**  | `string(50)`       | `not null`
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true)).to eql(expected_result)
   end
 
   it 'should get schema info as Markdown with foreign keys' do
@@ -670,24 +722,27 @@ EOS
                                           on_delete: 'on_delete_value',
                                           on_update: 'on_update_value')
                        ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_foreign_keys: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name                    | Type               | Attributes
-# ----------------------- | ------------------ | ---------------------------
-# **`id`**                | `integer`          | `not null, primary key`
-# **`foreign_thing_id`**  | `integer`          | `not null`
-#
-# ### Foreign Keys
-#
-# * `fk_rails_...` (_ON DELETE => on_delete_value ON UPDATE => on_update_value_):
-#     * **`foreign_thing_id => foreign_things.id`**
-#
-EOS
+
+    expected_result = <<~EOS
+      # #{AnnotateModels::PREFIX}
+      #
+      # Table name: `users`
+      #
+      # ### Columns
+      #
+      # Name                    | Type               | Attributes
+      # ----------------------- | ------------------ | ---------------------------
+      # **`id`**                | `integer`          | `not null, primary key`
+      # **`foreign_thing_id`**  | `integer`          | `not null`
+      #
+      # ### Foreign Keys
+      #
+      # * `fk_rails_...` (_ON DELETE => on_delete_value ON UPDATE => on_update_value_):
+      #     * **`foreign_thing_id => foreign_things.id`**
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_foreign_keys: true)).to eql(expected_result)
   end
 
   it 'should get schema info as Markdown with indexes' do
@@ -702,26 +757,29 @@ EOS
                          mock_index('index_rails_02e851e3b8',
                                     columns: ['foreign_thing_id'])
                        ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-# ### Indexes
-#
-# * `index_rails_02e851e3b7`:
-#     * **`id`**
-# * `index_rails_02e851e3b8`:
-#     * **`foreign_thing_id`**
-#
-EOS
+
+    expected_result = <<~EOS
+      # #{AnnotateModels::PREFIX}
+      #
+      # Table name: `users`
+      #
+      # ### Columns
+      #
+      # Name        | Type               | Attributes
+      # ----------- | ------------------ | ---------------------------
+      # **`id`**    | `integer`          | `not null, primary key`
+      # **`name`**  | `string(50)`       | `not null`
+      #
+      # ### Indexes
+      #
+      # * `index_rails_02e851e3b7`:
+      #     * **`id`**
+      # * `index_rails_02e851e3b8`:
+      #     * **`foreign_thing_id`**
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
   end
 
   it 'should get schema info as Markdown with unique indexes' do
@@ -737,26 +795,29 @@ EOS
                                     columns: ['foreign_thing_id'],
                                     unique: true)
                        ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-# ### Indexes
-#
-# * `index_rails_02e851e3b7`:
-#     * **`id`**
-# * `index_rails_02e851e3b8` (_unique_):
-#     * **`foreign_thing_id`**
-#
-EOS
+
+    expected_result = <<~EOS
+      # #{AnnotateModels::PREFIX}
+      #
+      # Table name: `users`
+      #
+      # ### Columns
+      #
+      # Name        | Type               | Attributes
+      # ----------- | ------------------ | ---------------------------
+      # **`id`**    | `integer`          | `not null, primary key`
+      # **`name`**  | `string(50)`       | `not null`
+      #
+      # ### Indexes
+      #
+      # * `index_rails_02e851e3b7`:
+      #     * **`id`**
+      # * `index_rails_02e851e3b8` (_unique_):
+      #     * **`foreign_thing_id`**
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
   end
 
   it 'should get schema info as Markdown with ordered indexes' do
@@ -772,26 +833,29 @@ EOS
                                     columns: ['foreign_thing_id'],
                                     orders: { 'foreign_thing_id' => :desc })
                        ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-# ### Indexes
-#
-# * `index_rails_02e851e3b7`:
-#     * **`id`**
-# * `index_rails_02e851e3b8`:
-#     * **`foreign_thing_id DESC`**
-#
-EOS
+
+    expected_result = <<~EOS
+      # #{AnnotateModels::PREFIX}
+      #
+      # Table name: `users`
+      #
+      # ### Columns
+      #
+      # Name        | Type               | Attributes
+      # ----------- | ------------------ | ---------------------------
+      # **`id`**    | `integer`          | `not null, primary key`
+      # **`name`**  | `string(50)`       | `not null`
+      #
+      # ### Indexes
+      #
+      # * `index_rails_02e851e3b7`:
+      #     * **`id`**
+      # * `index_rails_02e851e3b8`:
+      #     * **`foreign_thing_id DESC`**
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
   end
 
   it 'should get schema info as Markdown with indexes with WHERE clause' do
@@ -808,26 +872,29 @@ EOS
                                     unique: true,
                                     where: 'name IS NOT NULL')
                        ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-# ### Indexes
-#
-# * `index_rails_02e851e3b7`:
-#     * **`id`**
-# * `index_rails_02e851e3b8` (_unique_ _where_ name IS NOT NULL):
-#     * **`foreign_thing_id`**
-#
-EOS
+
+    expected_result = <<~EOS
+      # #{AnnotateModels::PREFIX}
+      #
+      # Table name: `users`
+      #
+      # ### Columns
+      #
+      # Name        | Type               | Attributes
+      # ----------- | ------------------ | ---------------------------
+      # **`id`**    | `integer`          | `not null, primary key`
+      # **`name`**  | `string(50)`       | `not null`
+      #
+      # ### Indexes
+      #
+      # * `index_rails_02e851e3b7`:
+      #     * **`id`**
+      # * `index_rails_02e851e3b8` (_unique_ _where_ name IS NOT NULL):
+      #     * **`foreign_thing_id`**
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
   end
 
   it 'should get schema info as Markdown with indexes with using clause other than btree' do
@@ -843,26 +910,29 @@ EOS
                                     columns: ['foreign_thing_id'],
                                     using: 'hash')
                        ])
-    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(<<-EOS)
-# #{AnnotateModels::PREFIX}
-#
-# Table name: `users`
-#
-# ### Columns
-#
-# Name        | Type               | Attributes
-# ----------- | ------------------ | ---------------------------
-# **`id`**    | `integer`          | `not null, primary key`
-# **`name`**  | `string(50)`       | `not null`
-#
-# ### Indexes
-#
-# * `index_rails_02e851e3b7`:
-#     * **`id`**
-# * `index_rails_02e851e3b8` (_using_ hash):
-#     * **`foreign_thing_id`**
-#
-EOS
+
+    expected_result = <<~EOS
+      # #{AnnotateModels::PREFIX}
+      #
+      # Table name: `users`
+      #
+      # ### Columns
+      #
+      # Name        | Type               | Attributes
+      # ----------- | ------------------ | ---------------------------
+      # **`id`**    | `integer`          | `not null, primary key`
+      # **`name`**  | `string(50)`       | `not null`
+      #
+      # ### Indexes
+      #
+      # * `index_rails_02e851e3b7`:
+      #     * **`id`**
+      # * `index_rails_02e851e3b8` (_using_ hash):
+      #     * **`foreign_thing_id`**
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
   end
 
   it 'should work with the Globalize gem' do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -179,7 +179,7 @@ describe AnnotateModels do
     context 'when header is "Schema Info"' do
       context 'when the primary key is not specified' do
         context 'when the columns are normal' do
-          it 'should get schema info even if the primary key is not set' do
+          it 'returns schema info' do
             klass = mock_class(:users,
                                nil,
                                [
@@ -202,7 +202,7 @@ describe AnnotateModels do
         end
 
         context 'when an enum column exists' do
-          it 'should get schema info with enum type' do
+          it 'returns schema info' do
             klass = mock_class(:users,
                                nil,
                                [
@@ -225,7 +225,7 @@ describe AnnotateModels do
         end
 
         context 'when unsigned columns exist' do
-          it 'should get schema info with unsigned' do
+          it 'returns schema info' do
             klass = mock_class(:users,
                                nil,
                                [
@@ -259,7 +259,7 @@ describe AnnotateModels do
       context 'when the primary key is specified' do
         context 'when the primary_key is :id' do
           context 'when columns are normal' do
-            it 'should get schema info with default options' do
+            it 'returns schema info' do
               klass = mock_class(:users,
                                  :id,
                                  [
@@ -284,7 +284,7 @@ describe AnnotateModels do
           end
 
           context 'when columns have default values' do
-            it 'should get schema info for integer and boolean with default' do
+            it 'returns schema info with default values' do
               klass = mock_class(:users,
                                  :id,
                                  [
@@ -309,7 +309,7 @@ describe AnnotateModels do
           end
 
           context 'when an integer column using ActiveRecord::Enum exists' do
-            it 'sets correct default value for integer column when ActiveRecord::Enum is used' do
+            it 'returns schema info with default values' do
               klass = mock_class(:users,
                                  :id,
                                  [
@@ -339,7 +339,7 @@ describe AnnotateModels do
           context 'when indexes exist' do
             context 'when option "show_indexes" is true' do
               context 'when indexes are normal' do
-                it 'should get indexes keys' do
+                it 'returns schema info with index information' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -368,7 +368,7 @@ describe AnnotateModels do
               end
 
               context 'when one of indexes includes orderd index key' do
-                it 'should get ordered indexes keys' do
+                it 'returns schema info with index information' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -406,7 +406,7 @@ describe AnnotateModels do
               end
 
               context 'when one of indexes includes "where" clause' do
-                it 'should get indexes keys with where clause' do
+                it 'returns schema info with index information' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -444,7 +444,7 @@ describe AnnotateModels do
               end
 
               context 'when one of indexes includes "using" clause other than "btree"' do
-                it 'should get indexes keys with using clause other than btree' do
+                it 'returns schema info with index information' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -482,7 +482,7 @@ describe AnnotateModels do
               end
 
               context 'when index is not defined' do
-                it 'should not crash getting indexes keys' do
+                it 'returns schema info without index information' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -507,7 +507,7 @@ describe AnnotateModels do
 
             context 'when option "simple_indexes" is true' do
               context 'when one of indexes includes "orders" clause' do # TODO
-                it 'should get simple indexes keys' do
+                it 'returns schema info with index information' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -536,7 +536,7 @@ describe AnnotateModels do
               end
 
               context 'when one of indexes is in string form' do
-                it 'should get simple indexes keys if one is in string form' do
+                it 'returns schema info with index information' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -564,7 +564,7 @@ describe AnnotateModels do
           context 'when foreign keys exist' do
             context 'when option "show_foreign_keys" is specified' do
               context 'when foreign_keys does not have option' do
-                it 'should get foreign key info' do
+                it 'returns schema info with foreign keys' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -605,7 +605,7 @@ describe AnnotateModels do
               end
 
               context 'when foreign_keys have option "on_delete" and "on_update"' do
-                it 'should get foreign key info if on_delete/on_update options present' do
+                it 'returns schema info with foreign keys' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -642,7 +642,7 @@ describe AnnotateModels do
             end
 
             context 'when option "show_foreign_keys" and "show_complete_foreign_keys" are specified' do
-              it 'should get complete foreign key info' do
+              it 'returns schema info with foreign keys' do
                 klass = mock_class(:users,
                                    :id,
                                    [
@@ -685,7 +685,7 @@ describe AnnotateModels do
         end
 
         context 'when the primary key is an array (using composite_primary_keys)' do
-          it 'should get schema info even if the primary key is array, if using composite_primary_keys' do
+          it 'returns schema info' do
             klass = mock_class(:users,
                                [:a_id, :b_id],
                                [
@@ -715,7 +715,7 @@ describe AnnotateModels do
       context 'when the primary key is specified' do
         context 'when the primary_key is :id' do
           context 'when option "format_rdoc" is true' do
-            it 'should get schema info as RDoc' do
+            it 'returns schema info in RDoc format' do
               klass = mock_class(:users,
                                  :id,
                                  [
@@ -741,7 +741,7 @@ describe AnnotateModels do
 
           context 'when option "format_markdown" is true' do
             context 'when other option is not specified' do
-              it 'should get schema info as Markdown' do
+              it 'returns schema info in Markdown format' do
                 klass = mock_class(:users,
                                    :id,
                                    [
@@ -769,7 +769,7 @@ describe AnnotateModels do
 
             context 'when option "show_indexes" is true' do
               context 'when indexes are normal' do
-                it 'should get schema info as Markdown with indexes' do
+                it 'returns schema info with index information in Markdown format' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -808,7 +808,7 @@ describe AnnotateModels do
               end
 
               context 'when one of indexes includes "unique" clause' do
-                it 'should get schema info as Markdown with unique indexes' do
+                it 'returns schema info with index information in Markdown format' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -848,7 +848,7 @@ describe AnnotateModels do
               end
 
               context 'when one of indexes includes orderd index key' do
-                it 'should get schema info as Markdown with ordered indexes' do
+                it 'returns schema info with index information in Markdown format' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -888,7 +888,7 @@ describe AnnotateModels do
               end
 
               context 'when one of indexes includes "where" clause and "unique" clause' do
-                it 'should get schema info as Markdown with indexes with WHERE clause' do
+                it 'returns schema info with index information in Markdown format' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -929,7 +929,7 @@ describe AnnotateModels do
               end
 
               context 'when one of indexes includes "using" clause other than "btree"' do
-                it 'should get schema info as Markdown with indexes with using clause other than btree' do
+                it 'returns schema info with index information in Markdown format' do
                   klass = mock_class(:users,
                                      :id,
                                      [
@@ -971,7 +971,7 @@ describe AnnotateModels do
 
             context 'when option "show_foreign_keys" is true' do
               context 'when foreign_keys have option "on_delete" and "on_update"' do
-                it 'should get schema info as Markdown with foreign keys' do
+                it 'returns schema info with foreign_keys in Markdown format' do
                   klass = mock_class(:users,
                                      :id,
                                      [

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -175,29 +175,6 @@ describe AnnotateModels do
     end
   end
 
-  it 'should get schema info with default options' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer, limit: 8),
-                         mock_column(:name, :string, limit: 50),
-                         mock_column(:notes, :text, limit: 55)
-                       ])
-
-    expected_result = <<~EOS
-      # Schema Info
-      #
-      # Table name: users
-      #
-      #  id    :integer          not null, primary key
-      #  name  :string(50)       not null
-      #  notes :text(55)         not null
-      #
-    EOS
-
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
-  end
-
   it 'should get schema info even if the primary key is not set' do
     klass = mock_class(:users,
                        nil,
@@ -286,6 +263,29 @@ describe AnnotateModels do
       #  bigint  :bigint           unsigned, not null
       #  float   :float            unsigned, not null
       #  decimal :decimal(10, 2)   unsigned, not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
+  end
+
+  it 'should get schema info with default options' do
+    klass = mock_class(:users,
+                       :id,
+                       [
+                         mock_column(:id, :integer, limit: 8),
+                         mock_column(:name, :string, limit: 50),
+                         mock_column(:notes, :text, limit: 55)
+                       ])
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id    :integer          not null, primary key
+      #  name  :string(50)       not null
+      #  notes :text(55)         not null
       #
     EOS
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -767,49 +767,6 @@ describe AnnotateModels do
               end
             end
 
-            context 'when option "show_foreign_keys" is true' do
-              context 'when foreign_keys have option "on_delete" and "on_update"' do
-                it 'should get schema info as Markdown with foreign keys' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:foreign_thing_id, :integer)
-                                     ],
-                                     [],
-                                     [
-                                       mock_foreign_key('fk_rails_02e851e3b7',
-                                                        'foreign_thing_id',
-                                                        'foreign_things',
-                                                        'id',
-                                                        on_delete: 'on_delete_value',
-                                                        on_update: 'on_update_value')
-                                     ])
-
-                  expected_result = <<~EOS
-                    # == Schema Information
-                    #
-                    # Table name: `users`
-                    #
-                    # ### Columns
-                    #
-                    # Name                    | Type               | Attributes
-                    # ----------------------- | ------------------ | ---------------------------
-                    # **`id`**                | `integer`          | `not null, primary key`
-                    # **`foreign_thing_id`**  | `integer`          | `not null`
-                    #
-                    # ### Foreign Keys
-                    #
-                    # * `fk_rails_...` (_ON DELETE => on_delete_value ON UPDATE => on_update_value_):
-                    #     * **`foreign_thing_id => foreign_things.id`**
-                    #
-                  EOS
-
-                  expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_foreign_keys: true)).to eql(expected_result)
-                end
-              end
-            end
-
             context 'when option "show_indexes" is true' do
               context 'when indexes are normal' do
                 it 'should get schema info as Markdown with indexes' do
@@ -1008,6 +965,49 @@ describe AnnotateModels do
                   EOS
 
                   expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
+                end
+              end
+            end
+
+            context 'when option "show_foreign_keys" is true' do
+              context 'when foreign_keys have option "on_delete" and "on_update"' do
+                it 'should get schema info as Markdown with foreign keys' do
+                  klass = mock_class(:users,
+                                     :id,
+                                     [
+                                       mock_column(:id, :integer),
+                                       mock_column(:foreign_thing_id, :integer)
+                                     ],
+                                     [],
+                                     [
+                                       mock_foreign_key('fk_rails_02e851e3b7',
+                                                        'foreign_thing_id',
+                                                        'foreign_things',
+                                                        'id',
+                                                        on_delete: 'on_delete_value',
+                                                        on_update: 'on_update_value')
+                                     ])
+
+                  expected_result = <<~EOS
+                    # == Schema Information
+                    #
+                    # Table name: `users`
+                    #
+                    # ### Columns
+                    #
+                    # Name                    | Type               | Attributes
+                    # ----------------------- | ------------------ | ---------------------------
+                    # **`id`**                | `integer`          | `not null, primary key`
+                    # **`foreign_thing_id`**  | `integer`          | `not null`
+                    #
+                    # ### Foreign Keys
+                    #
+                    # * `fk_rails_...` (_ON DELETE => on_delete_value ON UPDATE => on_update_value_):
+                    #     * **`foreign_thing_id => foreign_things.id`**
+                    #
+                  EOS
+
+                  expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_foreign_keys: true)).to eql(expected_result)
                 end
               end
             end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -735,7 +735,7 @@ describe AnnotateModels do
 
             context 'when option "show_foreign_keys" and "show_complete_foreign_keys" are specified' do
               subject do
-                AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)
+                AnnotateModels.get_schema_info(klass, header, show_foreign_keys: true, show_complete_foreign_keys: true)
               end
 
               let :expected_result do
@@ -816,7 +816,7 @@ describe AnnotateModels do
 
           context 'when option "format_rdoc" is true' do
             subject do
-              AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true)
+              AnnotateModels.get_schema_info(klass, header, format_rdoc: true)
             end
 
             let :expected_result do
@@ -840,7 +840,7 @@ describe AnnotateModels do
 
           context 'when option "format_yard" is true' do
             subject do
-              AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_yard: true)
+              AnnotateModels.get_schema_info(klass, header, format_yard: true)
             end
 
             let :expected_result do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -318,45 +318,6 @@ describe AnnotateModels do
     expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
   end
 
-  it 'should get foreign key info' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ],
-                       [],
-                       [
-                         mock_foreign_key('fk_rails_cf2568e89e',
-                                          'foreign_thing_id',
-                                          'foreign_things'),
-                         mock_foreign_key('custom_fk_name',
-                                          'other_thing_id',
-                                          'other_things'),
-                         mock_foreign_key('fk_rails_a70234b26c',
-                                          'third_thing_id',
-                                          'third_things')
-                       ])
-
-    expected_result = <<~EOS
-      # Schema Info
-      #
-      # Table name: users
-      #
-      #  id               :integer          not null, primary key
-      #  foreign_thing_id :integer          not null
-      #
-      # Foreign Keys
-      #
-      #  custom_fk_name  (other_thing_id => other_things.id)
-      #  fk_rails_...    (foreign_thing_id => foreign_things.id)
-      #  fk_rails_...    (third_thing_id => third_things.id)
-      #
-    EOS
-
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(expected_result)
-  end
-
   it 'should get indexes keys' do
     klass = mock_class(:users,
                        :id,
@@ -560,6 +521,45 @@ describe AnnotateModels do
     EOS
 
     expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
+  end
+
+  it 'should get foreign key info' do
+    klass = mock_class(:users,
+                       :id,
+                       [
+                         mock_column(:id, :integer),
+                         mock_column(:foreign_thing_id, :integer)
+                       ],
+                       [],
+                       [
+                         mock_foreign_key('fk_rails_cf2568e89e',
+                                          'foreign_thing_id',
+                                          'foreign_things'),
+                         mock_foreign_key('custom_fk_name',
+                                          'other_thing_id',
+                                          'other_things'),
+                         mock_foreign_key('fk_rails_a70234b26c',
+                                          'third_thing_id',
+                                          'third_things')
+                       ])
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id               :integer          not null, primary key
+      #  foreign_thing_id :integer          not null
+      #
+      # Foreign Keys
+      #
+      #  custom_fk_name  (other_thing_id => other_things.id)
+      #  fk_rails_...    (foreign_thing_id => foreign_things.id)
+      #  fk_rails_...    (third_thing_id => third_things.id)
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(expected_result)
   end
 
   it 'should get foreign key info if on_delete/on_update options present' do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -357,45 +357,6 @@ describe AnnotateModels do
     expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(expected_result)
   end
 
-  it 'should get complete foreign key info' do
-    klass = mock_class(:users,
-                       :id,
-                       [
-                         mock_column(:id, :integer),
-                         mock_column(:foreign_thing_id, :integer)
-                       ],
-                       [],
-                       [
-                         mock_foreign_key('fk_rails_cf2568e89e',
-                                          'foreign_thing_id',
-                                          'foreign_things'),
-                         mock_foreign_key('custom_fk_name',
-                                          'other_thing_id',
-                                          'other_things'),
-                         mock_foreign_key('fk_rails_a70234b26c',
-                                          'third_thing_id',
-                                          'third_things')
-                       ])
-
-    expected_result = <<~EOS
-      # Schema Info
-      #
-      # Table name: users
-      #
-      #  id               :integer          not null, primary key
-      #  foreign_thing_id :integer          not null
-      #
-      # Foreign Keys
-      #
-      #  custom_fk_name       (other_thing_id => other_things.id)
-      #  fk_rails_a70234b26c  (third_thing_id => third_things.id)
-      #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
-      #
-    EOS
-
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)).to eql(expected_result)
-  end
-
   it 'should get foreign key info if on_delete/on_update options present' do
     klass = mock_class(:users,
                        :id,
@@ -633,6 +594,45 @@ describe AnnotateModels do
     EOS
 
     expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
+  end
+
+  it 'should get complete foreign key info' do
+    klass = mock_class(:users,
+                       :id,
+                       [
+                         mock_column(:id, :integer),
+                         mock_column(:foreign_thing_id, :integer)
+                       ],
+                       [],
+                       [
+                         mock_foreign_key('fk_rails_cf2568e89e',
+                                          'foreign_thing_id',
+                                          'foreign_things'),
+                         mock_foreign_key('custom_fk_name',
+                                          'other_thing_id',
+                                          'other_things'),
+                         mock_foreign_key('fk_rails_a70234b26c',
+                                          'third_thing_id',
+                                          'third_things')
+                       ])
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  id               :integer          not null, primary key
+      #  foreign_thing_id :integer          not null
+      #
+      # Foreign Keys
+      #
+      #  custom_fk_name       (other_thing_id => other_things.id)
+      #  fk_rails_a70234b26c  (third_thing_id => third_things.id)
+      #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)).to eql(expected_result)
   end
 
   it 'should get schema info as RDoc' do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -176,18 +176,42 @@ describe AnnotateModels do
   end
 
   describe '.get_schema_info' do
-    context 'when header is "Schema Info"' do
-      context 'when the primary key is not specified' do
-        context 'when the columns are normal' do
-          it 'returns schema info' do
-            klass = mock_class(:users,
-                               nil,
-                               [
-                                 mock_column(:id, :integer),
-                                 mock_column(:name, :string, limit: 50)
-                               ])
+    subject do
+      AnnotateModels.get_schema_info(klass, header)
+    end
 
-            expected_result = <<~EOS
+    let :klass do
+      mock_class(:users, primary_key, columns, indexes, foreign_keys)
+    end
+
+    let :indexes do
+      []
+    end
+
+    let :foreign_keys do
+      []
+    end
+
+    context 'when header is "Schema Info"' do
+      let :header do
+        'Schema Info'
+      end
+
+      context 'when the primary key is not specified' do
+        let :primary_key do
+          nil
+        end
+
+        context 'when the columns are normal' do
+          let :columns do
+            [
+              mock_column(:id, :integer),
+              mock_column(:name, :string, limit: 50)
+            ]
+          end
+
+          let :expected_result do
+            <<~EOS
               # Schema Info
               #
               # Table name: users
@@ -196,21 +220,23 @@ describe AnnotateModels do
               #  name :string(50)       not null
               #
             EOS
+          end
 
-            expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
+          it 'returns schema info' do
+            is_expected.to eq(expected_result)
           end
         end
 
         context 'when an enum column exists' do
-          it 'returns schema info' do
-            klass = mock_class(:users,
-                               nil,
-                               [
-                                 mock_column(:id, :integer),
-                                 mock_column(:name, :enum, limit: [:enum1, :enum2])
-                               ])
+          let :columns do
+            [
+              mock_column(:id, :integer),
+              mock_column(:name, :enum, limit: [:enum1, :enum2])
+            ]
+          end
 
-            expected_result = <<~EOS
+          let :expected_result do
+            <<~EOS
               # Schema Info
               #
               # Table name: users
@@ -219,25 +245,27 @@ describe AnnotateModels do
               #  name :enum             not null, (enum1, enum2)
               #
             EOS
+          end
 
-            expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
+          it 'returns schema info' do
+            is_expected.to eq(expected_result)
           end
         end
 
         context 'when unsigned columns exist' do
-          it 'returns schema info' do
-            klass = mock_class(:users,
-                               nil,
-                               [
-                                 mock_column(:id, :integer),
-                                 mock_column(:integer, :integer, unsigned?: true),
-                                 mock_column(:bigint,  :integer, unsigned?: true, bigint?: true),
-                                 mock_column(:bigint,  :bigint,  unsigned?: true),
-                                 mock_column(:float,   :float,   unsigned?: true),
-                                 mock_column(:decimal, :decimal, unsigned?: true, precision: 10, scale: 2),
-                               ])
+          let :columns do
+            [
+              mock_column(:id, :integer),
+              mock_column(:integer, :integer, unsigned?: true),
+              mock_column(:bigint,  :integer, unsigned?: true, bigint?: true),
+              mock_column(:bigint,  :bigint,  unsigned?: true),
+              mock_column(:float,   :float,   unsigned?: true),
+              mock_column(:decimal, :decimal, unsigned?: true, precision: 10, scale: 2),
+            ]
+          end
 
-            expected_result = <<~EOS
+          let :expected_result do
+            <<~EOS
               # Schema Info
               #
               # Table name: users
@@ -250,25 +278,31 @@ describe AnnotateModels do
               #  decimal :decimal(10, 2)   unsigned, not null
               #
             EOS
+          end
 
-            expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
+          it 'returns schema info' do
+            is_expected.to eq(expected_result)
           end
         end
       end
 
       context 'when the primary key is specified' do
         context 'when the primary_key is :id' do
-          context 'when columns are normal' do
-            it 'returns schema info' do
-              klass = mock_class(:users,
-                                 :id,
-                                 [
-                                   mock_column(:id, :integer, limit: 8),
-                                   mock_column(:name, :string, limit: 50),
-                                   mock_column(:notes, :text, limit: 55)
-                                 ])
+          let :primary_key do
+            :id
+          end
 
-              expected_result = <<~EOS
+          context 'when columns are normal' do
+            let :columns do
+              [
+                mock_column(:id, :integer, limit: 8),
+                mock_column(:name, :string, limit: 50),
+                mock_column(:notes, :text, limit: 55)
+              ]
+            end
+
+            let :expected_result do
+              <<~EOS
                 # Schema Info
                 #
                 # Table name: users
@@ -278,22 +312,24 @@ describe AnnotateModels do
                 #  notes :text(55)         not null
                 #
               EOS
+            end
 
-              expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
+            it 'returns schema info' do
+              is_expected.to eq(expected_result)
             end
           end
 
           context 'when columns have default values' do
-            it 'returns schema info with default values' do
-              klass = mock_class(:users,
-                                 :id,
-                                 [
-                                   mock_column(:id, :integer),
-                                   mock_column(:size, :integer, default: 20),
-                                   mock_column(:flag, :boolean, default: false)
-                                 ])
+            let :columns do
+              [
+                mock_column(:id, :integer),
+                mock_column(:size, :integer, default: 20),
+                mock_column(:flag, :boolean, default: false)
+              ]
+            end
 
-              expected_result = <<~EOS
+            let :expected_result do
+              <<~EOS
                 # Schema Info
                 #
                 # Table name: users
@@ -303,21 +339,31 @@ describe AnnotateModels do
                 #  flag :boolean          default(FALSE), not null
                 #
               EOS
+            end
 
-              expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
+            it 'returns schema info with default values' do
+              is_expected.to eq(expected_result)
             end
           end
 
           context 'when an integer column using ActiveRecord::Enum exists' do
-            it 'returns schema info with default values' do
-              klass = mock_class(:users,
-                                 :id,
-                                 [
-                                   mock_column(:id, :integer),
-                                   mock_column(:status, :integer, default: 0)
-                                 ])
+            let :columns do
+              [
+                mock_column(:id, :integer),
+                mock_column(:status, :integer, default: 0)
+              ]
+            end
 
-              expected_result = <<~EOS
+            before :each do
+              # column_defaults may be overritten when ActiveRecord::Enum is used, e.g:
+              # class User < ActiveRecord::Base
+              #   enum status: [ :disabled, :enabled ]
+              # end
+              allow(klass).to receive(:column_defaults).and_return('id' => nil, 'status' => 'disabled')
+            end
+
+            let :expected_result do
+              <<~EOS
                 # Schema Info
                 #
                 # Table name: users
@@ -326,29 +372,36 @@ describe AnnotateModels do
                 #  status :integer          default(0), not null
                 #
               EOS
+            end
 
-              # column_defaults may be overritten when ActiveRecord::Enum is used, e.g:
-              # class User < ActiveRecord::Base
-              #   enum status: [ :disabled, :enabled ]
-              # end
-              allow(klass).to receive(:column_defaults).and_return('id' => nil, 'status' => 'disabled')
-              expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
+            it 'returns schema info with default values' do
+              is_expected.to eq(expected_result)
             end
           end
 
           context 'when indexes exist' do
             context 'when option "show_indexes" is true' do
-              context 'when indexes are normal' do
-                it 'returns schema info with index information' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:foreign_thing_id, :integer)
-                                     ], [mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                     mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])])
+              subject do
+                AnnotateModels.get_schema_info(klass, header, show_indexes: true)
+              end
 
-                  expected_result = <<~EOS
+              context 'when indexes are normal' do
+                let :columns do
+                  [
+                    mock_column(:id, :integer),
+                    mock_column(:foreign_thing_id, :integer)
+                  ]
+                end
+
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
                     # Schema Info
                     #
                     # Table name: users
@@ -362,29 +415,34 @@ describe AnnotateModels do
                     #  index_rails_02e851e3b8  (foreign_thing_id)
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
                 end
               end
 
               context 'when one of indexes includes orderd index key' do
-                it 'returns schema info with index information' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column("id", :integer),
-                                       mock_column("firstname", :string),
-                                       mock_column("surname", :string),
-                                       mock_column("value", :string)
-                                     ],
-                                     [
-                                       mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                       mock_index('index_rails_02e851e3b8',
-                                                  columns: %w(firstname surname value),
-                                                  orders: { 'surname' => :asc, 'value' => :desc })
-                                     ])
+                let :columns do
+                  [
+                    mock_column("id", :integer),
+                    mock_column("firstname", :string),
+                    mock_column("surname", :string),
+                    mock_column("value", :string)
+                  ]
+                end
 
-                  expected_result = <<~EOS
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: %w(firstname surname value),
+                               orders: { 'surname' => :asc, 'value' => :desc })
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
                     # Schema Info
                     #
                     # Table name: users
@@ -400,29 +458,34 @@ describe AnnotateModels do
                     #  index_rails_02e851e3b8  (firstname,surname ASC,value DESC)
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
                 end
               end
 
               context 'when one of indexes includes "where" clause' do
-                it 'returns schema info with index information' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column("id", :integer),
-                                       mock_column("firstname", :string),
-                                       mock_column("surname", :string),
-                                       mock_column("value", :string)
-                                     ],
-                                     [
-                                       mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                       mock_index('index_rails_02e851e3b8',
-                                                  columns: %w(firstname surname),
-                                                  where: 'value IS NOT NULL')
-                                     ])
+                let :columns do
+                  [
+                    mock_column("id", :integer),
+                    mock_column("firstname", :string),
+                    mock_column("surname", :string),
+                    mock_column("value", :string)
+                  ]
+                end
 
-                  expected_result = <<~EOS
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: %w(firstname surname),
+                               where: 'value IS NOT NULL')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
                     # Schema Info
                     #
                     # Table name: users
@@ -438,29 +501,34 @@ describe AnnotateModels do
                     #  index_rails_02e851e3b8  (firstname,surname) WHERE value IS NOT NULL
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
                 end
               end
 
               context 'when one of indexes includes "using" clause other than "btree"' do
-                it 'returns schema info with index information' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column("id", :integer),
-                                       mock_column("firstname", :string),
-                                       mock_column("surname", :string),
-                                       mock_column("value", :string)
-                                     ],
-                                     [
-                                       mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                       mock_index('index_rails_02e851e3b8',
-                                                  columns: %w(firstname surname),
-                                                  using: 'hash')
-                                     ])
+                let :columns do
+                  [
+                    mock_column("id", :integer),
+                    mock_column("firstname", :string),
+                    mock_column("surname", :string),
+                    mock_column("value", :string)
+                  ]
+                end
 
-                  expected_result = <<~EOS
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: %w(firstname surname),
+                               using: 'hash')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
                     # Schema Info
                     #
                     # Table name: users
@@ -476,21 +544,27 @@ describe AnnotateModels do
                     #  index_rails_02e851e3b8  (firstname,surname) USING hash
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
                 end
               end
 
               context 'when index is not defined' do
-                it 'returns schema info without index information' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:foreign_thing_id, :integer)
-                                     ], [])
+                let :columns do
+                  [
+                    mock_column(:id, :integer),
+                    mock_column(:foreign_thing_id, :integer)
+                  ]
+                end
 
-                  expected_result = <<~EOS
+                let :indexes do
+                  []
+                end
+
+                let :expected_result do
+                  <<~EOS
                     # Schema Info
                     #
                     # Table name: users
@@ -499,29 +573,38 @@ describe AnnotateModels do
                     #  foreign_thing_id :integer          not null
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_indexes: true)).to eql(expected_result)
+                it 'returns schema info without index information' do
+                  is_expected.to eq expected_result
                 end
               end
             end
 
             context 'when option "simple_indexes" is true' do
-              context 'when one of indexes includes "orders" clause' do # TODO
-                it 'returns schema info with index information' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:foreign_thing_id, :integer)
-                                     ],
-                                     [
-                                       mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                       mock_index('index_rails_02e851e3b8',
-                                                  columns: ['foreign_thing_id'],
-                                                  orders: { 'foreign_thing_id' => :desc })
-                                     ])
+              subject do
+                AnnotateModels.get_schema_info(klass, header, simple_indexes: true)
+              end
 
-                  expected_result = <<~EOS
+              context 'when one of indexes includes "orders" clause' do # TODO
+                let :columns do
+                  [
+                    mock_column(:id, :integer),
+                    mock_column(:foreign_thing_id, :integer)
+                  ]
+                end
+
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: ['foreign_thing_id'],
+                               orders: { 'foreign_thing_id' => :desc })
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
                     # Schema Info
                     #
                     # Table name: users
@@ -530,22 +613,30 @@ describe AnnotateModels do
                     #  foreign_thing_id :integer          not null
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, 'Schema Info', simple_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
                 end
               end
 
               context 'when one of indexes is in string form' do
-                it 'returns schema info with index information' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column("id", :integer),
-                                       mock_column("name", :string)
-                                     ], [mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                     mock_index('index_rails_02e851e3b8', columns: 'LOWER(name)')])
+                let :columns do
+                  [
+                    mock_column("id", :integer),
+                    mock_column("name", :string)
+                  ]
+                end
 
-                  expected_result = <<~EOS
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8', columns: 'LOWER(name)')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
                     # Schema Info
                     #
                     # Table name: users
@@ -554,37 +645,39 @@ describe AnnotateModels do
                     #  name :string           not null
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, 'Schema Info', simple_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information' do
+                  is_expected.to eq expected_result
                 end
               end
             end
           end
 
           context 'when foreign keys exist' do
-            context 'when option "show_foreign_keys" is specified' do
-              context 'when foreign_keys does not have option' do
-                it 'returns schema info with foreign keys' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:foreign_thing_id, :integer)
-                                     ],
-                                     [],
-                                     [
-                                       mock_foreign_key('fk_rails_cf2568e89e',
-                                                        'foreign_thing_id',
-                                                        'foreign_things'),
-                                       mock_foreign_key('custom_fk_name',
-                                                        'other_thing_id',
-                                                        'other_things'),
-                                       mock_foreign_key('fk_rails_a70234b26c',
-                                                        'third_thing_id',
-                                                        'third_things')
-                                     ])
+            let :columns do
+              [
+                mock_column(:id, :integer),
+                mock_column(:foreign_thing_id, :integer)
+              ]
+            end
 
-                  expected_result = <<~EOS
+            let :foreign_keys do
+              [
+                mock_foreign_key('fk_rails_cf2568e89e', 'foreign_thing_id', 'foreign_things'),
+                mock_foreign_key('custom_fk_name', 'other_thing_id', 'other_things'),
+                mock_foreign_key('fk_rails_a70234b26c', 'third_thing_id', 'third_things')
+              ]
+            end
+
+            context 'when option "show_foreign_keys" is specified' do
+              subject do
+                AnnotateModels.get_schema_info(klass, header, show_foreign_keys: true)
+              end
+
+              context 'when foreign_keys does not have option' do
+                let :expected_result do
+                  <<~EOS
                     # Schema Info
                     #
                     # Table name: users
@@ -599,30 +692,27 @@ describe AnnotateModels do
                     #  fk_rails_...    (third_thing_id => third_things.id)
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(expected_result)
+                it 'returns schema info with foreign keys' do
+                  is_expected.to eq(expected_result)
                 end
               end
 
               context 'when foreign_keys have option "on_delete" and "on_update"' do
-                it 'returns schema info with foreign keys' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:foreign_thing_id, :integer)
-                                     ],
-                                     [],
-                                     [
-                                       mock_foreign_key('fk_rails_02e851e3b7',
-                                                        'foreign_thing_id',
-                                                        'foreign_things',
-                                                        'id',
-                                                        on_delete: 'on_delete_value',
-                                                        on_update: 'on_update_value')
-                                     ])
+                let :foreign_keys do
+                  [
+                    mock_foreign_key('fk_rails_02e851e3b7',
+                                     'foreign_thing_id',
+                                     'foreign_things',
+                                     'id',
+                                     on_delete: 'on_delete_value',
+                                     on_update: 'on_update_value')
+                  ]
+                end
 
-                  expected_result = <<~EOS
+                let :expected_result do
+                  <<~EOS
                     # Schema Info
                     #
                     # Table name: users
@@ -635,34 +725,21 @@ describe AnnotateModels do
                     #  fk_rails_...  (foreign_thing_id => foreign_things.id) ON DELETE => on_delete_value ON UPDATE => on_update_value
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true)).to eql(expected_result)
+                it 'returns schema info with foreign keys' do
+                  is_expected.to eq(expected_result)
                 end
               end
             end
 
             context 'when option "show_foreign_keys" and "show_complete_foreign_keys" are specified' do
-              it 'returns schema info with foreign keys' do
-                klass = mock_class(:users,
-                                   :id,
-                                   [
-                                     mock_column(:id, :integer),
-                                     mock_column(:foreign_thing_id, :integer)
-                                   ],
-                                   [],
-                                   [
-                                     mock_foreign_key('fk_rails_cf2568e89e',
-                                                      'foreign_thing_id',
-                                                      'foreign_things'),
-                                     mock_foreign_key('custom_fk_name',
-                                                      'other_thing_id',
-                                                      'other_things'),
-                                     mock_foreign_key('fk_rails_a70234b26c',
-                                                      'third_thing_id',
-                                                      'third_things')
-                                   ])
+              subject do
+                AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)
+              end
 
-                expected_result = <<~EOS
+              let :expected_result do
+                <<~EOS
                   # Schema Info
                   #
                   # Table name: users
@@ -677,24 +754,30 @@ describe AnnotateModels do
                   #  fk_rails_cf2568e89e  (foreign_thing_id => foreign_things.id)
                   #
                 EOS
+              end
 
-                expect(AnnotateModels.get_schema_info(klass, 'Schema Info', show_foreign_keys: true, show_complete_foreign_keys: true)).to eql(expected_result)
+              it 'returns schema info with foreign keys' do
+                is_expected.to eq(expected_result)
               end
             end
           end
         end
 
         context 'when the primary key is an array (using composite_primary_keys)' do
-          it 'returns schema info' do
-            klass = mock_class(:users,
-                               [:a_id, :b_id],
-                               [
-                                 mock_column(:a_id, :integer),
-                                 mock_column(:b_id, :integer),
-                                 mock_column(:name, :string, limit: 50)
-                               ])
+          let :primary_key do
+            [:a_id, :b_id]
+          end
 
-            expected_result = <<~EOS
+          let :columns do
+            [
+              mock_column(:a_id, :integer),
+              mock_column(:b_id, :integer),
+              mock_column(:name, :string, limit: 50)
+            ]
+          end
+
+          let :expected_result do
+            <<~EOS
               # Schema Info
               #
               # Table name: users
@@ -704,26 +787,40 @@ describe AnnotateModels do
               #  name :string(50)       not null
               #
             EOS
+          end
 
-            expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
+          it 'returns schema info' do
+            is_expected.to eq(expected_result)
           end
         end
       end
     end
 
     context 'when header is "== Schema Information"' do
+      let :header do
+        AnnotateModels::PREFIX
+      end
+
       context 'when the primary key is specified' do
         context 'when the primary_key is :id' do
-          context 'when option "format_rdoc" is true' do
-            it 'returns schema info in RDoc format' do
-              klass = mock_class(:users,
-                                 :id,
-                                 [
-                                   mock_column(:id, :integer),
-                                   mock_column(:name, :string, limit: 50)
-                                 ])
+          let :primary_key do
+            :id
+          end
 
-              expected_result = <<~EOS
+          let :columns do
+            [
+              mock_column(:id, :integer),
+              mock_column(:name, :string, limit: 50)
+            ]
+          end
+
+          context 'when option "format_rdoc" is true' do
+            subject do
+              AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true)
+            end
+
+            let :expected_result do
+              <<~EOS
                 # == Schema Information
                 #
                 # Table name: users
@@ -734,22 +831,21 @@ describe AnnotateModels do
                 # == Schema Information End
                 #++
               EOS
+            end
 
-              expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_rdoc: true)).to eql(expected_result)
+            it 'returns schema info in RDoc format' do
+              is_expected.to eq(expected_result)
             end
           end
 
           context 'when option "format_markdown" is true' do
             context 'when other option is not specified' do
-              it 'returns schema info in Markdown format' do
-                klass = mock_class(:users,
-                                   :id,
-                                   [
-                                     mock_column(:id, :integer),
-                                     mock_column(:name, :string, limit: 50)
-                                   ])
+              subject do
+                AnnotateModels.get_schema_info(klass, header, format_markdown: true)
+              end
 
-                expected_result = <<~EOS
+              let :expected_result do
+                <<~EOS
                   # == Schema Information
                   #
                   # Table name: `users`
@@ -762,27 +858,28 @@ describe AnnotateModels do
                   # **`name`**  | `string(50)`       | `not null`
                   #
                 EOS
+              end
 
-                expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true)).to eql(expected_result)
+              it 'returns schema info in Markdown format' do
+                is_expected.to eq(expected_result)
               end
             end
 
             context 'when option "show_indexes" is true' do
-              context 'when indexes are normal' do
-                it 'returns schema info with index information in Markdown format' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:name, :string, limit: 50)
-                                     ],
-                                     [
-                                       mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                       mock_index('index_rails_02e851e3b8',
-                                                  columns: ['foreign_thing_id'])
-                                     ])
+              subject do
+                AnnotateModels.get_schema_info(klass, header, format_markdown: true, show_indexes: true)
+              end
 
-                  expected_result = <<~EOS
+              context 'when indexes are normal' do
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
                     # == Schema Information
                     #
                     # Table name: `users`
@@ -802,27 +899,25 @@ describe AnnotateModels do
                     #     * **`foreign_thing_id`**
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information in Markdown format' do
+                  is_expected.to eq expected_result
                 end
               end
 
               context 'when one of indexes includes "unique" clause' do
-                it 'returns schema info with index information in Markdown format' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:name, :string, limit: 50)
-                                     ],
-                                     [
-                                       mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                       mock_index('index_rails_02e851e3b8',
-                                                  columns: ['foreign_thing_id'],
-                                                  unique: true)
-                                     ])
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: ['foreign_thing_id'],
+                               unique: true)
+                  ]
+                end
 
-                  expected_result = <<~EOS
+                let :expected_result do
+                  <<~EOS
                     # == Schema Information
                     #
                     # Table name: `users`
@@ -842,27 +937,25 @@ describe AnnotateModels do
                     #     * **`foreign_thing_id`**
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information in Markdown format' do
+                  is_expected.to eq expected_result
                 end
               end
 
               context 'when one of indexes includes orderd index key' do
-                it 'returns schema info with index information in Markdown format' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:name, :string, limit: 50)
-                                     ],
-                                     [
-                                       mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                       mock_index('index_rails_02e851e3b8',
-                                                  columns: ['foreign_thing_id'],
-                                                  orders: { 'foreign_thing_id' => :desc })
-                                     ])
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: ['foreign_thing_id'],
+                               orders: { 'foreign_thing_id' => :desc })
+                  ]
+                end
 
-                  expected_result = <<~EOS
+                let :expected_result do
+                  <<~EOS
                     # == Schema Information
                     #
                     # Table name: `users`
@@ -882,28 +975,26 @@ describe AnnotateModels do
                     #     * **`foreign_thing_id DESC`**
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information in Markdown format' do
+                  is_expected.to eq expected_result
                 end
               end
 
               context 'when one of indexes includes "where" clause and "unique" clause' do
-                it 'returns schema info with index information in Markdown format' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:name, :string, limit: 50)
-                                     ],
-                                     [
-                                       mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                       mock_index('index_rails_02e851e3b8',
-                                                  columns: ['foreign_thing_id'],
-                                                  unique: true,
-                                                  where: 'name IS NOT NULL')
-                                     ])
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: ['foreign_thing_id'],
+                               unique: true,
+                               where: 'name IS NOT NULL')
+                  ]
+                end
 
-                  expected_result = <<~EOS
+                let :expected_result do
+                  <<~EOS
                     # == Schema Information
                     #
                     # Table name: `users`
@@ -923,27 +1014,25 @@ describe AnnotateModels do
                     #     * **`foreign_thing_id`**
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information in Markdown format' do
+                  is_expected.to eq expected_result
                 end
               end
 
               context 'when one of indexes includes "using" clause other than "btree"' do
-                it 'returns schema info with index information in Markdown format' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:name, :string, limit: 50)
-                                     ],
-                                     [
-                                       mock_index('index_rails_02e851e3b7', columns: ['id']),
-                                       mock_index('index_rails_02e851e3b8',
-                                                  columns: ['foreign_thing_id'],
-                                                  using: 'hash')
-                                     ])
+                let :indexes do
+                  [
+                    mock_index('index_rails_02e851e3b7', columns: ['id']),
+                    mock_index('index_rails_02e851e3b8',
+                               columns: ['foreign_thing_id'],
+                               using: 'hash')
+                  ]
+                end
 
-                  expected_result = <<~EOS
+                let :expected_result do
+                  <<~EOS
                     # == Schema Information
                     #
                     # Table name: `users`
@@ -963,32 +1052,40 @@ describe AnnotateModels do
                     #     * **`foreign_thing_id`**
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
+                it 'returns schema info with index information in Markdown format' do
+                  is_expected.to eq expected_result
                 end
               end
             end
 
             context 'when option "show_foreign_keys" is true' do
-              context 'when foreign_keys have option "on_delete" and "on_update"' do
-                it 'returns schema info with foreign_keys in Markdown format' do
-                  klass = mock_class(:users,
-                                     :id,
-                                     [
-                                       mock_column(:id, :integer),
-                                       mock_column(:foreign_thing_id, :integer)
-                                     ],
-                                     [],
-                                     [
-                                       mock_foreign_key('fk_rails_02e851e3b7',
-                                                        'foreign_thing_id',
-                                                        'foreign_things',
-                                                        'id',
-                                                        on_delete: 'on_delete_value',
-                                                        on_update: 'on_update_value')
-                                     ])
+              subject do
+                AnnotateModels.get_schema_info(klass, header, format_markdown: true, show_foreign_keys: true)
+              end
 
-                  expected_result = <<~EOS
+              let :columns do
+                [
+                  mock_column(:id, :integer),
+                  mock_column(:foreign_thing_id, :integer)
+                ]
+              end
+
+              context 'when foreign_keys have option "on_delete" and "on_update"' do
+                let :foreign_keys do
+                  [
+                    mock_foreign_key('fk_rails_02e851e3b7',
+                                     'foreign_thing_id',
+                                     'foreign_things',
+                                     'id',
+                                     on_delete: 'on_delete_value',
+                                     on_update: 'on_update_value')
+                  ]
+                end
+
+                let :expected_result do
+                  <<~EOS
                     # == Schema Information
                     #
                     # Table name: `users`
@@ -1006,8 +1103,10 @@ describe AnnotateModels do
                     #     * **`foreign_thing_id => foreign_things.id`**
                     #
                   EOS
+                end
 
-                  expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_foreign_keys: true)).to eql(expected_result)
+                it 'returns schema info with foreign_keys in Markdown format' do
+                  is_expected.to eq(expected_result)
                 end
               end
             end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -196,29 +196,6 @@ describe AnnotateModels do
     expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
   end
 
-  it 'should get schema info even if the primary key is array, if using composite_primary_keys' do
-    klass = mock_class(:users,
-                       [:a_id, :b_id],
-                       [
-                         mock_column(:a_id, :integer),
-                         mock_column(:b_id, :integer),
-                         mock_column(:name, :string, limit: 50)
-                       ])
-
-    expected_result = <<~EOS
-      # Schema Info
-      #
-      # Table name: users
-      #
-      #  a_id :integer          not null, primary key
-      #  b_id :integer          not null, primary key
-      #  name :string(50)       not null
-      #
-    EOS
-
-    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
-  end
-
   it 'should get schema info with enum type' do
     klass = mock_class(:users,
                        nil,
@@ -933,6 +910,29 @@ describe AnnotateModels do
     EOS
 
     expect(AnnotateModels.get_schema_info(klass, AnnotateModels::PREFIX, format_markdown: true, show_indexes: true)).to eql(expected_result)
+  end
+
+  it 'should get schema info even if the primary key is array, if using composite_primary_keys' do
+    klass = mock_class(:users,
+                       [:a_id, :b_id],
+                       [
+                         mock_column(:a_id, :integer),
+                         mock_column(:b_id, :integer),
+                         mock_column(:name, :string, limit: 50)
+                       ])
+
+    expected_result = <<~EOS
+      # Schema Info
+      #
+      # Table name: users
+      #
+      #  a_id :integer          not null, primary key
+      #  b_id :integer          not null, primary key
+      #  name :string(50)       not null
+      #
+    EOS
+
+    expect(AnnotateModels.get_schema_info(klass, 'Schema Info')).to eql(expected_result)
   end
 
   it 'should work with the Globalize gem' do


### PR DESCRIPTION
I refactored test cases of AnnotateModels without custom options.

I will refactor the test case added in #602 in another PR.
