### PR TITLE
Add annotation for table comment

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -190,13 +190,16 @@ module AnnotateModels
     end
 
     def get_schema_header_text(klass, options = {})
+      table_comment = ""
+      table_comment = "(#{klass.connection.table_comment(klass.table_name)})" if with_table_comment?(klass, options)
+
       info = "#\n"
       if options[:format_markdown]
-        info << "# Table name: `#{klass.table_name}`\n"
+        info << "# Table name: `#{klass.table_name}#{table_comment}`\n"
         info << "#\n"
         info << "# ### Columns\n"
       else
-        info << "# Table name: #{klass.table_name}\n"
+        info << "# Table name: #{klass.table_name}#{table_comment}\n"
       end
       info << "#\n"
     end
@@ -796,6 +799,12 @@ module AnnotateModels
       options[:with_comment] &&
         klass.columns.first.respond_to?(:comment) &&
         klass.columns.any? { |col| !col.comment.nil? }
+    end
+
+    def with_table_comment?(klass, options)
+      options[:with_comment] &&
+        klass.connection.respond_to?(:table_comment) &&
+        klass.connection.table_comment(klass.table_name).present?
     end
 
     def max_schema_info_width(klass, options)


### PR DESCRIPTION
Fixed https://github.com/ctran/annotate_models/issues/917 .

Similar corresponding PR have existed in the past.
I interpreted the amount of revisions as too much to be reflected and kept them to a minimum.

Annotation of table comments would be great.
