### PR TITLE
[WIP] Bump Ruby version for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,18 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
 
       - name: Install sqlite
         run: |
           sudo apt-get install libsqlite3-dev
+
+      - name: Update System
+        run: |
+          gem update --system --no-document
+
+      - name: Bundle install for Annotate models
+        run: |
+          bundle install --jobs=4 --retry=3
 
       - name: Run Tests
         run: INTEGRATION_TESTS=1 bundle exec rspec


### PR DESCRIPTION
Ruby 2.4 is no longer supported and the support of the Ruby 2.5 series ends on March 2021.
So I bumped Ruby version for CI.

https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

before: 2.4, 2.5, 2.6
after: 2.6, 2.7, 3.0