### PR TITLE
Travis CI: Add Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.2
 
 env:
   - RAILS_ENV=development RACK_ENV=development INTEGRATION_TESTS=1


### PR DESCRIPTION
This PR adds the latest stable release to the CI matrix.