### PR TITLE
Fix: Mysql2::Error: Table 'foobar' doesn't exist: RuntimeError

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -119,12 +119,16 @@ module AnnotateModels
       table_name = klass.table_name
       return [] unless table_name
 
-      indexes = klass.connection.indexes(table_name)
+      indexes = klass.connection.indexes(table_name) if klass.connection.table_exists?(table_name)
       return indexes if indexes.any? || !klass.table_name_prefix
 
       # Try to search the table without prefix
       table_name_without_prefix = table_name.to_s.sub(klass.table_name_prefix, '')
-      klass.connection.indexes(table_name_without_prefix)
+      if klass.connection.table_exists?(table_name_without_prefix)
+        klass.connection.indexes(table_name_without_prefix)
+      else
+        []
+      end
     end
 
     # Use the column information in an ActiveRecord class


### PR DESCRIPTION
Add table existence check.

Annotation on a modularized class that does not have indexes raises an exception because it tries to get indexes from a table that does not exist.

`app/models/some.rb`
```
module Some
  def self.table_name_prefix
     "some_"
  end
end
```

`app/models/some/base.rb`
```
module Some
  class Base < ActiveRecord::Base
    self.abstract_class = true
    self.table_name_prefix = "some_"
  end
end
```

`app/models/some/info.rb` (table: `some_infos` which doesn't have indexes)
```
class Some::Info < Some::Base
  validates :title
  validates :type
  validates :body
end
```

### Command 

`bundle exec rake annotate_models`

### Message 

```
Unable to annotate app/models/some/info.rb: Mysql2::Error: Table 'railsdb.infos' doesn't exist: SHOW KEYS FROM `infos`
Unable to annotate app/models/some/info.rb: no implicit conversion of nil into Array
```