### PR TITLE
Fix max_size for empty cols array

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -834,7 +834,7 @@ module AnnotateModels
         end.max || 0
         max_size += 2
       else
-        max_size = cols.map(&:name).map(&:size).max
+        max_size = cols.map(&:name).map(&:size).max || 0
       end
       max_size += options[:format_rdoc] ? 5 : 1
 


### PR DESCRIPTION
This ensure a `max_size = zero` for the `max_schema_info_width` method for the case when cols array is empty. When table has columns without comments that also are all ignored, then cols array results on empty array, resulting on a nil `max_size`. This is fixed using the same estrategy as with commented cols putting zero as default if there are no cols.