### PR TITLE
Fix retrieve_indexes_from_table when indexes is empty and base table does not exist

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -124,7 +124,11 @@ module AnnotateModels
 
       # Try to search the table without prefix
       table_name_without_prefix = table_name.to_s.sub(klass.table_name_prefix, '')
-      klass.connection.indexes(table_name_without_prefix)
+      if klass.connection.table_exists?(table_name_without_prefix)
+        klass.connection.indexes(table_name_without_prefix)
+      else
+        []
+      end
     end
 
     # Use the column information in an ActiveRecord class


### PR DESCRIPTION
Some tables may have a table_name_prefix but no indexes. Previous versions of
the code would strip the prefix and look for indexes on the resulting table name,
which likely would not exist. This causes DB errors, at least in MySQL. So now
check if the table with the derived name exists first before trying to show its indexes.

Example error otherwise:
```
myservice:development [10] pry(main)> ActiveRecord::Base.connection.indexes('garbage')
Mysql2::Error: Table 'myservice_development.garbage' doesn't exist: SHOW KEYS FROM `garbage`
ActiveRecord::StatementInvalid: Mysql2::Error: Table 'myservice_development.garbage' doesn't exist: SHOW KEYS FROM `garbage`
```