### PR TITLE
Option to add a blank line between annotation and class definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ you can do so with a simple environment variable, instead of editing the
 
     Usage: annotate [options] [model_file]*
             --additional-file-patterns   Additional file paths or globs to annotate, separated by commas (e.g. `/foo/bar/%model_name%/*.rb,/baz/%model_name%.rb`)
+            --bl, --blank-line           Add a blank line separator before of after the annotation
         -d, --delete                     Remove annotations from all model files or the routes.rb file
         -p [before|top|after|bottom],    Place the annotations at the top (before) or the bottom (after) of the model/test/fixture/factory/route/serializer file(s)
             --position

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -396,13 +396,14 @@ module AnnotateModels
         magic_comments_block = magic_comments_as_string(old_content)
         old_content.gsub!(MAGIC_COMMENT_MATCHER, '')
         old_content.sub!(annotate_pattern(options), '')
+        blank_line_separator = options[:blank_line] ? "\n" : ''
 
         new_content = if %w(after bottom).include?(options[position].to_s)
                         magic_comments_block + (old_content.rstrip + "\n\n" + wrapped_info_block)
                       elsif magic_comments_block.empty?
-                        magic_comments_block + wrapped_info_block + old_content.lstrip
+                        magic_comments_block + wrapped_info_block + blank_line_separator + old_content.lstrip
                       else
-                        magic_comments_block + "\n" + wrapped_info_block + old_content.lstrip
+                        magic_comments_block + "\n" + wrapped_info_block + blank_line_separator + old_content.lstrip
                       end
       else
         # replace the old annotation with the new one

--- a/lib/annotate/parser.rb
+++ b/lib/annotate/parser.rb
@@ -59,6 +59,13 @@ module Annotate
         ENV['additional_file_patterns'] = additional_file_patterns
       end
 
+      option_parser.on('--bl',
+                       '--blank-line',
+                       'Add a blank line separator between the annotation and class definition') do
+        @options[:target_action] = :blank_line
+        ENV['blank_line'] = 'yes'
+      end
+
       option_parser.on('-d',
                        '--delete',
                        'Remove annotations from all model files or the routes.rb file') do

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -52,6 +52,7 @@ task annotate_models: :environment do
   options[:hide_default_column_types] = Annotate::Helpers.fallback(ENV['hide_default_column_types'], '')
   options[:with_comment] = Annotate::Helpers.true?(ENV['with_comment'])
   options[:ignore_unknown_models] = Annotate::Helpers.true?(ENV.fetch('ignore_unknown_models', 'false'))
+  options[:blank_line] = Annotate::Helpers.fallback(ENV['blank_line'])
 
   AnnotateModels.do_annotations(options)
 end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2790,6 +2790,34 @@ describe AnnotateModels do
         expect { annotate_one_file frozen: true }.not_to raise_error
       end
     end
+
+    describe 'with blank line separator enabled' do
+      context "when there are no magic comments" do
+        it 'should add a blank line between the annotation and the class definition' do
+          content = "class User < ActiveRecord::Base\nend\n"
+          schema_info = AnnotateModels.get_schema_info(@klass, '== Schema Info')
+          model_file_name, = write_model 'user.rb', "#{content}"
+
+          annotate_one_file blank_line: true
+
+          expect(File.read(model_file_name)).to eq("#{schema_info}\n#{content}")
+        end
+      end
+
+      context "when there is a magic comment" do
+        it 'should add a blank line between the annotation and the class definition' do
+          content = "class User < ActiveRecord::Base\nend\n"
+          schema_info = AnnotateModels.get_schema_info(@klass, '== Schema Info')
+          MAGIC_COMMENTS.each do |magic_comment|
+            model_file_name, = write_model 'user.rb', "#{magic_comment}\n#{content}"
+
+            annotate_one_file blank_line: true
+
+            expect(File.read(model_file_name)).to eq("#{magic_comment}\n\n#{schema_info}\n#{content}")
+          end
+        end
+      end
+    end
   end
 
   describe '.annotate_model_file' do

--- a/spec/lib/annotate/parser_spec.rb
+++ b/spec/lib/annotate/parser_spec.rb
@@ -25,6 +25,15 @@ module Annotate # rubocop:disable Metrics/ModuleLength
       end
     end
 
+    %w[--bl --blank-line].each do |option|
+      describe option do
+        it 'adds a blank line separator between the annotation and class definition' do
+          result = Parser.parse([option])
+          expect(result).to include(target_action: :blank_line)
+        end
+      end
+    end
+
     %w[-d --delete].each do |option|
       describe option do
         it 'sets target_action to :remove_annotations' do


### PR DESCRIPTION
This adds an option to add a blank line separator between the annotation and the class definition of models. I believe this is important and should likely be the default in order to prevent deletion of comments above a class definition, as per issue #951.

