### PR TITLE
Fix: use klass.table_name instead of guessing from associated models

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -846,9 +846,7 @@ module AnnotateModels
       # Construct the foreign column name in the translations table
       # eg. Model: Car, foreign column name: car_id
       foreign_column_name = [
-        klass.translation_class.to_s
-             .gsub('::Translation', '').gsub('::', '_')
-             .downcase,
+        klass.table_name.to_s.singularize,
         '_id'
       ].join.to_sym
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -389,8 +389,8 @@ describe AnnotateModels do
 
             context 'with Globalize gem' do
               let :translation_klass do
-                double('Post::Translation',
-                       to_s: 'Post::Translation',
+                double('Folder::Post::Translation',
+                       to_s: 'Folder::Post::Translation',
                        columns: [
                          mock_column(:id, :integer, limit: 8),
                          mock_column(:post_id, :integer, limit: 8),


### PR DESCRIPTION
Hi,

In a middle of a refactoring task, we came across a issue with globalize + annotate. Annotate is adding a none-existant field to the model:

```git
  # Table name: countries
  #
+ #  country_id  :integer
  #  created_at  :datetime         not null
  ....
 ``` 
 
 The issue come when you overide `table_name`. For exemple, if we have a model `Country` located at `models/country.rb` and we decide to move the file in a folder without changing the table_name, we will have:
 `models/folder/country.rb`
 ```ruby
 module Folder
  class Country < ApplicationRecord
     self.table_name = "countries"
     ...
  end
 end
 
 # == Schema Information
#
# Table name: countries
#
#  country_id  :integer <- field added
# ....
 ```
 
 With the orginal code, we have:
 ```ruby
 pry(main)> klass = Folder::Country
 pry(main)> foreign_column_name = [klass.translation_class.to_s.gsub('::Translation', '').gsub('::', '_').downcase,'_id'].join.to_sym
 => :folder_country_id
 ```
 Using table_name is a safer way to do it, in my opinion
 ```ruby
 pry(main)> klass = Folder::Country
 pry(main)> foreign_column_name = [klass.table_name.singularize,'_id'].join.to_sym
  => :country_id
 ```