### PR TITLE
Modify column pattern regexp

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -375,7 +375,7 @@ module AnnotateModels
       old_header = old_content.match(header_pattern).to_s
       new_header = info_block.match(header_pattern).to_s
 
-      column_pattern = /^#[\t ]+[\w\*\.`]+[\t ]+.+$/
+      column_pattern = /^#[\t ]+[\w\*\.]+[\(]?.*?[\)]?[\t ]+.+$/
       old_columns = old_header && old_header.scan(column_pattern).sort
       new_columns = new_header && new_header.scan(column_pattern).sort
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2601,6 +2601,26 @@ describe AnnotateModels do
           annotate_one_file
           expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
         end
+
+        it 'should update foreign key constraint with comment' do
+          klass = mock_class(:users,
+                             :id,
+                             [
+                               mock_column(:id, :integer),
+                               mock_column(:foreign_thing_id, :integer, comment: "foreign_thing_id")
+                             ],
+                             [],
+                             [
+                               mock_foreign_key('fk_rails_cf2568e89e',
+                                                'foreign_thing_id',
+                                                'foreign_things',
+                                                'id',
+                                                on_delete: :cascade)
+                             ])
+          @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', with_comment: 'yes')
+          annotate_one_file
+          expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
+        end
       end
     end
 


### PR DESCRIPTION
I try to fix these issues.
  - https://github.com/ctran/annotate_models/issues/816
  - https://github.com/ctran/annotate_models/issues/882

The with-comment option is set to true.
When I add columns with comment to database, a new commented column is not annotated.
I modify column pattern regexp to detect new columns with comment.
