### PR TITLE
Fix output for multiline column comments

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -251,10 +251,11 @@ module AnnotateModels
         col_type = get_col_type(col)
         attrs = get_attributes(col, col_type, klass, options)
         col_name = if with_comments?(klass, options) && col.comment
-                     "#{col.name}(#{col.comment})"
+                     "#{col.name}(#{col.comment.gsub(/\n/, "\\n")})"
                    else
                      col.name
                    end
+
         if options[:format_rdoc]
           info << sprintf("# %-#{max_size}.#{max_size}s<tt>%s</tt>", "*#{col_name}*::", attrs.unshift(col_type).join(", ")).rstrip + "\n"
         elsif options[:format_yard]

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1096,6 +1096,33 @@ describe AnnotateModels do
                   end
                 end
 
+                context 'when columns have multiline comments' do
+                  let :columns do
+                    [
+                      mock_column(:id,         :integer, limit: 8,  comment: 'ID'),
+                      mock_column(:notes,      :text,    limit: 55, comment: "Notes.\nMay include things like notes."),
+                      mock_column(:no_comment, :text,    limit: 20, comment: nil)
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id(ID)                                       :integer          not null, primary key
+                      #  notes(Notes.\\nMay include things like notes.):text(55)         not null
+                      #  no_comment                                   :text(20)         not null
+                      #
+                    EOS
+                  end
+
+                  it 'works with option "with_comment"' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
                 context 'when geometry columns are included' do
                   let :columns do
                     [


### PR DESCRIPTION
Closes #778 

If a column comment includes the newline character, the newline character
would be "printed" into the annotation block resulting in a line break
and an uncommented line.

For example, for the following table:

```
create_table "users", force: :cascade do |t|
  t.string "name", comment: "This is a comment.\nWith two lines!"
  t.datetime "created_at", precision: 6, null: false
  t.datetime "updated_at", precision: 6, null: false
end
```

annotating the model with the `--with-comment` flag will result in:

```
\# == Schema Information
\#
\# Table name: users
\#
\#  id                                       :bigint           not null, primary key
\#  name(This is a comment.
With two lines!) :string
\#  created_at                               :datetime         not null
\#  updated_at                               :datetime         not null
\#
```

This uncommented line would result in invalid Ruby and cause the file to
no longer be valid.

This fix replaces the newline character with an escaped version, so the
output will look more like:

```
\# == Schema Information
\#
\# Table name: users
\#
\#  id                                       :bigint           not null, primary key
\#  name(This is a comment.\nWith two lines!):string
\#  created_at                               :datetime         not null
\#  updated_at                               :datetime         not null
\#
```