### PR TITLE
Allow composite foreign keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source 'https://rubygems.org'
 
-ruby '>= 2.4.0'
+ruby '>= 3.3.0'
 
-gem 'activerecord', '>= 4.2.5', '< 6', require: false
+gem 'activerecord', '>= 7.1', require: false
 gem 'rake', require: false
+gem 'activerecord-multi-tenant', git: 'https://github.com/citusdata/activerecord-multi-tenant.git', require: false
 
 group :development do
   gem 'bump'
   gem 'mg', require: false
-  gem 'travis', require: false
   platforms :mri, :mingw do
     gem 'yard', require: false
   end
@@ -19,9 +19,9 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'rspec', require: false
 
-  gem 'rubocop', '~> 1.12.0', require: false
+  gem 'rubocop', require: false
   gem 'rubocop-rake', require: false
-  gem 'rubocop-rspec', '~> 2.2.0', require: false
+  gem 'rubocop-rspec', require: false
   gem 'simplecov', require: false
   gem 'terminal-notifier-guard', require: false
 
@@ -29,7 +29,6 @@ group :development, :test do
   gem 'coveralls'
 
   gem 'overcommit'
-  gem 'ruby_dep', '1.5.0'
 
   platforms :mri, :mingw do
     gem 'pry', require: false

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -345,6 +345,12 @@ module AnnotateModels
       excludes.include?(col_type)
     end
 
+    #  The fk columns might be composite keys, so format them into
+    #  a string for the annotation
+    def stringify_fk_columns( columns )
+      columns.class == Array ? columns.join( ", " ) : columns
+    end
+
     def get_foreign_key_info(klass, options = {})
       fk_info = if options[:format_markdown]
                   "#\n# ### Foreign Keys\n#\n"
@@ -365,12 +371,10 @@ module AnnotateModels
 
       max_size = foreign_keys.map(&format_name).map(&:size).max + 1
 
-puts foreign_keys.inspect
-
       foreign_keys.sort_by { |fk|
-        [format_name.call(fk), ( fk.column.class == Array ? fk.column.join( ", " ) : fk.column ) ]
+        [format_name.call(fk), stringify_fk_columns( fk.column ) ]
       }.each do |fk|
-        ref_info = "#{fk.column} => #{fk.to_table}.#{fk.primary_key}"
+        ref_info = "#{stringify_fk_columns( fk.column )} => #{fk.to_table}.#{fk.primary_key}"
         constraints_info = ''
         constraints_info += "ON DELETE => #{fk.on_delete} " if fk.on_delete
         constraints_info += "ON UPDATE => #{fk.on_update} " if fk.on_update

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -347,8 +347,8 @@ module AnnotateModels
 
     #  The fk columns might be composite keys, so format them into
     #  a string for the annotation
-    def stringify_fk_columns( columns )
-      columns.class == Array ? columns.join( ", " ) : columns
+    def stringify_columns( columns )
+      columns.class == Array ? "[#{columns.join( ", " )}]" : columns
     end
 
     def get_foreign_key_info(klass, options = {})
@@ -372,9 +372,9 @@ module AnnotateModels
       max_size = foreign_keys.map(&format_name).map(&:size).max + 1
 
       foreign_keys.sort_by { |fk|
-        [format_name.call(fk), stringify_fk_columns( fk.column ) ]
+        [format_name.call(fk), stringify_columns( fk.column ) ]
       }.each do |fk|
-        ref_info = "#{stringify_fk_columns( fk.column )} => #{fk.to_table}.#{fk.primary_key}"
+        ref_info = "#{stringify_columns( fk.column )} => #{fk.to_table}.#{stringify_columns(fk.primary_key)}"
         constraints_info = ''
         constraints_info += "ON DELETE => #{fk.on_delete} " if fk.on_delete
         constraints_info += "ON UPDATE => #{fk.on_update} " if fk.on_update

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -364,7 +364,12 @@ module AnnotateModels
       end
 
       max_size = foreign_keys.map(&format_name).map(&:size).max + 1
-      foreign_keys.sort_by {|fk| [format_name.call(fk), fk.column]}.each do |fk|
+
+puts foreign_keys.inspect
+
+      foreign_keys.sort_by { |fk|
+        [format_name.call(fk), ( fk.column.class == Array ? fk.column.join( ", " ) : fk.column ) ]
+      }.each do |fk|
         ref_info = "#{fk.column} => #{fk.to_table}.#{fk.primary_key}"
         constraints_info = ''
         constraints_info += "ON DELETE => #{fk.on_delete} " if fk.on_delete

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,13 @@ Bundler.setup
 require 'rake'
 require 'rspec'
 
+#  Crappy monkey patch so files gem doesn't fail.
+class File
+  def self.exists?(file)
+    File.exist?(file)
+  end
+end
+
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '../lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 


### PR DESCRIPTION
I'm using composite foreign keys in my database, and currently Annotate complains with warnings like :

```
Unable to annotate app/models/monitor_base.rb: comparison of Array with Array failed
Unable to annotate app/models/monitor_base.rb: no implicit conversion of nil into Array
```

This pull request adds support for composite keys, with output such as :

```
#  fk_rails_...  ([id, default_notification_policy_id] => notification_policies.[team_id, id])
#  fk_rails_...  (owner_id => users.id)
```

(The PR also hacks around with `Gemfile` and `spec/spec_helper.rb` so I could get the tests to run locally on my Ruby version - those changes aren't really necessary.)