### PR TITLE
Adds typed and warn_indent as magic comments

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -39,7 +39,7 @@ module AnnotateModels
     }
   }.freeze
 
-  MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/).freeze
+  MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))|(^#\s*typed:.+(?:\n|\r\n))|(^# -\*- typed\s*:.+-\*-(?:\n|\r\n))|(^#\s*warn_indent:.+(?:\n|\r\n))|(^# -\*- warn_indent\s*:.+-\*-(?:\n|\r\n))/).freeze
 
   class << self
     def annotate_pattern(options = {})


### PR DESCRIPTION
As of right now, annotate models only considers `frozen_string_literal` and `encoding` as magic comments. This pr adds `typed` and `warn_indent` to the list.