### PR TITLE
CI: Tell dependabot to update GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds a configuration to tell Dependabot to update the versions used for some well-known GitHub Actions, such as `checkout`, in order to avoid deprecation warnings when those get too old. [Documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)

Update:

Here are some warnings that some of the Actions output currently:


**Analyze (ruby)**
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, github/codeql-action/init@v2, github/codeql-action/autobuild@v2, github/codeql-action/analyze@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

**Analyze (ruby)**
> CodeQL Action v2 will be deprecated on December 5th, 2024. Please update all occurrences of the CodeQL Action in your workflow files to v3. For more information, see https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/
