### PR TITLE
[#969] Add support for Rails autoloader collapsed directories

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -611,6 +611,15 @@ module AnnotateModels
         $LOAD_PATH.map(&:to_s)
                   .select { |path| absolute_file.include?(path) }
                   .map { |path| absolute_file.sub(path, '').sub(/\.rb$/, '').sub(/^\//, '') }
+
+      # Handle Rails apps with collapsed model paths
+      model_paths = model_paths
+        .select do |model_path|
+          defined?(Rails) &&
+          Rails.autoloaders.main.collapse_dirs.any? &&
+          Rails.autoloaders.main.collapse_dirs.select { |path| path.match(model_path) }
+        end.map { |model_path| model_path.sub(/\/models/, '') }
+
       model_paths
         .map { |path| get_loaded_model_by_path(path) }
         .find { |loaded_model| !loaded_model.nil? }

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -614,11 +614,11 @@ module AnnotateModels
 
       # Handle Rails apps with collapsed model paths
       model_paths = model_paths
-        .select do |model_path|
-          defined?(Rails) &&
-          Rails.autoloaders.main.collapse_dirs.any? &&
-          Rails.autoloaders.main.collapse_dirs.select { |path| path.match(model_path) }
-        end.map { |model_path| model_path.sub(/\/models/, '') }
+                    .select do |mpath|
+                      defined?(Rails) &&
+                      Rails.autoloaders.main.collapse_dirs.any? &&
+                      Rails.autoloaders.main.collapse_dirs.select { |path| path.match(mpath) }
+                    end.map { |mpath| mpath.sub(/\/models/, '') }
 
       model_paths
         .map { |path| get_loaded_model_by_path(path) }

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1892,6 +1892,37 @@ describe AnnotateModels do
           expect(klass.name).to eq('Bar::FooInsideBar')
         end
       end
+
+      context 'when class Bar::Foo is defined in Rails collapsed directory' do
+        before do
+          Rails = double('Rails')
+          # rubocop:disable RSpec/MessageChain
+          allow(Rails).to receive_message_chain(:autoloaders, :main, :collapse_dirs) { Set.new(["bar/models"]) }
+          # rubocop:enable RSpec/MessageChain
+          $LOAD_PATH.unshift(dir)
+        end
+
+        let :dir do
+          AnnotateModels.model_dir[0]
+        end
+
+        let :filename do
+          'bar/models/foo.rb'
+        end
+
+        let :file_content do
+          <<~EOS
+            module Bar
+              class Foo < ActiveRecord::Base
+              end
+            end
+          EOS
+        end
+
+        it 'works' do
+          expect(klass.name).to eql('Bar::Foo')
+        end
+      end
     end
 
     context 'when class is defined inside module and class name is not capitalized normally' do


### PR DESCRIPTION
Add support for collapsed autoloader directories set using `Rails.autoloaders.main.collapse(...)`.

Checklist:
- [x] Add tests