### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,7 @@ See https://github.com/ctran/annotate_models/releases/tag/v2.7.0
     you don't.) Also includes a mode for "tinkering" by hand with a scenario,
     and won't let you run it through rspect if the repo is in a dirty state. 
     Added appropriate rake tasks to help with all of this.
-- Routes can now be appended, pre-pended, or removed -- and do sane things in all cases.
+- Routes can now be appended, prepended, or removed -- and do sane things in all cases.
 - Expose all `position_*` variables as CLI params.
 - Make `ENV ['position']` work as a default for all the `ENV ['position_*']` variables.
 - Make rake tasks more resilient to unusual circumstances / code loading behavior.

--- a/Guardfile
+++ b/Guardfile
@@ -4,7 +4,7 @@
 #  * bundler binstubs: 'bin/rspec'
 #  * spring: 'bin/rsspec' (This will use spring if running and you have
 #                          installed the spring binstubs per the docs)
-#  * zeus: 'zeus rspec' (requires the server to be started separetly)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
 #  * 'just' rspec: 'rspec'
 guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ you can do so with a simple environment variable, instead of editing the
         -R, --require path               Additional file to require before loading models, may be used multiple times
         -e [tests,fixtures,factories,serializers],
             --exclude                    Do not annotate fixtures, test files, factories, and/or serializers
-        -f [bare|rdoc|yard|markdown],    Render Schema Infomation as plain/RDoc/YARD/Markdown
+        -f [bare|rdoc|yard|markdown],    Render Schema Information as plain/RDoc/YARD/Markdown
             --format
             --force                      Force new annotations even if there are no changes.
             --frozen                     Do not allow to change annotations. Exits non-zero if there are going to be changes to files.

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -904,7 +904,7 @@ module AnnotateModels
     def translated_columns(klass)
       return [] unless klass.respond_to? :translation_class
 
-      ignored_cols = ignored_translation_table_colums(klass)
+      ignored_cols = ignored_translation_table_columns(klass)
       klass.translation_class.columns.reject do |col|
         ignored_cols.include? col.name.to_sym
       end
@@ -913,7 +913,7 @@ module AnnotateModels
     ##
     # These are the columns that the globalize gem needs to work but
     # are not necessary for the models to be displayed as annotations.
-    def ignored_translation_table_colums(klass)
+    def ignored_translation_table_columns(klass)
       # Construct the foreign column name in the translations table
       # eg. Model: Car, foreign column name: car_id
       foreign_column_name = [

--- a/lib/annotate/parser.rb
+++ b/lib/annotate/parser.rb
@@ -250,7 +250,7 @@ module Annotate
       option_parser.on('-f',
                        '--format [bare|rdoc|yard|markdown]',
                        FORMAT_TYPES,
-                       'Render Schema Infomation as plain/RDoc/Yard/Markdown') do |format_type|
+                       'Render Schema Information as plain/RDoc/Yard/Markdown') do |format_type|
         env["format_#{format_type}"] = 'yes'
       end
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1625,7 +1625,7 @@ describe AnnotateModels do
                   end
                 end
 
-                context 'when one of indexes includes orderd index key' do
+                context 'when one of indexes includes ordered index key' do
                   let :indexes do
                     [
                       mock_index('index_rails_02e851e3b7', columns: ['id']),


### PR DESCRIPTION
Found via `codespell -H -L tread` and `typos --format brief`