### PR TITLE
Support `--frozen` option for routing annotations

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -29,8 +29,7 @@ module AnnotateRoutes
         content, header_position = Helpers.strip_annotations(existing_text)
         new_content = annotate_routes(HeaderGenerator.generate(options), content, header_position, options)
         new_text = new_content.join("\n")
-
-        if rewrite_contents(existing_text, new_text)
+        if rewrite_contents(existing_text, new_text, options[:frozen])
           puts "#{routes_file} was annotated."
         else
           puts "#{routes_file} was not changed."
@@ -82,11 +81,11 @@ module AnnotateRoutes
       content
     end
 
-    def rewrite_contents(existing_text, new_text)
+    def rewrite_contents(existing_text, new_text, frozen)
       content_changed = (existing_text != new_text)
 
       if content_changed
-        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if options[:frozen]        
+        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if frozen        
         File.open(routes_file, 'wb') { |f| f.puts(new_text) }
       end
       

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -30,13 +30,7 @@ module AnnotateRoutes
         new_content = annotate_routes(HeaderGenerator.generate(options), content, header_position, options)
         new_text = new_content.join("\n")
 
-        if options[:frozen]
-          if needs_rewrite_contents?(existing_text, new_text)
-            abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`."
-          else
-            puts "#{routes_file} was not changed."
-          end
-        elsif rewrite_contents(existing_text, new_text)
+        if rewrite_contents(existing_text, new_text)
           puts "#{routes_file} was annotated."
         else
           puts "#{routes_file} was not changed."
@@ -89,16 +83,14 @@ module AnnotateRoutes
     end
 
     def rewrite_contents(existing_text, new_text)
-      if needs_rewrite_contents?(existing_text, new_text)
-        File.open(routes_file, 'wb') { |f| f.puts(new_text) }
-        true
-      else
-        false
-      end
-    end
+      content_changed = (existing_text != new_text)
 
-    def needs_rewrite_contents?(existing_text, new_text)
-      existing_text != new_text
+      if content_changed
+        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if options[:frozen]        
+        File.open(routes_file, 'wb') { |f| f.puts(new_text) }
+      end
+      
+      content_changed
     end
 
     def annotate_routes(header, content, header_position, options = {})

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -45,7 +45,7 @@ module AnnotateRoutes
         content, header_position = Helpers.strip_annotations(existing_text)
         new_content = strip_on_removal(content, header_position)
         new_text = new_content.join("\n")
-        if rewrite_contents(existing_text, new_text)
+        if rewrite_contents(existing_text, new_text, _options[:frozen])
           puts "Annotations were removed from #{routes_file}."
         else
           puts "#{routes_file} was not changed (Annotation did not exist)."

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -39,13 +39,13 @@ module AnnotateRoutes
       end
     end
 
-    def remove_annotations(_options={})
+    def remove_annotations(options={})
       if routes_file_exist?
         existing_text = File.read(routes_file)
         content, header_position = Helpers.strip_annotations(existing_text)
         new_content = strip_on_removal(content, header_position)
         new_text = new_content.join("\n")
-        if rewrite_contents(existing_text, new_text, _options[:frozen])
+        if rewrite_contents(existing_text, new_text, options[:frozen])
           puts "Annotations were removed from #{routes_file}."
         else
           puts "#{routes_file} was not changed (Annotation did not exist)."
@@ -85,10 +85,10 @@ module AnnotateRoutes
       content_changed = (existing_text != new_text)
 
       if content_changed
-        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if frozen        
+        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if frozen
         File.open(routes_file, 'wb') { |f| f.puts(new_text) }
       end
-      
+
       content_changed
     end
 

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -36,12 +36,10 @@ module AnnotateRoutes
           else
             puts "#{routes_file} was not changed."
           end
+        elsif rewrite_contents(existing_text, new_text)
+          puts "#{routes_file} was annotated."
         else
-          if rewrite_contents(existing_text, new_text)
-            puts "#{routes_file} was annotated."
-          else
-            puts "#{routes_file} was not changed."
-          end
+          puts "#{routes_file} was not changed."
         end
       else
         puts "#{routes_file} could not be found."

--- a/lib/tasks/annotate_routes.rake
+++ b/lib/tasks/annotate_routes.rake
@@ -14,6 +14,7 @@ task :annotate_routes => :environment do
   options[:position_in_routes] = Annotate::Helpers.fallback(ENV['position_in_routes'], ENV['position'])
   options[:ignore_routes] = Annotate::Helpers.fallback(ENV['ignore_routes'],  nil)
   options[:require] = ENV['require'] ? ENV['require'].split(',') : []
+  options[:frozen] = Annotate::Helpers.true?(ENV['frozen'])
   options[:wrapper_open] = Annotate::Helpers.fallback(ENV['wrapper_open'], ENV['wrapper'])
   options[:wrapper_close] = Annotate::Helpers.fallback(ENV['wrapper_close'], ENV['wrapper'])
   AnnotateRoutes.do_annotations(options)


### PR DESCRIPTION
Hi. Thanks for this great gem! The `--frozen` option is very useful.

I noticed that the `--frozen` option doesn't work for routing annotations (`rake annotate_routes` and `annotate --routes`). This pull request adds the support for that.

Best regards.