### PR TITLE
Fix --additional-file-patterns parsing from CLI

### DIFF
--- a/lib/annotate/parser.rb
+++ b/lib/annotate/parser.rb
@@ -56,7 +56,7 @@ module Annotate
       option_parser.on('--additional-file-patterns path1,path2,path3',
                        Array,
                        "Additional file paths or globs to annotate, separated by commas (e.g. `/foo/bar/%model_name%/*.rb,/baz/%model_name%.rb`)") do |additional_file_patterns|
-        ENV['additional_file_patterns'] = additional_file_patterns
+        env['additional_file_patterns'] = additional_file_patterns.join(',')
       end
 
       option_parser.on('-d',


### PR DESCRIPTION
Convert additional-file-patterns array back into comma separated string before saving it to `ENV` which currently raises. The array is then split out again [here](https://github.com/ctran/annotate_models/blob/develop/lib/annotate.rb#L60) and works as expected.

Fixes https://github.com/ctran/annotate_models/issues/802