### PR TITLE
Bump project required ruby version to >= 2.4

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = 'annotate'
   s.version = Annotate.version
 
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.4.0'
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.authors = ['Alex Chaffee', 'Cuong Tran', 'Marcos Piccinini', 'Turadg Aleahmad', 'Jon Frisby']
   s.description = 'Annotates Rails/ActiveRecord Models, routes, fixtures, and others based on the database schema.'


### PR DESCRIPTION
In #764, it was pointed out that the gemspec requires ruby version `>= 2.2.0`. We've stopped testing for older versions of Ruby in CI and so it makes sense to make it explicit.