### PR TITLE
Update annotate.gemspec

### DIFF
--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4 if s.respond_to? :specification_version
   s.add_runtime_dependency(%q<rake>, '>= 10.4', '< 14.0')
-  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 7.0'])
+  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 7.1'])
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/ctran/annotate_models/issues/",


### PR DESCRIPTION
Add Support for rails 7.0.1 too.

```
Bundler could not find compatible versions for gem "activerecord":
  In snapshot (Gemfile.lock):
    activerecord (= 7.0.1)

  In Gemfile:
    annotate (~> 3.1, >= 3.1.1) was resolved to 3.1.1, which depends on
      activerecord (< 7.0, >= 3.2)

    rails (~> 7.0.1) was resolved to 7.0.1, which depends on
      activerecord (= 7.0.1)
```