### PR TITLE
Add parentheses in allowed column pattern for commented columns

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -433,7 +433,7 @@ module AnnotateModels
       old_header = old_content.match(header_pattern).to_s
       new_header = info_block.match(header_pattern).to_s
 
-      column_pattern = /^#[\t ]+[\w\*\.`]+[\t ]+.+$/
+      column_pattern = /^#[\t ]+[\w\*\.`()]+[\t ]+.+$/
       old_columns = old_header && old_header.scan(column_pattern).sort
       new_columns = new_header && new_header.scan(column_pattern).sort
 


### PR DESCRIPTION
This PR adds parentheses in allowed column pattern for commented columns.

The annotation of a model with commented columns is not updated even if the column will be updated.

### Steps to reproduce

1. Create a new Rails application and use MySQL or PostgreSQL database
2. Add annotate_models gem in Gemfile
3. Create a model with a commented column
    - e.g.
    - ```ruby
      create_table :users do |t|
        t.string :name, comment: 'first_name + last_name'
        t.string :email, null: false

        t.timestamps
      end
      ```
5. Change the commented column from default null to non-null.
    - e.g.
    - ```ruby
      change_column_null :users, :name, false
      ```
7. The annotation of the model isn't updated
    - ```
      Model files unchanged.
      ```
    - but, schema.rb is updated.
    - ```diff
      -ActiveRecord::Schema[7.0].define(version: 2023_12_03_034600) do
      +ActiveRecord::Schema[7.0].define(version: 2023_12_03_040324) do
         create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
      -    t.string "name", comment: "first_name + last_name"
      +    t.string "name", null: false, comment: "first_name + last_name"
           t.string "email", null: false
           t.datetime "created_at", null: false
           t.datetime "updated_at", null: false
      ```
