### PR TITLE
Put Comments on New Line for Bare Formatting

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -149,24 +149,25 @@ module AnnotateModels
       cols.each do |col|
         col_type = get_col_type(col)
         attrs = get_attributes(col, col_type, klass, options)
-        col_name = if with_comments?(klass, options) && col.comment
-                     "#{col.name}(#{col.comment.gsub(/\n/, "\\n")})"
+        comment = if with_comments?(klass, options) && col.comment
+                     col.comment.gsub(/\n/, "\\n")
                    else
-                     col.name
+                     nil
                    end
+        commented_name = comment ? "#{col.name}(#{comment})" : col.name
 
         if options[:format_rdoc]
-          info << sprintf("# %-#{max_size}.#{max_size}s<tt>%s</tt>", "*#{col_name}*::", attrs.unshift(col_type).join(", ")).rstrip + "\n"
+          info << sprintf("# %-#{max_size}.#{max_size}s<tt>%s</tt>", "*#{commented_name}*::", attrs.unshift(col_type).join(", ")).rstrip + "\n"
         elsif options[:format_yard]
-          info << sprintf("# @!attribute #{col_name}") + "\n"
+          info << sprintf("# @!attribute #{commented_name}") + "\n"
           ruby_class = col.respond_to?(:array) && col.array ? "Array<#{map_col_type_to_ruby_classes(col_type)}>": map_col_type_to_ruby_classes(col_type)
           info << sprintf("#   @return [#{ruby_class}]") + "\n"
         elsif options[:format_markdown]
-          name_remainder = max_size - col_name.length - non_ascii_length(col_name)
+          name_remainder = max_size - commented_name.length - non_ascii_length(commented_name)
           type_remainder = (md_type_allowance - 2) - col_type.length
-          info << (sprintf("# **`%s`**%#{name_remainder}s | `%s`%#{type_remainder}s | `%s`", col_name, " ", col_type, " ", attrs.join(", ").rstrip)).gsub('``', '  ').rstrip + "\n"
+          info << (sprintf("# **`%s`**%#{name_remainder}s | `%s`%#{type_remainder}s | `%s`", commented_name, " ", col_type, " ", attrs.join(", ").rstrip)).gsub('``', '  ').rstrip + "\n"
         else
-          info << format_default(col_name, max_size, col_type, bare_type_allowance, attrs)
+          info << format_default(col.name, max_size, col_type, bare_type_allowance, comment, attrs)
         end
       end
 
@@ -765,7 +766,8 @@ module AnnotateModels
     def max_schema_info_width(klass, options)
       cols = columns(klass, options)
 
-      if with_comments?(klass, options)
+      if with_comments?(klass, options) && [
+          :format_rdoc, :format_markdown, :format_yard].any? { |f| options[f] }
         max_size = cols.map do |column|
           column.name.size + (column.comment ? width(column.comment) : 0)
         end.max || 0
@@ -778,8 +780,17 @@ module AnnotateModels
       max_size
     end
 
-    def format_default(col_name, max_size, col_type, bare_type_allowance, attrs)
-      sprintf("#  %s:%s %s", mb_chars_ljust(col_name, max_size), mb_chars_ljust(col_type, bare_type_allowance),  attrs.join(", ")).rstrip + "\n"
+    def format_default(col_name, max_size, col_type, bare_type_allowance, comment, attrs)
+      output = sprintf(
+        "#  %s:%s %s",
+        mb_chars_ljust(col_name, max_size),
+        mb_chars_ljust(col_type, bare_type_allowance),
+        attrs.join(", ")
+      ).rstrip + "\n"
+      if comment
+        output += sprintf("#    ^ %s", comment).rstrip + "\n"
+      end
+      output
     end
 
     def width(string)

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1078,11 +1078,15 @@ describe AnnotateModels do
                       #
                       # Table name: users
                       #
-                      #  id(ID)         :integer          not null, primary key
-                      #  active(Active) :boolean          not null
-                      #  name(Name)     :string(50)       not null
-                      #  notes(Notes)   :text(55)         not null
-                      #  no_comment     :text(20)         not null
+                      #  id         :integer          not null, primary key
+                      #    ^ ID
+                      #  active     :boolean          not null
+                      #    ^ Active
+                      #  name       :string(50)       not null
+                      #    ^ Name
+                      #  notes      :text(55)         not null
+                      #    ^ Notes
+                      #  no_comment :text(20)         not null
                       #
                     EOS
                   end
@@ -1113,15 +1117,22 @@ describe AnnotateModels do
                       #
                       # Table name: users
                       #
-                      #  id(ＩＤ)                           :integer          not null, primary key
-                      #  active(ＡＣＴＩＶＥ)               :boolean          not null
-                      #  name(ＮＡＭＥ)                     :string(50)       not null
-                      #  notes(ＮＯＴＥＳ)                  :text(55)         not null
-                      #  cyrillic(Кириллица)                :text(30)         not null
-                      #  japanese(熊本大学　イタリア　宝島) :text(60)         not null
-                      #  arabic(لغة)                        :text(20)         not null
-                      #  no_comment                         :text(20)         not null
-                      #  location                           :geometry_collect not null
+                      #  id         :integer          not null, primary key
+                      #    ^ ＩＤ
+                      #  active     :boolean          not null
+                      #    ^ ＡＣＴＩＶＥ
+                      #  name       :string(50)       not null
+                      #    ^ ＮＡＭＥ
+                      #  notes      :text(55)         not null
+                      #    ^ ＮＯＴＥＳ
+                      #  cyrillic   :text(30)         not null
+                      #    ^ Кириллица
+                      #  japanese   :text(60)         not null
+                      #    ^ 熊本大学　イタリア　宝島
+                      #  arabic     :text(20)         not null
+                      #    ^ لغة
+                      #  no_comment :text(20)         not null
+                      #  location   :geometry_collect not null
                       #
                     EOS
                   end
@@ -1146,9 +1157,11 @@ describe AnnotateModels do
                       #
                       # Table name: users
                       #
-                      #  id(ID)                                       :integer          not null, primary key
-                      #  notes(Notes.\\nMay include things like notes.):text(55)         not null
-                      #  no_comment                                   :text(20)         not null
+                      #  id         :integer          not null, primary key
+                      #    ^ ID
+                      #  notes      :text(55)         not null
+                      #    ^ Notes.\\nMay include things like notes.
+                      #  no_comment :text(20)         not null
                       #
                     EOS
                   end


### PR DESCRIPTION
Prevent unusably spaced formatting that occurs when comments are the
length of normal sentences.