### PR TITLE
feat: add COMMENT support to indexes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '>= 2.4.0'
 
-gem 'activerecord', '>= 4.2.5', '< 6', require: false
+gem 'activerecord', '>= 4.2.5', '< 9', require: false
 gem 'rake', require: false
 
 group :development do

--- a/annotate.gemspec
+++ b/annotate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4 if s.respond_to? :specification_version
   s.add_runtime_dependency(%q<rake>, '>= 10.4', '< 14.0')
-  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 8.0'])
+  s.add_runtime_dependency(%q<activerecord>, ['>= 3.2', '< 9.0'])
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/ctran/annotate_models/issues/",

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -36,6 +36,10 @@ module AnnotateModels
     using: {
       default: 'USING',
       markdown: '_using_'
+    },
+    comment: {
+      default: 'COMMENT',
+      markdown: '_comment_'
     }
   }.freeze
 
@@ -295,12 +299,22 @@ module AnnotateModels
       end
     end
 
+    def index_comment_info(index, format = :default)
+      value = index.try(:comment).try(:to_s)
+      if value.blank?
+        ''
+      else
+        " #{INDEX_CLAUSES[:comment][format]} #{value}"
+      end
+    end
+
     def final_index_string_in_markdown(index)
       details = sprintf(
-        "%s%s%s",
+        "%s%s%s%s",
         index_unique_info(index, :markdown),
         index_where_info(index, :markdown),
-        index_using_info(index, :markdown)
+        index_using_info(index, :markdown),
+        index_comment_info(index, :markdown)
       ).strip
       details = " (#{details})" unless details.blank?
 
@@ -314,12 +328,13 @@ module AnnotateModels
 
     def final_index_string(index, max_size)
       sprintf(
-        "#  %-#{max_size}.#{max_size}s %s%s%s%s",
+        "#  %-#{max_size}.#{max_size}s %s%s%s%s%s",
         index.name,
         "(#{index_columns_info(index).join(',')})",
         index_unique_info(index),
         index_where_info(index),
-        index_using_info(index)
+        index_using_info(index),
+        index_comment_info(index)
       ).rstrip + "\n"
     end
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -28,7 +28,8 @@ describe AnnotateModels do
            unique:        params[:unique] || false,
            orders:        params[:orders] || {},
            where:         params[:where],
-           using:         params[:using])
+           using:         params[:using],
+           comment:       params[:comment])
   end
 
   def mock_foreign_key(name, from_column, to_table, to_column = 'id', constraints = {})
@@ -530,6 +531,43 @@ describe AnnotateModels do
                       #
                       #  index_rails_02e851e3b7  (id)
                       #  index_rails_02e851e3b8  (foreign_thing_id)
+                      #
+                    EOS
+                  end
+
+                  it 'returns schema info with index information' do
+                    is_expected.to eq expected_result
+                  end
+                end
+
+                context 'when an index has a comment' do
+                  let :columns do
+                    [
+                      mock_column(:id, :integer),
+                      mock_column(:foreign_thing_id, :integer)
+                    ]
+                  end
+
+                  let :indexes do
+                    [
+                      mock_index('index_rails_02e851e3b9', columns: ['id']),
+                      mock_index('index_rails_02e851e3ba', columns: ['foreign_thing_id'], comment: 'This is a comment')
+                    ]
+                  end
+
+                  let :expected_result do
+                    <<~EOS
+                      # Schema Info
+                      #
+                      # Table name: users
+                      #
+                      #  id               :integer          not null, primary key
+                      #  foreign_thing_id :integer          not null
+                      #
+                      # Indexes
+                      #
+                      #  index_rails_02e851e3b9  (id)
+                      #  index_rails_02e851e3ba  (foreign_thing_id) COMMENT This is a comment
                       #
                     EOS
                   end


### PR DESCRIPTION
This reads out any COMMENT added to an INDEX object and adds its after the last output on its "details" line.

An example of what this looks like:

```diff
 # Indexes
 #
-#  attestations_avoid_same_employee  (attested_by_employee_id,subject_id,subject_type) UNIQUE
+#  attestations_avoid_same_employee  (attested_by_employee_id,subject_id,subject_type) UNIQUE COMMENT My explanatory comment is right here
```

EDIT: I added a test case after I had made it possible to run them locally on newer Ruby versions, in #1007 