### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
 env:
   - RAILS_ENV=development RACK_ENV=development INTEGRATION_TESTS=1
 
+cache: bundler
+
 addons:
   apt_packages:
     - libsqlite3-dev


### PR DESCRIPTION
Would be interested to know why bundler caching of Travis hasn't been enabled in this repository. Thank you.