### PR TITLE
[Revert #677] Fix column default annotations

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -213,7 +213,7 @@ module AnnotateModels
     end
 
     def schema_default(klass, column)
-      quote(klass.columns.find { |x| x.name.to_s == column.name.to_s }.try(:default))
+      quote(klass.column_defaults[column.name])
     end
 
     def retrieve_indexes_from_table(klass)

--- a/spec/integration/rails_5.2.4.1_spec.rb
+++ b/spec/integration/rails_5.2.4.1_spec.rb
@@ -34,8 +34,8 @@ describe 'Integration testing on Rails 5.2.4.1', if: IntegrationHelper.able_to_r
         +#
         +#  id         :integer          not null, primary key
         +#  content    :string
-        +#  count      :integer          default("0")
-        +#  status     :boolean          default("0")
+        +#  count      :integer          default(0)
+        +#  status     :boolean          default(FALSE)
         +#  created_at :datetime         not null
         +#  updated_at :datetime         not null
         +#
@@ -55,8 +55,8 @@ describe 'Integration testing on Rails 5.2.4.1', if: IntegrationHelper.able_to_r
         +#
         +#  id         :integer          not null, primary key
         +#  content    :string
-        +#  count      :integer          default("0")
-        +#  status     :boolean          default("0")
+        +#  count      :integer          default(0)
+        +#  status     :boolean          default(FALSE)
         +#  created_at :datetime         not null
         +#  updated_at :datetime         not null
         +#
@@ -76,8 +76,8 @@ describe 'Integration testing on Rails 5.2.4.1', if: IntegrationHelper.able_to_r
         +#
         +#  id         :integer          not null, primary key
         +#  content    :string
-        +#  count      :integer          default("0")
-        +#  status     :boolean          default("0")
+        +#  count      :integer          default(0)
+        +#  status     :boolean          default(FALSE)
         +#  created_at :datetime         not null
         +#  updated_at :datetime         not null
         +#

--- a/spec/integration/rails_6.0.2.1_spec.rb
+++ b/spec/integration/rails_6.0.2.1_spec.rb
@@ -34,8 +34,8 @@ describe 'Integration testing on Rails 6.0.2.1', if: IntegrationHelper.able_to_r
         +#
         +#  id         :integer          not null, primary key
         +#  content    :string
-        +#  count      :integer          default("0")
-        +#  status     :boolean          default("0")
+        +#  count      :integer          default(0)
+        +#  status     :boolean          default(FALSE)
         +#  created_at :datetime         not null
         +#  updated_at :datetime         not null
         +#
@@ -55,8 +55,8 @@ describe 'Integration testing on Rails 6.0.2.1', if: IntegrationHelper.able_to_r
         +#
         +#  id         :integer          not null, primary key
         +#  content    :string
-        +#  count      :integer          default("0")
-        +#  status     :boolean          default("0")
+        +#  count      :integer          default(0)
+        +#  status     :boolean          default(FALSE)
         +#  created_at :datetime         not null
         +#  updated_at :datetime         not null
         +#
@@ -76,8 +76,8 @@ describe 'Integration testing on Rails 6.0.2.1', if: IntegrationHelper.able_to_r
         +#
         +#  id         :integer          not null, primary key
         +#  content    :string
-        +#  count      :integer          default("0")
-        +#  status     :boolean          default("0")
+        +#  count      :integer          default(0)
+        +#  status     :boolean          default(FALSE)
         +#  created_at :datetime         not null
         +#  updated_at :datetime         not null
         +#

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -351,39 +351,6 @@ describe AnnotateModels do
               end
             end
 
-            context 'when an integer column using ActiveRecord::Enum exists' do
-              let :columns do
-                [
-                  mock_column(:id, :integer),
-                  mock_column(:status, :integer, default: 0)
-                ]
-              end
-
-              before :each do
-                # column_defaults may be overritten when ActiveRecord::Enum is used, e.g:
-                # class User < ActiveRecord::Base
-                #   enum status: [ :disabled, :enabled ]
-                # end
-                allow(klass).to receive(:column_defaults).and_return('id' => nil, 'status' => 'disabled')
-              end
-
-              let :expected_result do
-                <<~EOS
-                  # Schema Info
-                  #
-                  # Table name: users
-                  #
-                  #  id     :integer          not null, primary key
-                  #  status :integer          default(0), not null
-                  #
-                EOS
-              end
-
-              it 'returns schema info with default values' do
-                is_expected.to eq(expected_result)
-              end
-            end
-
             context 'with Globalize gem' do
               let :translation_klass do
                 double('Post::Translation',


### PR DESCRIPTION
It was reported in https://github.com/ctran/annotate_models/issues/762 that column defaults were broken. This reverts changes made in #677 to restore the expected behavior of column defaults. 

For the time being columns with associated enums won't be working.