### PR TITLE
Add AnnotateRoutes::AnnotationProcessor and AnnotateRoutes::RemovalProcessor

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -24,9 +24,10 @@ require_relative './annotate_routes/removal_processor'
 module AnnotateRoutes
   class << self
     def do_annotations(options = {})
-      if routes_file_exist?
-        existing_text = File.read(routes_file)
-        if AnnotationProcessor.update(routes_file, existing_text, options)
+      routes_file = File.join('config', 'routes.rb')
+      processor = AnnotationProcessor.new(options, routes_file)
+      if processor.routes_file_exist?
+        if processor.update
           puts "#{routes_file} was annotated."
         else
           puts "#{routes_file} was not changed."
@@ -37,9 +38,10 @@ module AnnotateRoutes
     end
 
     def remove_annotations(options = {})
-      if routes_file_exist?
-        existing_text = File.read(routes_file)
-        if RemovalProcessor.update(routes_file, existing_text, options)
+      routes_file = File.join('config', 'routes.rb')
+      processor = RemovalProcessor.new(options, routes_file)
+      if processor.routes_file_exist?
+        if processor.update
           puts "Annotations were removed from #{routes_file}."
         else
           puts "#{routes_file} was not changed (Annotation did not exist)."
@@ -47,16 +49,6 @@ module AnnotateRoutes
       else
         puts "#{routes_file} could not be found."
       end
-    end
-
-    private
-
-    def routes_file_exist?
-      File.exist?(routes_file)
-    end
-
-    def routes_file
-      @routes_rb ||= File.join('config', 'routes.rb')
     end
   end
 end

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -19,17 +19,14 @@
 #
 
 require_relative './annotate_routes/helpers'
-require_relative './annotate_routes/header_generator'
+require_relative './annotate_routes/annotation_processor'
 
 module AnnotateRoutes
   class << self
     def do_annotations(options = {})
       if routes_file_exist?
         existing_text = File.read(routes_file)
-        content, header_position = Helpers.strip_annotations(existing_text)
-        new_content = annotate_routes(HeaderGenerator.generate(options), content, header_position, options)
-        new_text = new_content.join("\n")
-        if rewrite_contents(existing_text, new_text, options[:frozen])
+        if AnnotationProcessor.update(routes_file, existing_text, options)
           puts "#{routes_file} was annotated."
         else
           puts "#{routes_file} was not changed."
@@ -90,30 +87,6 @@ module AnnotateRoutes
       end
 
       content_changed
-    end
-
-    def annotate_routes(header, content, header_position, options = {})
-      magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
-      if %w(before top).include?(options[:position_in_routes])
-        header = header << '' if content.first != ''
-        magic_comments_map << '' if magic_comments_map.any?
-        new_content = magic_comments_map + header + content
-      else
-        # Ensure we have adequate trailing newlines at the end of the file to
-        # ensure a blank line separating the content from the annotation.
-        content << '' unless content.last == ''
-
-        # We're moving something from the top of the file to the bottom, so ditch
-        # the spacer we put in the first time around.
-        content.shift if header_position == :before && content.first == ''
-
-        new_content = magic_comments_map + content + header
-      end
-
-      # Make sure we end on a trailing newline.
-      new_content << '' unless new_content.last == ''
-
-      new_content
     end
   end
 end

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -1,0 +1,63 @@
+require_relative './helpers'
+require_relative './header_generator'
+
+module AnnotateRoutes
+  # Class to add and update annotations in routes.rb
+  module AnnotationProcessor
+    class << self
+      # @param [Boolean]
+      def update(routes_file, existing_text, options = {})
+        header = HeaderGenerator.generate(options)
+        content, header_position = Helpers.strip_annotations(existing_text)
+        new_content = annotate_routes(header, content, header_position, options)
+        new_text = new_content.join("\n")
+        rewrite_contents(routes_file, existing_text, new_text, options)
+      end
+
+      private
+
+      def annotate_routes(header, content, header_position, options = {})
+        magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
+        if %w[before top].include?(options[:position_in_routes])
+          header = header << '' if content.first != ''
+          magic_comments_map << '' if magic_comments_map.any?
+          new_content = magic_comments_map + header + content
+        else
+          # Ensure we have adequate trailing newlines at the end of the file to
+          # ensure a blank line separating the content from the annotation.
+          content << '' unless content.last == ''
+
+          # We're moving something from the top of the file to the bottom, so ditch
+          # the spacer we put in the first time around.
+          content.shift if header_position == :before && content.first == ''
+
+          new_content = magic_comments_map + content + header
+        end
+
+        # Make sure we end on a trailing newline.
+        new_content << '' unless new_content.last == ''
+
+        new_content
+      end
+
+      # @param routes_file [String]
+      # @param existing_text [String]
+      # @param new_text [String]
+      # @param options [Hash]
+      # @return [Boolean]
+      def rewrite_contents(routes_file, existing_text, new_text, options)
+        content_changed = existing_text != new_text
+        frozen = options[:frozen]
+
+        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen
+
+        if content_changed
+          File.open(routes_file, 'wb') { |f| f.puts(new_text) }
+          true
+        else
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -1,63 +1,43 @@
+require_relative './base_processor'
 require_relative './helpers'
 require_relative './header_generator'
 
 module AnnotateRoutes
   # Class to add and update annotations in routes.rb
-  module AnnotationProcessor
-    class << self
-      # @param [Boolean]
-      def update(routes_file, existing_text, options = {})
-        header = HeaderGenerator.generate(options)
-        content, header_position = Helpers.strip_annotations(existing_text)
-        new_content = annotate_routes(header, content, header_position, options)
-        new_text = new_content.join("\n")
-        rewrite_contents(routes_file, existing_text, new_text, options)
+  class AnnotationProcessor < BaseProcessor
+    # @return [Boolean]
+    def update
+      header = HeaderGenerator.generate(options)
+      content, header_position = Helpers.strip_annotations(existing_text)
+      new_content = annotate_routes(header, content, header_position)
+      new_text = new_content.join("\n")
+      rewrite_contents(new_text)
+    end
+
+    private
+
+    def annotate_routes(header, content, header_position)
+      magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
+      if %w[before top].include?(options[:position_in_routes])
+        header = header << '' if content.first != ''
+        magic_comments_map << '' if magic_comments_map.any?
+        new_content = magic_comments_map + header + content
+      else
+        # Ensure we have adequate trailing newlines at the end of the file to
+        # ensure a blank line separating the content from the annotation.
+        content << '' unless content.last == ''
+
+        # We're moving something from the top of the file to the bottom, so ditch
+        # the spacer we put in the first time around.
+        content.shift if header_position == :before && content.first == ''
+
+        new_content = magic_comments_map + content + header
       end
 
-      private
+      # Make sure we end on a trailing newline.
+      new_content << '' unless new_content.last == ''
 
-      def annotate_routes(header, content, header_position, options = {})
-        magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
-        if %w[before top].include?(options[:position_in_routes])
-          header = header << '' if content.first != ''
-          magic_comments_map << '' if magic_comments_map.any?
-          new_content = magic_comments_map + header + content
-        else
-          # Ensure we have adequate trailing newlines at the end of the file to
-          # ensure a blank line separating the content from the annotation.
-          content << '' unless content.last == ''
-
-          # We're moving something from the top of the file to the bottom, so ditch
-          # the spacer we put in the first time around.
-          content.shift if header_position == :before && content.first == ''
-
-          new_content = magic_comments_map + content + header
-        end
-
-        # Make sure we end on a trailing newline.
-        new_content << '' unless new_content.last == ''
-
-        new_content
-      end
-
-      # @param routes_file [String]
-      # @param existing_text [String]
-      # @param new_text [String]
-      # @param options [Hash]
-      # @return [Boolean]
-      def rewrite_contents(routes_file, existing_text, new_text, options)
-        content_changed = existing_text != new_text
-        frozen = options[:frozen]
-
-        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen
-
-        if content_changed
-          File.open(routes_file, 'wb') { |f| f.puts(new_text) }
-          true
-        else
-          false
-        end
-      end
+      new_content
     end
   end
 end

--- a/lib/annotate/annotate_routes/base_processor.rb
+++ b/lib/annotate/annotate_routes/base_processor.rb
@@ -1,0 +1,48 @@
+module AnnotateRoutes
+  # Base class of processors (AnnotationProcessor and RemovalProcessor)
+  class BaseProcessor
+    def initialize(options, routes_file)
+      @options = options
+      @routes_file = routes_file
+    end
+
+    def routes_file_exist?
+      File.exist?(routes_file)
+    end
+
+    private
+
+    attr_reader :options, :routes_file
+
+    def existing_text
+      @existing_text ||= File.read(routes_file)
+    end
+
+    # @param new_text [String]
+    # @return [Boolean]
+    def rewrite_contents(new_text)
+      content_changed = content_changed?(new_text)
+
+      abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen?
+
+      if content_changed
+        write(new_text)
+        true
+      else
+        false
+      end
+    end
+
+    def write(text)
+      File.open(routes_file, 'wb') { |f| f.puts(text) }
+    end
+
+    def content_changed?(new_text)
+      existing_text != new_text
+    end
+
+    def frozen?
+      options[:frozen]
+    end
+  end
+end

--- a/lib/annotate/annotate_routes/removal_processor.rb
+++ b/lib/annotate/annotate_routes/removal_processor.rb
@@ -1,56 +1,34 @@
+require_relative './base_processor'
 require_relative './helpers'
 
 module AnnotateRoutes
   # Class to remove annotations in routes.rb
-  module RemovalProcessor
-    class << self
-      # @param routes_file [String]
-      # @param existing_text [String]
-      # @param options [Hash]
-      def update(routes_file, existing_text, options)
-        content, header_position = Helpers.strip_annotations(existing_text)
-        new_content = strip_on_removal(content, header_position)
-        new_text = new_content.join("\n")
-        rewrite_contents(routes_file, existing_text, new_text, options)
+  class RemovalProcessor < BaseProcessor
+    # @return [Boolean]
+    def update
+      content, header_position = Helpers.strip_annotations(existing_text)
+      new_content = strip_on_removal(content, header_position)
+      new_text = new_content.join("\n")
+      rewrite_contents(new_text)
+    end
+
+    private
+
+    def strip_on_removal(content, header_position)
+      case header_position
+      when :before
+        content.shift while content.first == ''
+      when :after
+        content.pop while content.last == ''
       end
 
-      private
+      # Make sure we end on a trailing newline.
+      content << '' unless content.last == ''
 
-      def strip_on_removal(content, header_position)
-        case header_position
-        when :before
-          content.shift while content.first == ''
-        when :after
-          content.pop while content.last == ''
-        end
-
-        # Make sure we end on a trailing newline.
-        content << '' unless content.last == ''
-
-        # TODO: If the user buried it in the middle, we should probably see about
-        # TODO: preserving a single line of space between the content above and
-        # TODO: below...
-        content
-      end
-
-      # @param routes_file [String]
-      # @param existing_text [String]
-      # @param new_text [String]
-      # @param options [Hash]
-      # @return [Boolean]
-      def rewrite_contents(routes_file, existing_text, new_text, options)
-        content_changed = existing_text != new_text
-        frozen = options[:frozen]
-
-        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen
-
-        if content_changed
-          File.open(routes_file, 'wb') { |f| f.puts(new_text) }
-          true
-        else
-          false
-        end
-      end
+      # TODO: If the user buried it in the middle, we should probably see about
+      # TODO: preserving a single line of space between the content above and
+      # TODO: below...
+      content
     end
   end
 end

--- a/lib/annotate/annotate_routes/removal_processor.rb
+++ b/lib/annotate/annotate_routes/removal_processor.rb
@@ -1,0 +1,56 @@
+require_relative './helpers'
+
+module AnnotateRoutes
+  # Class to remove annotations in routes.rb
+  module RemovalProcessor
+    class << self
+      # @param routes_file [String]
+      # @param existing_text [String]
+      # @param options [Hash]
+      def update(routes_file, existing_text, options)
+        content, header_position = Helpers.strip_annotations(existing_text)
+        new_content = strip_on_removal(content, header_position)
+        new_text = new_content.join("\n")
+        rewrite_contents(routes_file, existing_text, new_text, options)
+      end
+
+      private
+
+      def strip_on_removal(content, header_position)
+        case header_position
+        when :before
+          content.shift while content.first == ''
+        when :after
+          content.pop while content.last == ''
+        end
+
+        # Make sure we end on a trailing newline.
+        content << '' unless content.last == ''
+
+        # TODO: If the user buried it in the middle, we should probably see about
+        # TODO: preserving a single line of space between the content above and
+        # TODO: below...
+        content
+      end
+
+      # @param routes_file [String]
+      # @param existing_text [String]
+      # @param new_text [String]
+      # @param options [Hash]
+      # @return [Boolean]
+      def rewrite_contents(routes_file, existing_text, new_text, options)
+        content_changed = existing_text != new_text
+        frozen = options[:frozen]
+
+        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen
+
+        if content_changed
+          File.open(routes_file, 'wb') { |f| f.puts(new_text) }
+          true
+        else
+          false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Redo version of #793 

cf. #790, #792

In order to refactor AnnoateRoutes, I added `AnnotateRoutes::AnnotationProcessor` and `AnnotateRoutes::RemovalProcessor`.

Refactoring AnnotateRoutes is not finished in this PR yet.

Some class methods in AnnotateRoutes is removed in the next PR.
