### PR TITLE
Make travis.yml valid and to unblock gem releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ rvm:
 env:
   - RAILS_ENV=development RACK_ENV=development
 
-matrix:
-  allow_failures:
-    - rvm: ruby-head
-
 addons:
   apt_packages:
     - libsqlite3-dev
@@ -30,7 +26,7 @@ jobs:
   include:
     - stage: gem release
       if: tag =~ ^v
-      rvm: 2.6.0
+      rvm: 2.6.5
       script: echo "Deploying to rubygems.org ..."
       deploy:
         provider: rubygems


### PR DESCRIPTION
In https://travis-ci.org/github/ctran/annotate_models/builds/659982898/config?utm_medium=notification&utm_source=github_status it looks like `travis.yml` is not valid and seems the `matrix` portion seems to be overwriting `jobs`, which is used to release the gem. 

This config is valid. I used `travis lint .travis.yml` to validate locally.