### PR TITLE
Add AnnotateRoutes::AnnotationProcessor and AnnotateRoutes::RemovalProcessor

### DIFF
--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -24,9 +24,10 @@ require_relative './annotate_routes/removal_processor'
 module AnnotateRoutes
   class << self
     def do_annotations(options = {})
-      if routes_file_exist?
-        existing_text = File.read(routes_file)
-        if AnnotationProcessor.update(routes_file, existing_text, options)
+      routes_file = File.join('config', 'routes.rb')
+      processor = AnnotationProcessor.new(options, routes_file)
+      if processor.routes_file_exist?
+        if processor.update
           puts "#{routes_file} was annotated."
         else
           puts "#{routes_file} was not changed."
@@ -37,9 +38,10 @@ module AnnotateRoutes
     end
 
     def remove_annotations(options = {})
-      if routes_file_exist?
-        existing_text = File.read(routes_file)
-        if RemovalProcessor.update(routes_file, existing_text, options)
+      routes_file = File.join('config', 'routes.rb')
+      processor = RemovalProcessor.new(options, routes_file)
+      if processor.routes_file_exist?
+        if processor.update
           puts "Annotations were removed from #{routes_file}."
         else
           puts "#{routes_file} was not changed (Annotation did not exist)."
@@ -47,16 +49,6 @@ module AnnotateRoutes
       else
         puts "#{routes_file} could not be found."
       end
-    end
-
-    private
-
-    def routes_file_exist?
-      File.exist?(routes_file)
-    end
-
-    def routes_file
-      @routes_rb ||= File.join('config', 'routes.rb')
     end
   end
 end

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -23,16 +23,22 @@ require_relative './annotate_routes/removal_processor'
 
 module AnnotateRoutes
   class << self
+    # @param options [Hash]
+    # @return [String]
     def do_annotations(options = {})
       routes_file = File.join('config', 'routes.rb')
-      result = AnnotationProcessor.execute(options, routes_file)
-      puts result
+      AnnotationProcessor.execute(options, routes_file).tap do |result|
+        puts result
+      end
     end
 
+    # @param options [Hash]
+    # @return [String]
     def remove_annotations(options = {})
       routes_file = File.join('config', 'routes.rb')
-      result = RemovalProcessor.execute(options, routes_file)
-      puts result
+      RemovalProcessor.execute(options, routes_file).tap do |result|
+        puts result
+      end
     end
   end
 end

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -19,17 +19,14 @@
 #
 
 require_relative './annotate_routes/helpers'
-require_relative './annotate_routes/header_generator'
+require_relative './annotate_routes/annotation_processor'
 
 module AnnotateRoutes
   class << self
     def do_annotations(options = {})
       if routes_file_exist?
         existing_text = File.read(routes_file)
-        content, header_position = Helpers.strip_annotations(existing_text)
-        new_content = annotate_routes(HeaderGenerator.generate(options), content, header_position, options)
-        new_text = new_content.join("\n")
-        if rewrite_contents(existing_text, new_text, options[:frozen])
+        if AnnotationProcessor.update(routes_file, existing_text, options)
           puts "#{routes_file} was annotated."
         else
           puts "#{routes_file} was not changed."
@@ -90,30 +87,6 @@ module AnnotateRoutes
       end
 
       content_changed
-    end
-
-    def annotate_routes(header, content, header_position, options = {})
-      magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
-      if %w(before top).include?(options[:position_in_routes])
-        header = header << '' if content.first != ''
-        magic_comments_map << '' if magic_comments_map.any?
-        new_content = magic_comments_map + header + content
-      else
-        # Ensure we have adequate trailing newlines at the end of the file to
-        # ensure a blank line separating the content from the annotation.
-        content << '' unless content.last == ''
-
-        # We're moving something from the top of the file to the bottom, so ditch
-        # the spacer we put in the first time around.
-        content.shift if header_position == :before && content.first == ''
-
-        new_content = magic_comments_map + content + header
-      end
-
-      # Make sure we end on a trailing newline.
-      new_content << '' unless new_content.last == ''
-
-      new_content
     end
   end
 end

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -25,30 +25,14 @@ module AnnotateRoutes
   class << self
     def do_annotations(options = {})
       routes_file = File.join('config', 'routes.rb')
-      processor = AnnotationProcessor.new(options, routes_file)
-      if processor.routes_file_exist?
-        if processor.update
-          puts "#{routes_file} was annotated."
-        else
-          puts "#{routes_file} was not changed."
-        end
-      else
-        puts "#{routes_file} could not be found."
-      end
+      result = AnnotationProcessor.execute(options, routes_file)
+      puts result
     end
 
     def remove_annotations(options = {})
       routes_file = File.join('config', 'routes.rb')
-      processor = RemovalProcessor.new(options, routes_file)
-      if processor.routes_file_exist?
-        if processor.update
-          puts "Annotations were removed from #{routes_file}."
-        else
-          puts "#{routes_file} was not changed (Annotation did not exist)."
-        end
-      else
-        puts "#{routes_file} could not be found."
-      end
+      result = RemovalProcessor.execute(options, routes_file)
+      puts result
     end
   end
 end

--- a/lib/annotate/annotate_routes.rb
+++ b/lib/annotate/annotate_routes.rb
@@ -21,6 +21,7 @@
 require_relative './annotate_routes/annotation_processor'
 require_relative './annotate_routes/removal_processor'
 
+# This module provides methods for annotating config/routes.rb.
 module AnnotateRoutes
   class << self
     # @param options [Hash]

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -6,14 +6,6 @@ require_relative './header_generator'
 module AnnotateRoutes
   # This class provides methods for adding annotation to config/routes.rb.
   class AnnotationProcessor < BaseProcessor
-    # @return [Boolean]
-    def update
-      content, header_position = strip_annotations(existing_text)
-      new_content = generate_new_content_array(content, header_position)
-      new_text = new_content.join("\n")
-      rewrite_contents(new_text)
-    end
-
     private
 
     def generate_new_content_array(content, header_position)

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -6,6 +6,19 @@ require_relative './magic_comments_extractor'
 module AnnotateRoutes
   # This class provides methods for adding annotation to config/routes.rb.
   class AnnotationProcessor < BaseProcessor
+    # @return [String]
+    def execute
+      if routes_file_exist?
+        if update
+          "#{routes_file} was annotated."
+        else
+          "#{routes_file} was not changed."
+        end
+      else
+        "#{routes_file} could not be found."
+      end
+    end
+
     private
 
     def header

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -9,7 +9,7 @@ module AnnotateRoutes
     # @return [Boolean]
     def update
       header = HeaderGenerator.generate(options)
-      content, header_position = Helpers.strip_annotations(existing_text)
+      content, header_position = strip_annotations(existing_text)
       new_content = annotate_routes(header, content, header_position)
       new_text = new_content.join("\n")
       rewrite_contents(new_text)

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -8,16 +8,16 @@ module AnnotateRoutes
   class AnnotationProcessor < BaseProcessor
     # @return [Boolean]
     def update
-      header = HeaderGenerator.generate(options)
       content, header_position = strip_annotations(existing_text)
-      new_content = annotate_routes(header, content, header_position)
+      new_content = annotate_routes(content, header_position)
       new_text = new_content.join("\n")
       rewrite_contents(new_text)
     end
 
     private
 
-    def annotate_routes(header, content, header_position)
+    def annotate_routes(content, header_position)
+      header = HeaderGenerator.generate(options)
       magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
       if %w[before top].include?(options[:position_in_routes])
         header = header << '' if content.first != ''

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -9,14 +9,14 @@ module AnnotateRoutes
     # @return [Boolean]
     def update
       content, header_position = strip_annotations(existing_text)
-      new_content = annotate_routes(content, header_position)
+      new_content = generate_new_content_array(content, header_position)
       new_text = new_content.join("\n")
       rewrite_contents(new_text)
     end
 
     private
 
-    def annotate_routes(content, header_position)
+    def generate_new_content_array(content, header_position)
       header = HeaderGenerator.generate(options)
       magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
       if %w[before top].include?(options[:position_in_routes])

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -1,6 +1,6 @@
 require_relative './base_processor'
-require_relative './helpers'
 require_relative './header_generator'
+require_relative './magic_comments_extractor'
 
 # This module provides methods for annotating config/routes.rb.
 module AnnotateRoutes
@@ -10,7 +10,7 @@ module AnnotateRoutes
 
     def generate_new_content_array(content, header_position)
       header = HeaderGenerator.generate(options)
-      magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
+      magic_comments_map, content = MagicCommentsExtractor.execute(content)
       if %w[before top].include?(options[:position_in_routes])
         header = header << '' if content.first != ''
         magic_comments_map << '' if magic_comments_map.any?

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -1,0 +1,64 @@
+require_relative './helpers'
+require_relative './header_generator'
+
+# This module provides methods for annotating config/routes.rb.
+module AnnotateRoutes
+  # This module provides methods for adding annotation to config/routes.rb.
+  module AnnotationProcessor
+    class << self
+      # @param [Boolean]
+      def update(routes_file, existing_text, options = {})
+        header = HeaderGenerator.generate(options)
+        content, header_position = Helpers.strip_annotations(existing_text)
+        new_content = annotate_routes(header, content, header_position, options)
+        new_text = new_content.join("\n")
+        rewrite_contents(routes_file, existing_text, new_text, options)
+      end
+
+      private
+
+      def annotate_routes(header, content, header_position, options = {})
+        magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
+        if %w[before top].include?(options[:position_in_routes])
+          header = header << '' if content.first != ''
+          magic_comments_map << '' if magic_comments_map.any?
+          new_content = magic_comments_map + header + content
+        else
+          # Ensure we have adequate trailing newlines at the end of the file to
+          # ensure a blank line separating the content from the annotation.
+          content << '' unless content.last == ''
+
+          # We're moving something from the top of the file to the bottom, so ditch
+          # the spacer we put in the first time around.
+          content.shift if header_position == :before && content.first == ''
+
+          new_content = magic_comments_map + content + header
+        end
+
+        # Make sure we end on a trailing newline.
+        new_content << '' unless new_content.last == ''
+
+        new_content
+      end
+
+      # @param routes_file [String]
+      # @param existing_text [String]
+      # @param new_text [String]
+      # @param options [Hash]
+      # @return [Boolean]
+      def rewrite_contents(routes_file, existing_text, new_text, options)
+        content_changed = existing_text != new_text
+        frozen = options[:frozen]
+
+        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen
+
+        if content_changed
+          File.open(routes_file, 'wb') { |f| f.puts(new_text) }
+          true
+        else
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -8,8 +8,11 @@ module AnnotateRoutes
   class AnnotationProcessor < BaseProcessor
     private
 
+    def header
+      @header ||= HeaderGenerator.generate(options)
+    end
+
     def generate_new_content_array(content, header_position)
-      header = HeaderGenerator.generate(options)
       magic_comments_map, content = MagicCommentsExtractor.execute(content)
       if %w[before top].include?(options[:position_in_routes])
         new_content_array = []

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -12,9 +12,12 @@ module AnnotateRoutes
       header = HeaderGenerator.generate(options)
       magic_comments_map, content = MagicCommentsExtractor.execute(content)
       if %w[before top].include?(options[:position_in_routes])
-        header = header << '' if content.first != ''
-        magic_comments_map << '' if magic_comments_map.any?
-        new_content = magic_comments_map + header + content
+        new_content_array = []
+        new_content_array += magic_comments_map
+        new_content_array << '' if magic_comments_map.any?
+        new_content_array += header
+        new_content_array << '' if content.first != ''
+        new_content_array += content
       else
         # Ensure we have adequate trailing newlines at the end of the file to
         # ensure a blank line separating the content from the annotation.
@@ -24,13 +27,13 @@ module AnnotateRoutes
         # the spacer we put in the first time around.
         content.shift if header_position == :before && content.first == ''
 
-        new_content = magic_comments_map + content + header
+        new_content_array = magic_comments_map + content + header
       end
 
       # Make sure we end on a trailing newline.
-      new_content << '' unless new_content.last == ''
+      new_content_array << '' unless new_content_array.last == ''
 
-      new_content
+      new_content_array
     end
   end
 end

--- a/lib/annotate/annotate_routes/annotation_processor.rb
+++ b/lib/annotate/annotate_routes/annotation_processor.rb
@@ -1,64 +1,44 @@
+require_relative './base_processor'
 require_relative './helpers'
 require_relative './header_generator'
 
 # This module provides methods for annotating config/routes.rb.
 module AnnotateRoutes
-  # This module provides methods for adding annotation to config/routes.rb.
-  module AnnotationProcessor
-    class << self
-      # @param [Boolean]
-      def update(routes_file, existing_text, options = {})
-        header = HeaderGenerator.generate(options)
-        content, header_position = Helpers.strip_annotations(existing_text)
-        new_content = annotate_routes(header, content, header_position, options)
-        new_text = new_content.join("\n")
-        rewrite_contents(routes_file, existing_text, new_text, options)
+  # This class provides methods for adding annotation to config/routes.rb.
+  class AnnotationProcessor < BaseProcessor
+    # @return [Boolean]
+    def update
+      header = HeaderGenerator.generate(options)
+      content, header_position = Helpers.strip_annotations(existing_text)
+      new_content = annotate_routes(header, content, header_position)
+      new_text = new_content.join("\n")
+      rewrite_contents(new_text)
+    end
+
+    private
+
+    def annotate_routes(header, content, header_position)
+      magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
+      if %w[before top].include?(options[:position_in_routes])
+        header = header << '' if content.first != ''
+        magic_comments_map << '' if magic_comments_map.any?
+        new_content = magic_comments_map + header + content
+      else
+        # Ensure we have adequate trailing newlines at the end of the file to
+        # ensure a blank line separating the content from the annotation.
+        content << '' unless content.last == ''
+
+        # We're moving something from the top of the file to the bottom, so ditch
+        # the spacer we put in the first time around.
+        content.shift if header_position == :before && content.first == ''
+
+        new_content = magic_comments_map + content + header
       end
 
-      private
+      # Make sure we end on a trailing newline.
+      new_content << '' unless new_content.last == ''
 
-      def annotate_routes(header, content, header_position, options = {})
-        magic_comments_map, content = Helpers.extract_magic_comments_from_array(content)
-        if %w[before top].include?(options[:position_in_routes])
-          header = header << '' if content.first != ''
-          magic_comments_map << '' if magic_comments_map.any?
-          new_content = magic_comments_map + header + content
-        else
-          # Ensure we have adequate trailing newlines at the end of the file to
-          # ensure a blank line separating the content from the annotation.
-          content << '' unless content.last == ''
-
-          # We're moving something from the top of the file to the bottom, so ditch
-          # the spacer we put in the first time around.
-          content.shift if header_position == :before && content.first == ''
-
-          new_content = magic_comments_map + content + header
-        end
-
-        # Make sure we end on a trailing newline.
-        new_content << '' unless new_content.last == ''
-
-        new_content
-      end
-
-      # @param routes_file [String]
-      # @param existing_text [String]
-      # @param new_text [String]
-      # @param options [Hash]
-      # @return [Boolean]
-      def rewrite_contents(routes_file, existing_text, new_text, options)
-        content_changed = existing_text != new_text
-        frozen = options[:frozen]
-
-        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen
-
-        if content_changed
-          File.open(routes_file, 'wb') { |f| f.puts(new_text) }
-          true
-        else
-          false
-        end
-      end
+      new_content
     end
   end
 end

--- a/lib/annotate/annotate_routes/base_processor.rb
+++ b/lib/annotate/annotate_routes/base_processor.rb
@@ -2,6 +2,17 @@
 module AnnotateRoutes
   # This class is abstract class of classes adding and removing annotation to config/routes.rb.
   class BaseProcessor
+    class << self
+      # @param options [Hash]
+      # @param routes_file [String]
+      # @return [String]
+      def execute(options, routes_file)
+        new(options, routes_file).execute
+      end
+
+      private :new
+    end
+
     def initialize(options, routes_file)
       @options = options
       @routes_file = routes_file

--- a/lib/annotate/annotate_routes/base_processor.rb
+++ b/lib/annotate/annotate_routes/base_processor.rb
@@ -45,5 +45,47 @@ module AnnotateRoutes
     def frozen?
       options[:frozen]
     end
+
+    # TODO: write the method doc using ruby rdoc formats
+    # This method returns an array of 'real_content' and 'header_position'.
+    # 'header_position' will either be :before, :after, or
+    # a number.  If the number is > 0, the
+    # annotation was found somewhere in the
+    # middle of the file.  If the number is
+    # zero, no annotation was found.
+    def strip_annotations(content)
+      real_content = []
+      mode = :content
+      header_position = 0
+
+      content.split(/\n/, -1).each_with_index do |line, line_number|
+        if mode == :header && line !~ /\s*#/
+          mode = :content
+          real_content << line unless line.blank?
+        elsif mode == :content
+          if line =~ /^\s*#\s*== Route.*$/
+            header_position = line_number + 1 # index start's at 0
+            mode = :header
+          else
+            real_content << line
+          end
+        end
+      end
+
+      real_content_and_header_position(real_content, header_position)
+    end
+
+    def real_content_and_header_position(real_content, header_position)
+      # By default assume the annotation was found in the middle of the file
+
+      # ... unless we have evidence it was at the beginning ...
+      return real_content, :before if header_position == 1
+
+      # ... or that it was at the end.
+      return real_content, :after if header_position >= real_content.count
+
+      # and the default
+      [real_content, header_position]
+    end
   end
 end

--- a/lib/annotate/annotate_routes/base_processor.rb
+++ b/lib/annotate/annotate_routes/base_processor.rb
@@ -1,0 +1,49 @@
+# This module provides methods for annotating config/routes.rb.
+module AnnotateRoutes
+  # This class is abstract class of classes adding and removing annotation to config/routes.rb.
+  class BaseProcessor
+    def initialize(options, routes_file)
+      @options = options
+      @routes_file = routes_file
+    end
+
+    def routes_file_exist?
+      File.exist?(routes_file)
+    end
+
+    private
+
+    attr_reader :options, :routes_file
+
+    def existing_text
+      @existing_text ||= File.read(routes_file)
+    end
+
+    # @param new_text [String]
+    # @return [Boolean]
+    def rewrite_contents(new_text)
+      content_changed = content_changed?(new_text)
+
+      abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen?
+
+      if content_changed
+        write(new_text)
+        true
+      else
+        false
+      end
+    end
+
+    def write(text)
+      File.open(routes_file, 'wb') { |f| f.puts(text) }
+    end
+
+    def content_changed?(new_text)
+      existing_text != new_text
+    end
+
+    def frozen?
+      options[:frozen]
+    end
+  end
+end

--- a/lib/annotate/annotate_routes/base_processor.rb
+++ b/lib/annotate/annotate_routes/base_processor.rb
@@ -9,10 +9,16 @@ module AnnotateRoutes
 
     # @return [Boolean]
     def update
-      content, header_position = strip_annotations(existing_text)
-      new_content = generate_new_content_array(content, header_position)
-      new_text = new_content.join("\n")
-      rewrite_contents(new_text)
+      content_changed = content_changed?(new_text)
+
+      abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen?
+
+      if content_changed
+        write(new_text)
+        true
+      else
+        false
+      end
     end
 
     def routes_file_exist?
@@ -27,19 +33,11 @@ module AnnotateRoutes
       @existing_text ||= File.read(routes_file)
     end
 
-    # @param new_text [String]
-    # @return [Boolean]
-    def rewrite_contents(new_text)
-      content_changed = content_changed?(new_text)
-
-      abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen?
-
-      if content_changed
-        write(new_text)
-        true
-      else
-        false
-      end
+    # @return [String]
+    def new_text
+      content, header_position = strip_annotations(existing_text)
+      new_content = generate_new_content_array(content, header_position)
+      new_content.join("\n")
     end
 
     def write(text)

--- a/lib/annotate/annotate_routes/base_processor.rb
+++ b/lib/annotate/annotate_routes/base_processor.rb
@@ -7,6 +7,14 @@ module AnnotateRoutes
       @routes_file = routes_file
     end
 
+    # @return [Boolean]
+    def update
+      content, header_position = strip_annotations(existing_text)
+      new_content = generate_new_content_array(content, header_position)
+      new_text = new_content.join("\n")
+      rewrite_contents(new_text)
+    end
+
     def routes_file_exist?
       File.exist?(routes_file)
     end

--- a/lib/annotate/annotate_routes/header_generator.rb
+++ b/lib/annotate/annotate_routes/header_generator.rb
@@ -1,6 +1,8 @@
 require_relative './magic_comments_extractor'
 
+# This module provides methods for annotating config/routes.rb.
 module AnnotateRoutes
+  # This class processes result of `rake routes` and generate content enbeded in config/routes.rb.
   class HeaderGenerator
     PREFIX = '== Route Map'.freeze
     PREFIX_MD = '## Route Map'.freeze

--- a/lib/annotate/annotate_routes/header_generator.rb
+++ b/lib/annotate/annotate_routes/header_generator.rb
@@ -1,4 +1,4 @@
-require_relative './helpers'
+require_relative './magic_comments_extractor'
 
 module AnnotateRoutes
   class HeaderGenerator
@@ -42,7 +42,7 @@ module AnnotateRoutes
     end
 
     def generate
-      magic_comments_map, contents_without_magic_comments = Helpers.extract_magic_comments_from_array(routes_map)
+      magic_comments_map, contents_without_magic_comments = MagicCommentsExtractor.execute(routes_map)
 
       out = []
 

--- a/lib/annotate/annotate_routes/helpers.rb
+++ b/lib/annotate/annotate_routes/helpers.rb
@@ -3,35 +3,6 @@ module AnnotateRoutes
     MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*)|(^# coding:.*)|(^# -\*- coding:.*)|(^# -\*- encoding\s?:.*)|(^#\s*frozen_string_literal:.+)|(^# -\*- frozen_string_literal\s*:.+-\*-)/).freeze
 
     class << self
-      # TODO: write the method doc using ruby rdoc formats
-      # This method returns an array of 'real_content' and 'header_position'.
-      # 'header_position' will either be :before, :after, or
-      # a number.  If the number is > 0, the
-      # annotation was found somewhere in the
-      # middle of the file.  If the number is
-      # zero, no annotation was found.
-      def strip_annotations(content)
-        real_content = []
-        mode = :content
-        header_position = 0
-
-        content.split(/\n/, -1).each_with_index do |line, line_number|
-          if mode == :header && line !~ /\s*#/
-            mode = :content
-            real_content << line unless line.blank?
-          elsif mode == :content
-            if line =~ /^\s*#\s*== Route.*$/
-              header_position = line_number + 1 # index start's at 0
-              mode = :header
-            else
-              real_content << line
-            end
-          end
-        end
-
-        real_content_and_header_position(real_content, header_position)
-      end
-
       # @param [Array<String>] content
       # @return [Array<String>] all found magic comments
       # @return [Array<String>] content without magic comments
@@ -48,21 +19,6 @@ module AnnotateRoutes
         end
 
         [magic_comments, new_content]
-      end
-
-      private
-
-      def real_content_and_header_position(real_content, header_position)
-        # By default assume the annotation was found in the middle of the file
-
-        # ... unless we have evidence it was at the beginning ...
-        return real_content, :before if header_position == 1
-
-        # ... or that it was at the end.
-        return real_content, :after if header_position >= real_content.count
-
-        # and the default
-        return real_content, header_position
       end
     end
   end

--- a/lib/annotate/annotate_routes/magic_comments_extractor.rb
+++ b/lib/annotate/annotate_routes/magic_comments_extractor.rb
@@ -1,12 +1,13 @@
 module AnnotateRoutes
-  module Helpers
+  # namespace to contain module function to extract magic comments
+  module MagicCommentsExtractor
     MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*)|(^# coding:.*)|(^# -\*- coding:.*)|(^# -\*- encoding\s?:.*)|(^#\s*frozen_string_literal:.+)|(^# -\*- frozen_string_literal\s*:.+-\*-)/).freeze
 
     class << self
       # @param [Array<String>] content
       # @return [Array<String>] all found magic comments
       # @return [Array<String>] content without magic comments
-      def extract_magic_comments_from_array(content_array)
+      def execute(content_array)
         magic_comments = []
         new_content = []
 

--- a/lib/annotate/annotate_routes/removal_processor.rb
+++ b/lib/annotate/annotate_routes/removal_processor.rb
@@ -7,14 +7,14 @@ module AnnotateRoutes
     # @return [Boolean]
     def update
       content, header_position = strip_annotations(existing_text)
-      new_content = strip_on_removal(content, header_position)
+      new_content = generate_new_content_array(content, header_position)
       new_text = new_content.join("\n")
       rewrite_contents(new_text)
     end
 
     private
 
-    def strip_on_removal(content, header_position)
+    def generate_new_content_array(content, header_position)
       case header_position
       when :before
         content.shift while content.first == ''

--- a/lib/annotate/annotate_routes/removal_processor.rb
+++ b/lib/annotate/annotate_routes/removal_processor.rb
@@ -4,14 +4,6 @@ require_relative './base_processor'
 module AnnotateRoutes
   # This class provides methods for removing annotation from config/routes.rb.
   class RemovalProcessor < BaseProcessor
-    # @return [Boolean]
-    def update
-      content, header_position = strip_annotations(existing_text)
-      new_content = generate_new_content_array(content, header_position)
-      new_text = new_content.join("\n")
-      rewrite_contents(new_text)
-    end
-
     private
 
     def generate_new_content_array(content, header_position)

--- a/lib/annotate/annotate_routes/removal_processor.rb
+++ b/lib/annotate/annotate_routes/removal_processor.rb
@@ -4,6 +4,19 @@ require_relative './base_processor'
 module AnnotateRoutes
   # This class provides methods for removing annotation from config/routes.rb.
   class RemovalProcessor < BaseProcessor
+    # @return [String]
+    def execute
+      if routes_file_exist?
+        if update
+          "Annotations were removed from #{routes_file}."
+        else
+          "#{routes_file} was not changed (Annotation did not exist)."
+        end
+      else
+        "#{routes_file} could not be found."
+      end
+    end
+
     private
 
     def generate_new_content_array(content, header_position)

--- a/lib/annotate/annotate_routes/removal_processor.rb
+++ b/lib/annotate/annotate_routes/removal_processor.rb
@@ -1,57 +1,35 @@
+require_relative './base_processor'
 require_relative './helpers'
 
 # This module provides methods for annotating config/routes.rb.
 module AnnotateRoutes
-  # This module provides methods for removing annotation from config/routes.rb.
-  module RemovalProcessor
-    class << self
-      # @param routes_file [String]
-      # @param existing_text [String]
-      # @param options [Hash]
-      def update(routes_file, existing_text, options)
-        content, header_position = Helpers.strip_annotations(existing_text)
-        new_content = strip_on_removal(content, header_position)
-        new_text = new_content.join("\n")
-        rewrite_contents(routes_file, existing_text, new_text, options)
+  # This class provides methods for removing annotation from config/routes.rb.
+  class RemovalProcessor < BaseProcessor
+    # @return [Boolean]
+    def update
+      content, header_position = Helpers.strip_annotations(existing_text)
+      new_content = strip_on_removal(content, header_position)
+      new_text = new_content.join("\n")
+      rewrite_contents(new_text)
+    end
+
+    private
+
+    def strip_on_removal(content, header_position)
+      case header_position
+      when :before
+        content.shift while content.first == ''
+      when :after
+        content.pop while content.last == ''
       end
 
-      private
+      # Make sure we end on a trailing newline.
+      content << '' unless content.last == ''
 
-      def strip_on_removal(content, header_position)
-        case header_position
-        when :before
-          content.shift while content.first == ''
-        when :after
-          content.pop while content.last == ''
-        end
-
-        # Make sure we end on a trailing newline.
-        content << '' unless content.last == ''
-
-        # TODO: If the user buried it in the middle, we should probably see about
-        # TODO: preserving a single line of space between the content above and
-        # TODO: below...
-        content
-      end
-
-      # @param routes_file [String]
-      # @param existing_text [String]
-      # @param new_text [String]
-      # @param options [Hash]
-      # @return [Boolean]
-      def rewrite_contents(routes_file, existing_text, new_text, options)
-        content_changed = existing_text != new_text
-        frozen = options[:frozen]
-
-        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen
-
-        if content_changed
-          File.open(routes_file, 'wb') { |f| f.puts(new_text) }
-          true
-        else
-          false
-        end
-      end
+      # TODO: If the user buried it in the middle, we should probably see about
+      # TODO: preserving a single line of space between the content above and
+      # TODO: below...
+      content
     end
   end
 end

--- a/lib/annotate/annotate_routes/removal_processor.rb
+++ b/lib/annotate/annotate_routes/removal_processor.rb
@@ -1,5 +1,4 @@
 require_relative './base_processor'
-require_relative './helpers'
 
 # This module provides methods for annotating config/routes.rb.
 module AnnotateRoutes
@@ -7,7 +6,7 @@ module AnnotateRoutes
   class RemovalProcessor < BaseProcessor
     # @return [Boolean]
     def update
-      content, header_position = Helpers.strip_annotations(existing_text)
+      content, header_position = strip_annotations(existing_text)
       new_content = strip_on_removal(content, header_position)
       new_text = new_content.join("\n")
       rewrite_contents(new_text)

--- a/lib/annotate/annotate_routes/removal_processor.rb
+++ b/lib/annotate/annotate_routes/removal_processor.rb
@@ -1,0 +1,57 @@
+require_relative './helpers'
+
+# This module provides methods for annotating config/routes.rb.
+module AnnotateRoutes
+  # This module provides methods for removing annotation from config/routes.rb.
+  module RemovalProcessor
+    class << self
+      # @param routes_file [String]
+      # @param existing_text [String]
+      # @param options [Hash]
+      def update(routes_file, existing_text, options)
+        content, header_position = Helpers.strip_annotations(existing_text)
+        new_content = strip_on_removal(content, header_position)
+        new_text = new_content.join("\n")
+        rewrite_contents(routes_file, existing_text, new_text, options)
+      end
+
+      private
+
+      def strip_on_removal(content, header_position)
+        case header_position
+        when :before
+          content.shift while content.first == ''
+        when :after
+          content.pop while content.last == ''
+        end
+
+        # Make sure we end on a trailing newline.
+        content << '' unless content.last == ''
+
+        # TODO: If the user buried it in the middle, we should probably see about
+        # TODO: preserving a single line of space between the content above and
+        # TODO: below...
+        content
+      end
+
+      # @param routes_file [String]
+      # @param existing_text [String]
+      # @param new_text [String]
+      # @param options [Hash]
+      # @return [Boolean]
+      def rewrite_contents(routes_file, existing_text, new_text, options)
+        content_changed = existing_text != new_text
+        frozen = options[:frozen]
+
+        abort "annotate error. #{routes_file} needs to be updated, but annotate was run with `--frozen`." if content_changed && frozen
+
+        if content_changed
+          File.open(routes_file, 'wb') { |f| f.puts(new_text) }
+          true
+        else
+          false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Redo version of #793 and #1008.

cf. #790, #792

In order to refactor AnnoateRoutes, I added `AnnotateRoutes::AnnotationProcessor` and `AnnotateRoutes::RemovalProcessor`.

Refactoring AnnotateRoutes is finished in this PR and I would like to refactor AnnotateModels in a like way.
