### PR TITLE
Fix annotation when a table_name_prefix is in use

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -120,15 +120,7 @@ module AnnotateModels
       return [] unless table_name
 
       indexes = klass.connection.indexes(table_name)
-      return indexes if indexes.any? || !klass.table_name_prefix
-
-      # Try to search the table without prefix
-      table_name_without_prefix = table_name.to_s.sub(klass.table_name_prefix, '')
-      if klass.connection.table_exists?(table_name_without_prefix)
-        klass.connection.indexes(table_name_without_prefix)
-      else
-        []
-      end
+      return indexes
     end
 
     # Use the column information in an ActiveRecord class


### PR DESCRIPTION
## Expected behavior: 
If a table has a table name prefix, I can annotate it.

## Current behavior: 
Annotation fails because it's trying to use the unprefixed table name when getting the indexes.

## Fix explanation 
In `retrieve_indexes_from_table`, klass.table_name already contains the prefix if one exists. So, we shouldn't need to check separately for the prefixed or unprefixed version. 

## Tests
I tried to add tests; there is one failing and I'm not sure what the expected behavior is there/how to fix it. (Unclear to me if it's a test-specific failure or the fix I am suggesting doesn't work for this particular case). 

## Related issues 
Seems related possibly to https://github.com/ctran/annotate_models/issues/967 and [this comment](https://github.com/ctran/annotate_models/issues/562#issuecomment-1650125757) - we were seeing the same error message as that user.
