### PR TITLE
Fix additional_file_patterns parsing

### DIFF
--- a/lib/annotate.rb
+++ b/lib/annotate.rb
@@ -57,6 +57,7 @@ module Annotate
     end
 
     options[:additional_file_patterns] ||= []
+    options[:additional_file_patterns] = options[:additional_file_patterns].split(',') if options[:additional_file_patterns].is_a?(String)
     options[:model_dir] = ['app/models'] if options[:model_dir].empty?
 
     options[:wrapper_open] ||= options[:wrapper]


### PR DESCRIPTION
There is a bug where `additional_file_patterns` are not parsed as an array from the rake config.  This splits them by `,`, as the `parser.rb` for CLI args.