### PR TITLE
Loosen activerecord restriction to work with rails 7

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4 if s.respond_to? :specification_version
   s.add_runtime_dependency(%q<rake>, '>= 10.4', '< 14.0')
-  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 7.0'])
+  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 7.1'])
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/ctran/annotate_models/issues/",

--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4 if s.respond_to? :specification_version
   s.add_runtime_dependency(%q<rake>, '>= 10.4', '< 14.0')
-  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 7.1'])
+  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 8.0'])
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/ctran/annotate_models/issues/",

--- a/lib/tasks/annotate_routes.rake
+++ b/lib/tasks/annotate_routes.rake
@@ -28,3 +28,10 @@ task :remove_routes => :environment do
   options[:require] = ENV['require'] ? ENV['require'].split(',') : []
   AnnotateRoutes.remove_annotations(options)
 end
+
+desc "Prints out the rails routes structure"
+task routes: :environment do
+  require 'rails/commands/routes/routes_command'
+  routes = Rails::Command::RoutesCommand.new
+  routes.perform
+end

--- a/lib/tasks/annotate_routes.rake
+++ b/lib/tasks/annotate_routes.rake
@@ -28,10 +28,3 @@ task :remove_routes => :environment do
   options[:require] = ENV['require'] ? ENV['require'].split(',') : []
   AnnotateRoutes.remove_annotations(options)
 end
-
-desc "Prints out the rails routes structure"
-task routes: :environment do
-  require 'rails/commands/routes/routes_command'
-  routes = Rails::Command::RoutesCommand.new
-  routes.perform
-end

--- a/spec/integration/rails_5.2.4.1/Gemfile.lock
+++ b/spec/integration/rails_5.2.4.1/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../../..
   specs:
     annotate (3.1.1)
-      activerecord (>= 3.2, < 7.0)
+      activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
 
 GEM

--- a/spec/integration/rails_6.0.2.1/Gemfile
+++ b/spec/integration/rails_6.0.2.1/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '~> 6.0.2', '>= 6.0.2.1'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
-gem 'puma', '~> 4.3'
+gem 'puma', '~> 5.6.1'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/spec/integration/rails_6.0.2.1/Gemfile.lock
+++ b/spec/integration/rails_6.0.2.1/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../../..
   specs:
     annotate (3.1.1)
-      activerecord (>= 3.2, < 7.0)
+      activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
 
 GEM
@@ -82,7 +82,7 @@ GEM
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     erubi (1.10.0)
-    ffi (1.12.2)
+    ffi (1.15.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.10)
@@ -113,7 +113,7 @@ GEM
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     public_suffix (4.0.3)
-    puma (4.3.5)
+    puma (5.6.1)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -146,7 +146,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (13.0.3)
-    rb-fsevent (0.10.3)
+    rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.6.0)
@@ -193,7 +193,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
-  puma (~> 4.3)
+  puma (~> 5.6.1)
   rails (~> 6.0.2, >= 6.0.2.1)
   selenium-webdriver
   sqlite3 (~> 1.4)


### PR DESCRIPTION
This change allows the gem to work with Rails 7 now that it's out.

I've been using it for a while with alpha and RC versions and at least models and routes work fine.

EDIT:

~~Just included as a bonus a `rake routes` task that fixes the problems that showed up when rails renamed the task to `rails routes`~~