### PR TITLE
Adding option to skip loading models from subdirectories

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -631,7 +631,7 @@ module AnnotateModels
     def parse_options(options = {})
       self.model_dir = split_model_dir(options[:model_dir]) if options[:model_dir]
       self.root_dir = options[:root_dir] if options[:root_dir]
-      self.skip_subdirectory_model_load = options[:skip_subdirectory_model_load].present? ? options[:skip_subdirectory_model_load] : false
+      self.skip_subdirectory_model_load = options[:skip_subdirectory_model_load].present?
     end
 
     def split_model_dir(option_value)

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -70,7 +70,7 @@ module AnnotateModels
     def skip_subdirectory_model_load
       # This option is set in options[:skip_subdirectory_model_load]
       # and stops the get_loaded_model method from loading a model from a subdir
- 
+
       if @skip_subdirectory_model_load.blank?
         false
       else
@@ -599,7 +599,7 @@ module AnnotateModels
 
     # Retrieve loaded model class
     def get_loaded_model(model_path, file)
-      if !skip_subdirectory_model_load
+      unless skip_subdirectory_model_load
         loaded_model_class = get_loaded_model_by_path(model_path)
         return loaded_model_class if loaded_model_class
       end

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -67,6 +67,16 @@ module AnnotateModels
 
     attr_writer :root_dir
 
+    def skip_subdirectory_model_load
+      if @skip_subdirectory_model_load.blank?
+        false
+      else
+        @skip_subdirectory_model_load
+      end
+    end
+
+    attr_writer :skip_subdirectory_model_load
+
     def get_patterns(options, pattern_types = [])
       current_patterns = []
       root_dir.each do |root_directory|
@@ -586,8 +596,10 @@ module AnnotateModels
 
     # Retrieve loaded model class
     def get_loaded_model(model_path, file)
-      loaded_model_class = get_loaded_model_by_path(model_path)
-      return loaded_model_class if loaded_model_class
+      if !skip_subdirectory_model_load
+        loaded_model_class = get_loaded_model_by_path(model_path)
+        return loaded_model_class if loaded_model_class
+      end
 
       # We cannot get loaded model when `model_path` is loaded by Rails
       # auto_load/eager_load paths. Try all possible model paths one by one.
@@ -616,6 +628,7 @@ module AnnotateModels
     def parse_options(options = {})
       self.model_dir = split_model_dir(options[:model_dir]) if options[:model_dir]
       self.root_dir = options[:root_dir] if options[:root_dir]
+      self.skip_subdirectory_model_load = options[:skip_subdirectory_model_load].present? ? options[:skip_subdirectory_model_load] : false
     end
 
     def split_model_dir(option_value)

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -68,6 +68,9 @@ module AnnotateModels
     attr_writer :root_dir
 
     def skip_subdirectory_model_load
+      # This option is set in options[:skip_subdirectory_model_load]
+      # and stops the get_loaded_model method from loading a model from a subdir
+ 
       if @skip_subdirectory_model_load.blank?
         false
       else

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -207,7 +207,6 @@ describe AnnotateModels do
         it 'sets skip_subdirectory_model_load to false' do
           is_expected.to eq(false)
         end
-
       end
     end
   end


### PR DESCRIPTION
Currently the models annotator automatically attempts to find a class with a matching name at the bottom of project's directory tree before going up into specific engine's models.  This causes issues with models that share names with classes in other engines or lower classes in the project's directory.   This PR adds the option to skip attempts to load classes from lower directories and just uses the model's file path directly. 

 #674 

cc @maxh