### PR TITLE
Only return valid models from get_loaded_model_by_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Into environment gems from Github checkout:
 
     git clone https://github.com/ctran/annotate_models.git annotate_models
     cd annotate_models
-    rake build
-    gem install pkg/annotate-*.gem
+    rake gem
+    gem install dist/annotate-*.gem
 
 ## Usage
 

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -602,7 +602,9 @@ module AnnotateModels
 
     # Retrieve loaded model class by path to the file where it's supposed to be defined.
     def get_loaded_model_by_path(model_path)
-      ActiveSupport::Inflector.constantize(ActiveSupport::Inflector.camelize(model_path))
+      klass = ActiveSupport::Inflector.constantize(ActiveSupport::Inflector.camelize(model_path))
+
+      klass if klass.is_a?(Class) && klass < ActiveRecord::Base
     rescue StandardError, LoadError
       # Revert to the old way but it is not really robust
       ObjectSpace.each_object(::Class)

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2074,7 +2074,40 @@ describe AnnotateModels do
 
         let :file_content_2 do
           <<-EOS
-            class Bar::Foo
+            class Bar::Foo < ActiveRecord::Base
+            end
+          EOS
+        end
+
+        let :klass_2 do
+          AnnotateModels.get_model_class(File.join(AnnotateModels.model_dir[0], filename_2))
+        end
+
+        it 'finds valid model' do
+          expect(klass.name).to eq('Foo')
+          expect(klass_2.name).to eq('Bar::Foo')
+        end
+      end
+
+      context 'the class name and base name clash' do
+        let :filename do
+          'foo.rb'
+        end
+
+        let :file_content do
+          <<-EOS
+            class Foo < ActiveRecord::Base
+            end
+          EOS
+        end
+
+        let :filename_2 do
+          'bar/foo.rb'
+        end
+
+        let :file_content_2 do
+          <<-EOS
+            class Bar::Foo < ActiveRecord::Base
             end
           EOS
         end
@@ -2108,7 +2141,7 @@ describe AnnotateModels do
         let :file_content_2 do
           <<~EOS
             class Voucher
-              class Foo
+              class Foo < ActiveRecord::Base
               end
             end
           EOS


### PR DESCRIPTION
This is a bugfix for the following case:

```
# app/models/foo.rb
module Foo; end

# app/models/bar/foo.rb
class Bar::Foo < Activerecord::Base; end
```

Where `Bar::Foo` would never get annotated.