### PR TITLE
Fix automatic annotation of Active Admin models in migration task

### DIFF
--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -12,7 +12,7 @@ task annotate_models: :environment do
 
   options = {is_rake: true}
   ENV['position'] = options[:position] = Annotate::Helpers.fallback(ENV['position'], 'before')
-  options[:active_admin] = ENV.fetch('active_admin', 'false')
+  options[:active_admin] = Annotate::Helpers.true?(ENV['active_admin'])
   options[:additional_file_patterns] = ENV['additional_file_patterns'] ? ENV['additional_file_patterns'].split(',') : []
   options[:position_in_class] = Annotate::Helpers.fallback(ENV['position_in_class'], ENV['position'])
   options[:position_in_fixture] = Annotate::Helpers.fallback(ENV['position_in_fixture'], ENV['position'])

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -12,6 +12,7 @@ task annotate_models: :environment do
 
   options = {is_rake: true}
   ENV['position'] = options[:position] = Annotate::Helpers.fallback(ENV['position'], 'before')
+  options[:active_admin] = ENV.fetch('active_admin', 'false')
   options[:additional_file_patterns] = ENV['additional_file_patterns'] ? ENV['additional_file_patterns'].split(',') : []
   options[:position_in_class] = Annotate::Helpers.fallback(ENV['position_in_class'], ENV['position'])
   options[:position_in_fixture] = Annotate::Helpers.fallback(ENV['position_in_fixture'], ENV['position'])


### PR DESCRIPTION
This pull request fixes an issue where automatic annotation of Active Admin models was not working with the migration task (cf. [auto_annotate.rake](https://github.com/ctran/annotate_models/blob/develop/lib/tasks/annotate_models.rake)), even though the `active_admin` option was set to true in the `:set_annotation_options` method.

The fix involves adding the `active_admin` option to the `options` variable generated by `set_annotation_options()`. This variable is then passed to `AnnotateModels.do_annotations()`, ensuring that the active admin option is set.

Fixes #777