### PR TITLE
Fix: RuntimeError: Don't know how to build task 'db:migrate'

### DIFF
--- a/lib/tasks/annotate_models_migrate.rake
+++ b/lib/tasks/annotate_models_migrate.rake
@@ -16,6 +16,8 @@ if defined?(Rails::Application) && Rails.version.split('.').first.to_i >= 6
 end
 
 migration_tasks.each do |task|
+  next unless Rake::Task.task_defined?(task)
+
   Rake::Task[task].enhance do
     Rake::Task[Rake.application.top_level_tasks.last].enhance do
       annotation_options_task = if Rake::Task.task_defined?('app:set_annotation_options')


### PR DESCRIPTION
ActiveRecord's migrate tasks are required since v2.7.5 (#588).


## How to reproduce

1. create non-rails project (like sinatra)

```
./
├── app.rb
├── Gemfile
├── Gemfile.lock
└── models/
   └── user.rb
```

```ruby
# Gemfile
source "https://rubygems.org"
gem "activerecord", require: "active_record"
gem "annotate"
gem "sqlite3"
```

```ruby
# app.rb
Bundler.require(:default)

ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
  end
end

Dir["models/*.rb"].sort.each {|f| require_relative f }
```

```ruby
# models/user.rb
class User < ActiveRecord::Base
end
```

2. execute annotate

```sh
$ bundle exec annotate -R ./app.rb --models --model-dir models
```

## Expected behavior 

```sh
$ bundle exec annotate -R ./app.rb --models --model-dir models
-- create_table(:users, {:force=>true})
   -> 0.0025s
Annotated (1): models/user.rb
```

```sh
$ cat models/user.rb
# == Schema Information
#
# Table name: users
#
#  id :integer          not null, primary key
#
class User < ActiveRecord::Base
end

```

## Actual behavior

```
$ bundle exec annotate -R ./app.rb --models --model-dir models
bundler: failed to load command: annotate (/Users/onaka/.bundle/ruby/3.0.0/bin/annotate)
RuntimeError: Don't know how to build task 'db:migrate' (See the list of available tasks with `rake --tasks`)
  /Users/onaka/.bundle/ruby/3.0.0/gems/rake-13.0.1/lib/rake/task_manager.rb:59:in `[]'
  /Users/onaka/.bundle/ruby/3.0.0/gems/rake-13.0.1/lib/rake/task.rb:405:in `[]'
  /Users/onaka/.bundle/ruby/3.0.0/gems/annotate-3.1.1/lib/tasks/annotate_models_migrate.rake:8:in `block in <top (required)>'
  /Users/onaka/.bundle/ruby/3.0.0/gems/annotate-3.1.1/lib/tasks/annotate_models_migrate.rake:7:in `each'
  /Users/onaka/.bundle/ruby/3.0.0/gems/annotate-3.1.1/lib/tasks/annotate_models_migrate.rake:7:in `<top (required)>'
  /Users/onaka/.bundle/ruby/3.0.0/gems/annotate-3.1.1/lib/annotate.rb:78:in `load'
  /Users/onaka/.bundle/ruby/3.0.0/gems/annotate-3.1.1/lib/annotate.rb:78:in `block in load_tasks'
  /Users/onaka/.bundle/ruby/3.0.0/gems/annotate-3.1.1/lib/annotate.rb:77:in `each'
  /Users/onaka/.bundle/ruby/3.0.0/gems/annotate-3.1.1/lib/annotate.rb:77:in `load_tasks'
  /Users/onaka/.bundle/ruby/3.0.0/gems/annotate-3.1.1/lib/annotate.rb:133:in `bootstrap_rake'
  /Users/onaka/.bundle/ruby/3.0.0/gems/annotate-3.1.1/bin/annotate:20:in `<top (required)>'
  /Users/onaka/.bundle/ruby/3.0.0/bin/annotate:23:in `load'
  /Users/onaka/.bundle/ruby/3.0.0/bin/annotate:23:in `<top (required)>'
```