### PR TITLE
DOC: Add single model use case explanation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ To annotate just your models:
 
     annotate --models
 
+To annotate a specific model:
+
+    annotate --models <path/to/model/file>
+
 To annotate routes.rb:
 
     annotate --routes


### PR DESCRIPTION
There is no explanation of single model use case in the readme, which I personally often use.
It took me a while to figure out, so I'd like to add this explanation to make the gem more beginner-friendly.