### PR TITLE
Turn on integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           bundle install --jobs=4 --retry=3
 
       - name: Run Tests
-        run: bundle exec rspec
+        run: INTEGRATION_TESTS=1 bundle exec rspec
 
       - name: Rubocop
         run: bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.6.5
 
 env:
-  - RAILS_ENV=development RACK_ENV=development
+  - RAILS_ENV=development RACK_ENV=development INTEGRATION_TESTS=1
 
 addons:
   apt_packages:


### PR DESCRIPTION
Integration tests were made conditional in #786 and so they stopped running in CI. This PR adds the `INTEGRATION_TESTS` environment variable to CI so that integration tests start running again.