### PR TITLE
Allow `get_loaded_model` to succeed when `$LOAD_PATH` contains non-string values

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -608,7 +608,8 @@ module AnnotateModels
       # auto_load/eager_load paths. Try all possible model paths one by one.
       absolute_file = File.expand_path(file)
       model_paths =
-        $LOAD_PATH.select { |path| absolute_file.include?(path) }
+        $LOAD_PATH.map(&:to_s)
+                  .select { |path| absolute_file.include?(path) }
                   .map { |path| absolute_file.sub(path, '').sub(/\.rb$/, '').sub(/^\//, '') }
       model_paths
         .map { |path| get_loaded_model_by_path(path) }


### PR DESCRIPTION
As currently implemented, `get_loaded_model` inspects the `$LOAD_PATH` global for path values when trying to find the path for a model file.  This would be fine, except that variable is affected by userspace, which means that it will sometimes contain non-string values, often Pathnames.  To avoid responding with the error `Unable to annotate #{model_path}: no implicit conversion of Pathname into String` in this situation, we simply add an explicit `to_s` call before performing string-specific operations.

Fixes https://github.com/ctran/annotate_models/issues/758