### PR TITLE
Use `rails routes` instead of `rake routes`, minimum rails is now 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.0
+Changes
+- Minimum supported rails version is now 5.0
+- Fixed rails 6 warning on `rake routes` deprecation
+
 ## 3.1.1
 Changes
 - Bump required ruby version to >= 2.4 [#772](https://github.com/ctran/annotate_models/pull/772)

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-ruby '>= 2.2.0'
+ruby '>= 2.4.0'
 
-gem 'activerecord', '>= 4.2.5', '< 6', require: false
+gem 'activerecord', '>= 5.0', '< 7', require: false
 gem 'rake', require: false
 
 group :development do
@@ -19,7 +19,7 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'rspec', require: false
 
-  gem 'rubocop', '~> 0.68.1', require: false unless RUBY_VERSION =~ /^1.8/
+  gem 'rubocop', '~> 0.68.1', require: false
   gem 'simplecov', require: false
   gem 'terminal-notifier-guard', require: false
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ when using `SpatialAdapter`, `PostgisAdapter` or `PostGISAdapter`:
 #  path            :geometry        line_string, 4326
 ```
 
-Also, if you pass the `-r` option, it'll annotate `routes.rb` with the output of `rake routes`.
+Also, if you pass the `-r` option, it'll annotate `routes.rb` with the output of `rails routes`.
 
 
 ## Upgrading to 3.X and annotate models not working?
@@ -219,7 +219,7 @@ you can do so with a simple environment variable, instead of editing the
                                          If --w option is used, the same text will be used as opening and closing
             --wo, --wrapper-open STR     Annotation wrapper opening.
             --wc, --wrapper-close STR    Annotation wrapper closing
-        -r, --routes                     Annotate routes.rb with the output of 'rake routes'
+        -r, --routes                     Annotate routes.rb with the output of 'rails routes'
             --models                     Annotate ActiveRecord models
         -a, --active-admin               Annotate active_admin models
         -v, --version                    Show the current version of this gem

--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4 if s.respond_to? :specification_version
   s.add_runtime_dependency(%q<rake>, '>= 10.4', '< 14.0')
-  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 7.0'])
+  s.add_runtime_dependency(%q<activerecord>, ['>= 5.0', '< 7.0'])
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/ctran/annotate_models/issues/",

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -4,7 +4,7 @@
 #
 #
 #
-# Prepends the output of "rake routes" to the top of your routes.rb file.
+# Prepends the output of "rails routes" to the top of your routes.rb file.
 # Yes, it's simple but I'm thick and often need a reminder of what my routes
 # mean.
 #

--- a/lib/annotate/annotate_routes/header_generator.rb
+++ b/lib/annotate/annotate_routes/header_generator.rb
@@ -16,7 +16,7 @@ module AnnotateRoutes
       private
 
       def routes_map(options)
-        result = `rake routes`.chomp("\n").split(/\n/, -1)
+        result = `rails routes`.chomp("\n").split(/\n/, -1)
 
         # In old versions of Rake, the first line of output was the cwd.  Not so
         # much in newer ones.  We ditch that line if it exists, and if not, we

--- a/lib/annotate/parser.rb
+++ b/lib/annotate/parser.rb
@@ -145,7 +145,7 @@ module Annotate
 
       option_parser.on('-r',
                        '--routes',
-                       "Annotate routes.rb with the output of 'rake routes'") do
+                       "Annotate routes.rb with the output of 'rails routes'") do
         env['routes'] = 'true'
       end
 

--- a/spec/lib/annotate/annotate_routes_spec.rb
+++ b/spec/lib/annotate/annotate_routes_spec.rb
@@ -49,11 +49,11 @@ describe AnnotateRoutes do
         expect(File).to receive(:exist?).with(ROUTE_FILE).and_return(true).once
         expect(File).to receive(:read).with(ROUTE_FILE).and_return(route_file_content).once
 
-        expect(AnnotateRoutes::HeaderGenerator).to receive(:`).with('rake routes').and_return(rake_routes_result).once
+        expect(AnnotateRoutes::HeaderGenerator).to receive(:`).with('rails routes').and_return(rake_routes_result).once
       end
 
-      context 'When the result of `rake routes` is present' do
-        context 'When the result of `rake routes` does not contain Rake version' do
+      context 'When the result of `rails routes` is present' do
+        context 'When the result of `rails routes` does not contain Rake version' do
           context 'When the file does not contain magic comment' do
             let :rake_routes_result do
               <<-EOS
@@ -236,7 +236,7 @@ describe AnnotateRoutes do
           end
         end
 
-        context 'When the result of `rake routes` contains Rake version' do
+        context 'When the result of `rails routes` contains Rake version' do
           context 'with older Rake versions' do
             let :rake_routes_result do
               <<~EOS.chomp
@@ -394,7 +394,7 @@ describe AnnotateRoutes do
         end
       end
 
-      context 'When the result of `rake routes` is blank' do
+      context 'When the result of `rails routes` is blank' do
         let :rake_routes_result do
           ''
         end


### PR DESCRIPTION
This fixes https://github.com/ctran/annotate_models/issues/696
Major version bump is required because of minimum rails >= 5.0