### PR TITLE
Place column comments at the end of the line

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -6,7 +6,6 @@
 #                          installed the spring binstubs per the docs)
 #  * zeus: 'zeus rspec' (requires the server to be started separetly)
 #  * 'just' rspec: 'rspec'
-clearing :on
 guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }

--- a/Guardfile
+++ b/Guardfile
@@ -6,6 +6,7 @@
 #                          installed the spring binstubs per the docs)
 #  * zeus: 'zeus rspec' (requires the server to be started separetly)
 #  * 'just' rspec: 'rspec'
+clearing :on
 guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ you can do so with a simple environment variable, instead of editing the
                                          don't show default for given column types, separated by commas (e.g. `json,jsonb,hstore`)
             --ignore-unknown-models      don't display warnings for bad model files
             --with-comment               include database comments in model annotations
-            --with-comment-column        include database comments in model annotations, as its own column, after all others.
+            --with-comment-column        include database comments in model annotations, as its own column, after all others
 
 ### Option: `additional_file_patterns`
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ you can do so with a simple environment variable, instead of editing the
                                          don't show default for given column types, separated by commas (e.g. `json,jsonb,hstore`)
             --ignore-unknown-models      don't display warnings for bad model files
             --with-comment               include database comments in model annotations
+            --with-comment-column        include database comments in model annotations, as its own column, after all others.
 
 ### Option: `additional_file_patterns`
 

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -146,7 +146,7 @@ module AnnotateModels
 
       if options[:format_markdown]
         info << sprintf( "# %-#{max_size + md_names_overhead}.#{max_size + md_names_overhead}s | %-#{md_type_allowance}.#{md_type_allowance}s | %s\n", 'Name', 'Type', 'Attributes' )
-        
+
         info << "# #{ '-' * ( max_size + md_names_overhead ) } | #{'-' * md_type_allowance} | #{ '-' * 27 }\n"
       end
 

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -142,6 +142,7 @@ module AnnotateModels
 
       if options[:format_markdown]
         info << sprintf( "# %-#{max_size + md_names_overhead}.#{max_size + md_names_overhead}s | %-#{md_type_allowance}.#{md_type_allowance}s | %s\n", 'Name', 'Type', 'Attributes' )
+        
         info << "# #{ '-' * ( max_size + md_names_overhead ) } | #{'-' * md_type_allowance} | #{ '-' * 27 }\n"
       end
 

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -841,6 +841,7 @@ module AnnotateModels
       max_size
     end
 
+    # rubocop:disable Metrics/ParameterLists
     def format_default(col_name, max_size, col_type, bare_type_allowance, simple_formatted_attrs, bare_max_attrs_length = 0, col_comment = nil)
       sprintf(
         "#  %s:%s %s   %s",

--- a/lib/annotate/constants.rb
+++ b/lib/annotate/constants.rb
@@ -18,7 +18,7 @@ module Annotate
       :trace, :timestamp, :exclude_serializers, :classified_sort,
       :show_foreign_keys, :show_complete_foreign_keys,
       :exclude_scaffolds, :exclude_controllers, :exclude_helpers,
-      :exclude_sti_subclasses, :ignore_unknown_models, :with_comment
+      :exclude_sti_subclasses, :ignore_unknown_models, :with_comment, :with_comment_column
     ].freeze
 
     OTHER_OPTIONS = [

--- a/lib/annotate/parser.rb
+++ b/lib/annotate/parser.rb
@@ -298,6 +298,11 @@ module Annotate
                        "include database comments in model annotations") do
         env['with_comment'] = 'true'
       end
+
+      option_parser.on('--with-comment-column',
+                       "include database comments in model annotations, as its own column, after all others") do
+        env['with_comment_column'] = 'true'
+      end
     end
   end
 end

--- a/spec/lib/annotate/parser_spec.rb
+++ b/spec/lib/annotate/parser_spec.rb
@@ -554,7 +554,7 @@ module Annotate # rubocop:disable Metrics/ModuleLength
       let(:option) { '--with-comment-column' }
       let(:env_key) { 'with_comment_column' }
       let(:set_value) { 'true' }
-      fit 'sets the ENV variable' do
+      it 'sets the ENV variable' do
         expect(ENV).to receive(:[]=).with(env_key, set_value)
         Parser.parse([option])
       end

--- a/spec/lib/annotate/parser_spec.rb
+++ b/spec/lib/annotate/parser_spec.rb
@@ -549,5 +549,15 @@ module Annotate # rubocop:disable Metrics/ModuleLength
         Parser.parse([option])
       end
     end
+
+    describe '--with-comment-column' do
+      let(:option) { '--with-comment-column' }
+      let(:env_key) { 'with_comment_column' }
+      let(:set_value) { 'true' }
+      fit 'sets the ENV variable' do
+        expect(ENV).to receive(:[]=).with(env_key, set_value)
+        Parser.parse([option])
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,4 +36,5 @@ require 'byebug'
 
 RSpec.configure do |config|
   config.order = 'random'
+  config.filter_run_when_matching :focus
 end


### PR DESCRIPTION
fixes #953.

By adding `--with-comment-column`, we can now see column comments at the end of the generated "table".
