### PR TITLE
Fix "undefined method `<'" error message

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -809,7 +809,7 @@ module AnnotateModels
       begin
         return false if /#{SKIP_ANNOTATION_PREFIX}.*/ =~ (File.exist?(file) ? File.read(file) : '')
         klass = get_model_class(file)
-        do_annotate = klass &&
+        do_annotate = klass.is_a?(Class) &&
           klass < ActiveRecord::Base &&
           (!options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name)) &&
           !klass.abstract_class? &&

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2743,5 +2743,18 @@ describe AnnotateModels do
     it 'skips attempt to annotate if no table exists for model' do
       is_expected.to eq nil
     end
+
+    context 'with a non-class' do
+      before do
+        NotAClass = 'foo'.freeze # rubocop:disable Naming/ConstantName
+        allow(AnnotateModels).to receive(:get_model_class).with('foo.rb') { NotAClass }
+      end
+
+      after { Object.send :remove_const, 'NotAClass' }
+
+      it "doesn't output an error" do
+        expect { subject }.not_to output.to_stderr
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

I have some files in the "models" directory that are not true a `Class`. For example, a [`dry-types`](https://dry-rb.org/gems/dry-types/1.2/sum/) sum type:

```ruby
# app/models/foo.rb
Foo = Types::String | Types::Integer
```

This results in the following line when I annotate.

```
Unable to annotate app/models/foo.rb: undefined method `<' for #<Dry::Struct::Sum:0x00007ff2dd262988>
```

Not a blocking issue but somewhat annoying nonetheless.

## Solution

When annotating a file, check that the file's object is a `Class` to ensure it has the interface we expect.