### PR TITLE
Guardfile: Drop very old generated code comment [ci skip]

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,11 +1,3 @@
-# NOTE: The cmd option is now required due to the increasing number of ways
-#       rspec may be run, below are examples of the most common uses.
-#  * bundler: 'bundle exec rspec'
-#  * bundler binstubs: 'bin/rspec'
-#  * spring: 'bin/rsspec' (This will use spring if running and you have
-#                          installed the spring binstubs per the docs)
-#  * zeus: 'zeus rspec' (requires the server to be started separetly)
-#  * 'just' rspec: 'rspec'
 guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }


### PR DESCRIPTION
This PR drop a verbose code comment from a config file for Guard.

I would also like to drop some of the generated lines for types of tests not used in this project.