### PR TITLE
Add Ruby 3.3 to CI matrix - Drop Travis gem, ruby_dep gem, files gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7']
+        ruby: ['2.7', '3.3']
 
     steps:
       - name: Checkout

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
     - 'spec/integration/**/*'
+    - 'Guardfile'
   NewCops: enable
 
 Metrics/BlockLength:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'rake', require: false
 group :development do
   gem 'bump'
   gem 'mg', require: false
-  gem 'travis', require: false
   platforms :mri, :mingw do
     gem 'yard', require: false
   end
@@ -29,7 +28,6 @@ group :development, :test do
   gem 'coveralls'
 
   gem 'overcommit'
-  gem 'ruby_dep', '1.5.0'
 
   platforms :mri, :mingw do
     gem 'pry', require: false
@@ -38,6 +36,5 @@ group :development, :test do
 end
 
 group :test do
-  gem 'files', require: false
   gem 'git', require: false
 end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../spec_helper'
 require 'annotate/annotate_models'
 require 'annotate/active_record_patch'
 require 'active_support/core_ext/string'
-require 'files'
+require 'pathname'
 require 'tmpdir'
 
 describe AnnotateModels do
@@ -2014,18 +2014,16 @@ describe AnnotateModels do
 
     context 'when `model_dir` is valid' do
       let(:model_dir) do
-        Files do
-          file 'foo.rb'
-          dir 'bar' do
-            file 'baz.rb'
-            dir 'qux' do
-              file 'quux.rb'
-            end
-          end
-          dir 'concerns' do
-            file 'corge.rb'
-          end
-        end
+        dir = Pathname(Dir.mktmpdir('annotate_models'))
+        dir.join('bar').mkdir
+        dir.join('bar', 'qux').mkdir
+        dir.join('concerns').mkdir
+
+        dir.join('foo.rb').write('')
+        dir.join('bar', 'baz.rb').write('')
+        dir.join('bar', 'qux', 'quux.rb').write('')
+        dir.join('concerns', 'corge.rb').write('')
+        dir
       end
 
       context 'when the model files are not specified' do


### PR DESCRIPTION
This made the test suite pass on Ruby 3.3. 🟢 

- Drop unused Travis gem
- Drop ruby_dep gem
- Drop files gem and work around it using Pathname
- Told RuboCop to ignore one file, in order that it would be able to run on all the others. Perhaps this RuboCop version's old, or something. In any case, it's better that it can run.