### PR TITLE
Fix undefined method error when spatial column does not have `srid`

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -889,9 +889,9 @@ module AnnotateModels
       # Check out if we got a geometric column
       # and print the type and SRID
       if column.respond_to?(:geometry_type)
-        attrs << "#{column.geometry_type}, #{column.srid}"
+        attrs << [column.geometry_type, column.try(:srid)].compact.join(', ')
       elsif column.respond_to?(:geometric_type) && column.geometric_type.present?
-        attrs << "#{column.geometric_type.to_s.downcase}, #{column.srid}"
+        attrs << [column.geometric_type.to_s.downcase, column.try(:srid)].compact.join(', ')
       end
 
       # Check if the column has indices and print "indexed" if true

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1168,7 +1168,10 @@ describe AnnotateModels do
                                   limit: { srid: 4326, type: 'geometry' }),
                       mock_column(:location, :geography,
                                   geometric_type: 'Point', srid: 0,
-                                  limit: { srid: 0, type: 'geometry' })
+                                  limit: { srid: 0, type: 'geometry' }),
+                      mock_column(:non_srid, :geography,
+                                  geometric_type: 'Point',
+                                  limit: { type: 'geometry' })
                     ]
                   end
 
@@ -1182,6 +1185,7 @@ describe AnnotateModels do
                       #  active   :boolean          default(FALSE), not null
                       #  geometry :geometry         not null, geometry, 4326
                       #  location :geography        not null, point, 0
+                      #  non_srid :geography        not null, point
                       #
                     EOS
                   end


### PR DESCRIPTION
Fix undefined method error when spatial column does not have `srid`. This error occurs when the following gem is used.

https://github.com/sebastianiorga/activerecord-mysql2spatial-adapter
(forked from https://github.com/rgeo/activerecord-mysql2spatial-adapter)

```
Unable to annotate app/models/location.rb: undefined method `srid' for #<ActiveRecord::ConnectionAdapters::Mysql2SpatialAdapter::SpatialColumn:...
```




