### PR TITLE
ActiveAdmin: Allow for both singular and plural model names

### DIFF
--- a/lib/annotate/annotate_models/file_patterns.rb
+++ b/lib/annotate/annotate_models/file_patterns.rb
@@ -59,7 +59,10 @@ module AnnotateModels
         when 'controller'
           [File.join(root_directory, CONTROLLER_DIR, '%PLURALIZED_MODEL_NAME%_controller.rb')]
         when 'admin'
-          [File.join(root_directory, ACTIVEADMIN_DIR, '%MODEL_NAME%.rb')]
+          [
+            File.join(root_directory, ACTIVEADMIN_DIR, '%MODEL_NAME%.rb'),
+            File.join(root_directory, ACTIVEADMIN_DIR, '%PLURALIZED_MODEL_NAME%.rb')
+          ]
         when 'helper'
           [File.join(root_directory, HELPER_DIR, '%PLURALIZED_MODEL_NAME%_helper.rb')]
         else

--- a/spec/lib/annotate/annotate_models/file_patterns_spec.rb
+++ b/spec/lib/annotate/annotate_models/file_patterns_spec.rb
@@ -119,10 +119,8 @@ describe AnnotateModels::FilePatterns do
     context 'when pattern_type is "admin"' do
       let(:pattern_type) { 'admin' }
 
-      it 'returns patterns of admin files' do
-        is_expected.to eq([
-          '/root/app/admin/%MODEL_NAME%.rb'
-        ])
+      it 'returns both singular and pluralized model names' do
+        is_expected.to eq(['/root/app/admin/%MODEL_NAME%.rb', '/root/app/admin/%PLURALIZED_MODEL_NAME%.rb'])
       end
     end
 


### PR DESCRIPTION
This is an addition to this PR: https://github.com/ctran/annotate_models/pull/692
I've seen it's been stale for a while and it's rather simple fix.

I noticed my ActiveAdmin resources are not being annotated.
I know ActiveAdmin uses plural model names, but, as far as I remember, they used to use singular model names in the past.

We can see some "evidence" of that here: https://activeadmin.info/2-resource-customization.html#customizing-parent-menu-items
Probably in other places as well.

In order to keep the gem working as expected for singular ActiveAdmin resources, I suggest we annotate both singular and plural model names.

I just tested this out in a project of mine where I renamed one file to be in singular form and left the other files in plural form.
It worked like a charm. :)

I also added a test, as best to my knowledge, as there are no similar tests that I could find.

Please let me know what you think!

/cc @danielricecodes @drwl 

Also please, don't make the default rake task do a git checkout! I've never seen this and I've lost the above changes once due to this! I just didn't expect that running tests would be changing the source files in any way.