### PR TITLE
Fixed columns difference detection

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -375,7 +375,7 @@ module AnnotateModels
       old_header = old_content.match(header_pattern).to_s
       new_header = info_block.match(header_pattern).to_s
 
-      column_pattern = /^#[\t ]+[\w\*\.`]+[\t ]+.+$/
+      column_pattern = /^#[\t ]+[\w\*\.`()]+[\t ]+.+$/
       old_columns = old_header && old_header.scan(column_pattern).sort
       new_columns = new_header && new_header.scan(column_pattern).sort
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2598,6 +2598,30 @@ describe AnnotateModels do
           expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
         end
       end
+
+      context 'with commented column' do
+        before do
+          klass = mock_class(:users,
+                             :id,
+                             [
+                               mock_column(:id, :integer, comment: 'ID'),
+                             ])
+          @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', with_comment: 'yes')
+          annotate_one_file
+        end
+
+        it 'should add new commented columns' do
+          klass = mock_class(:users,
+                             :id,
+                             [
+                               mock_column(:id, :integer, comment: 'ID'),
+                               mock_column(:name, :string, comment: 'Name')
+                             ])
+          @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', with_comment: 'yes')
+          annotate_one_file
+          expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
+        end
+      end
     end
 
     describe 'with existing annotation => :before' do


### PR DESCRIPTION
See also https://github.com/ctran/annotate_models/issues/816

When commented columns was include on annotate, a new commented column was not added.The difference could not be detected because `(comment)` is included after the column name.

Fixed pattern match to detect differences even when `with_comment` option is enabled.