### PR TITLE
load :set_annotation_options before running :annotate_routes

### DIFF
--- a/lib/tasks/annotate_routes.rake
+++ b/lib/tasks/annotate_routes.rake
@@ -1,6 +1,12 @@
+annotate_lib = File.expand_path(File.dirname(File.dirname(__FILE__)))
+
+unless ENV['is_cli']
+  task :set_annotation_options
+  task annotate_routes: :set_annotation_options
+end
+
 desc "Adds the route map to routes.rb"
 task :annotate_routes => :environment do
-  annotate_lib = File.expand_path(File.dirname(File.dirname(__FILE__)))
   require "#{annotate_lib}/annotate/annotate_routes"
 
   options={}


### PR DESCRIPTION
Make `annotate_routes` depend on `set_annotation_options` just as `annotate_models` does.

Fixes #761.

I copied the `ENV['is_cli']` check from `annotate_models.rake`, but I don't know what its purpose is. Feel free to tell me to get rid of it. I also moved the `annotate_lib = ...` bit to the top of the file to keep `annotate_routes.rake` consistent with `annotate_models.rake`.