### PR TITLE
Fix `annotate_one_file` to avoid ignoring commented columns

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -433,7 +433,9 @@ module AnnotateModels
       old_header = old_content.match(header_pattern).to_s
       new_header = info_block.match(header_pattern).to_s
 
-      column_pattern = /^#[\t ]+[\w\*\.`]+[\t ]+.+$/
+      column_name_pattern = '[\w\*\.`]+'
+      comment_pattern = '(?:\(.+\))?'
+      column_pattern = /^#[\t ]+#{column_name_pattern}#{comment_pattern}[\t ]+.+$/
       old_columns = old_header && old_header.scan(column_pattern).sort
       new_columns = new_header && new_header.scan(column_pattern).sort
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2922,6 +2922,35 @@ describe AnnotateModels do
           expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
         end
       end
+
+      context 'of commented columns' do
+        before do
+          klass = mock_class(:users,
+                             :id,
+                             [
+                               mock_column(:id, :integer, comment: 'primary key'),
+                               mock_column(:name, :string, comment: 'with comment')
+                             ],
+                             [],
+                             [])
+          @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', with_comment: true)
+          annotate_one_file
+        end
+
+        it 'should update a commented column' do
+          klass = mock_class(:users,
+                             :id,
+                             [
+                               mock_column(:id, :integer, comment: 'primary key'),
+                               mock_column(:name, :text, comment: 'ｗｉｔｈ ｍｕｌｔｉｂｙｔｅ ｃｏｍｍｅｎｔ')
+                             ],
+                             [],
+                             [])
+          @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', with_comment: true)
+          annotate_one_file
+          expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
+        end
+      end
     end
 
     describe 'with existing annotation => :before' do


### PR DESCRIPTION
Fixed an issue in `annotate_one_file` where columns with comments were being overlooked, leading to them being excluded from change detection.

The updated regular expression now correctly matches comment lines like the following. Previously, these comments weren't matching due to the `(column comment)` part.

```ruby
# column_name(column comment)  :column_type  not null
```