### PR TITLE
`get_loaded_model_by_path` is supposed to be nil-safe

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -618,9 +618,7 @@ module AnnotateModels
 
     # Retrieve loaded model class by path to the file where it's supposed to be defined.
     def get_loaded_model_by_path(model_path)
-      klass = ActiveSupport::Inflector.constantize(ActiveSupport::Inflector.camelize(model_path))
-
-      klass if klass.is_a?(Class) && klass < ActiveRecord::Base
+      ActiveSupport::Inflector.constantize(ActiveSupport::Inflector.camelize(model_path))
     rescue StandardError, LoadError
       # Revert to the old way but it is not really robust
       ObjectSpace.each_object(::Class)


### PR DESCRIPTION
This commit partially reverts #801, which by declaring conditional return
has turned `get_loaded_model_by_path` to a less safe method that can
return nil when its condition is not met.

Apparently the very same condition has been brought to `annotate_model_file`
by #774, which seems to cover the "bug" insisted in #801 as well.

On the other hand #801 has brought an inconvenient behaviour as well:
whenever a non-activerecord model file is found, `get_loaded_model_by_path`
returns nil, which leads to raising `BadModelFileError` and ends up
printing a bunch of "Unable to annotate ..." messages.

Now it seems tests added by #801 are running right and I do not find
a problem restoring the previous behaviour and turn it nil-safe again.

---

Say we have a file like `app/models/foo/bar.rb` which is NOT a subclass of ActiveRecord::Base:

```ruby
class Foo::Bar
end
```

We do not want this to get annotated but the current code does give it a try, ending up showing a bunch of error messages like this:

```
Unable to annotate app/models/foo/bar.rb: file doesn't contain a valid model class
Unable to annotate app/models/foo/baz.rb: file doesn't contain a valid model class
...
```

With this change the behaviour in v3.1.1 is restored and these un-informational errors are gone.