### PR TITLE
Fix typo invlaid -> invalid

### DIFF
--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1971,7 +1971,7 @@ describe AnnotateModels do
       end
     end
 
-    context 'when the file includes invlaid multibyte chars (USASCII)' do
+    context 'when the file includes invalid multibyte chars (USASCII)' do
       context 'when class FooWithUtf8 is defined in "foo_with_utf8.rb"' do
         let :filename do
           'foo_with_utf8.rb'


### PR DESCRIPTION
This PR fixes a typo in a  test name.