### PR TITLE
Some project clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
-  - ruby-head
 
 env:
   - RAILS_ENV=development RACK_ENV=development

--- a/Gemfile
+++ b/Gemfile
@@ -38,5 +38,4 @@ end
 group :test do
   gem 'files', require: false
   gem 'git', require: false
-  gem 'wrong', require: false
 end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -5,6 +5,8 @@ class IntegrationHelper
   }.freeze
 
   def self.able_to_run?(file_path, ruby_version)
+    return false unless ENV['INTEGRATION_TESTS']
+
     file_name = File.basename(file_path)
     rails_app = File.basename(file_name, '_spec.rb')
     ruby_dependency = MIN_RUBY_VERSIONS[rails_app]

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -4,6 +4,7 @@ require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'
 require 'files'
+require 'tmpdir'
 
 describe AnnotateModels do
   MAGIC_COMMENTS = [
@@ -1781,7 +1782,6 @@ describe AnnotateModels do
 
   describe '.get_model_class' do
     before :all do
-      require 'tmpdir'
       AnnotateModels.model_dir = Dir.mktmpdir('annotate_models')
     end
 
@@ -2137,7 +2137,6 @@ describe AnnotateModels do
     end
 
     let :tmpdir do
-      require 'tmpdir'
       Dir.mktmpdir('annotate_models')
     end
 
@@ -2659,21 +2658,13 @@ describe AnnotateModels do
       end
 
       it 'displays just the error message with trace disabled (default)' do
-        error_output = capturing(:stderr) do
-          AnnotateModels.do_annotations model_dir: @model_dir, is_rake: true
-        end
-
-        expect(error_output).to include("Unable to annotate #{@model_dir}/user.rb: oops")
-        expect(error_output).not_to include('/spec/annotate/annotate_models_spec.rb:')
+        expect { AnnotateModels.do_annotations model_dir: @model_dir, is_rake: true }.to output(a_string_including("Unable to annotate #{@model_dir}/user.rb: oops")).to_stderr
+        expect { AnnotateModels.do_annotations model_dir: @model_dir, is_rake: true }.not_to output(a_string_including('/spec/annotate/annotate_models_spec.rb:')).to_stderr
       end
 
       it 'displays the error message and stacktrace with trace enabled' do
-        error_output = capturing(:stderr) do
-          AnnotateModels.do_annotations model_dir: @model_dir, is_rake: true, trace: true
-        end
-
-        expect(error_output).to include("Unable to annotate #{@model_dir}/user.rb: oops")
-        expect(error_output).to include('/spec/lib/annotate/annotate_models_spec.rb:')
+        expect { AnnotateModels.do_annotations model_dir: @model_dir, is_rake: true, trace: true }.to output(a_string_including("Unable to annotate #{@model_dir}/user.rb: oops")).to_stderr
+        expect { AnnotateModels.do_annotations model_dir: @model_dir, is_rake: true, trace: true }.to output(a_string_including('/spec/lib/annotate/annotate_models_spec.rb:')).to_stderr
       end
     end
 
@@ -2689,21 +2680,13 @@ describe AnnotateModels do
       end
 
       it 'displays just the error message with trace disabled (default)' do
-        error_output = capturing(:stderr) do
-          AnnotateModels.remove_annotations model_dir: @model_dir, is_rake: true
-        end
-
-        expect(error_output).to include("Unable to deannotate #{@model_dir}/user.rb: oops")
-        expect(error_output).not_to include("/user.rb:2:in `<class:User>'")
+        expect { AnnotateModels.remove_annotations model_dir: @model_dir, is_rake: true }.to output(a_string_including("Unable to deannotate #{@model_dir}/user.rb: oops")).to_stderr
+        expect { AnnotateModels.remove_annotations model_dir: @model_dir, is_rake: true }.not_to output(a_string_including("/user.rb:2:in `<class:User>'")).to_stderr
       end
 
       it 'displays the error message and stacktrace with trace enabled' do
-        error_output = capturing(:stderr) do
-          AnnotateModels.remove_annotations model_dir: @model_dir, is_rake: true, trace: true
-        end
-
-        expect(error_output).to include("Unable to deannotate #{@model_dir}/user.rb: oops")
-        expect(error_output).to include("/user.rb:2:in `<class:User>'")
+        expect { AnnotateModels.remove_annotations model_dir: @model_dir, is_rake: true, trace: true }.to output(a_string_including("Unable to deannotate #{@model_dir}/user.rb: oops")).to_stderr
+        expect { AnnotateModels.remove_annotations model_dir: @model_dir, is_rake: true, trace: true }.to output(a_string_including("/user.rb:2:in `<class:User>'")).to_stderr
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,6 @@ Bundler.setup
 
 require 'rake'
 require 'rspec'
-require 'wrong/adapters/rspec'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '../lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,18 @@
-require 'coveralls'
-require 'codeclimate-test-reporter'
-require 'simplecov'
+if ENV['COVERAGE']
+  require 'coveralls'
+  require 'codeclimate-test-reporter'
+  require 'simplecov'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [
-    Coveralls::SimpleCov::Formatter,
-    SimpleCov::Formatter::HTMLFormatter,
-    CodeClimate::TestReporter::Formatter
-  ]
-)
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+    [
+      Coveralls::SimpleCov::Formatter,
+      SimpleCov::Formatter::HTMLFormatter,
+      CodeClimate::TestReporter::Formatter
+    ]
+  )
 
-SimpleCov.start
+  SimpleCov.start
+end
 
 require 'rubygems'
 require 'bundler'


### PR DESCRIPTION
This PR does the following:
* moves code coverage generation to happen when `COVERAGE` environment variable is present.
* makes integration tests run when when `INTEGRATION_TESTS` is present.
* moves `ruby-head` from TravisCI build. Previously the configuration allowed for `ruby-head` to be ignored if it failed, but it conflicted with the gem release build job step.