### PR TITLE
Fix backslashes incorrectly escaped

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -469,7 +469,8 @@ module AnnotateModels
         space_match = old_annotation.match(/\A(?<start>\s*).*?\n(?<end>\s*)\z/m)
         new_annotation = space_match[:start] + wrapped_info_block + space_match[:end]
 
-        new_content = old_content.sub(annotate_pattern(options), new_annotation)
+        # use the block version of sub to avoid interpreting special characters
+        new_content = old_content.sub(annotate_pattern(options)) { |_match| new_annotation }
       end
 
       File.open(file_name, 'wb') { |f| f.puts new_content }

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2922,6 +2922,65 @@ describe AnnotateModels do
           expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
         end
       end
+
+      context 'of an index' do
+        before do
+          klass = mock_class(:users,
+                             :id,
+                             [
+                               mock_column(:id, :integer),
+                               mock_column(:foreign_thing_id, :integer)
+                             ],
+                             [
+                              mock_index('index_rails_02e851e3b7', columns: ['id']),
+                              mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
+                             ])
+          @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', show_indexes: true)
+          annotate_one_file
+        end
+
+        it 'should update index' do
+          klass = mock_class(:users,
+                             :id,
+                             [
+                               mock_column(:id, :integer),
+                               mock_column(:foreign_thing_id, :integer),
+                               mock_column(:another_column, :integer)
+                             ],
+                             [
+                              mock_index('index_rails_02e851e3b7', columns: ['id']),
+                              mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id']),
+                              mock_index('index_rails_02e851e3b9',
+                                columns: ['another_column'],
+                                where: "another_column IS NOT NULL"
+                              )
+                             ])
+          @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', show_indexes: true)
+          annotate_one_file
+          expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
+        end
+
+        it 'should update index without escaping backslashes' do
+          klass = mock_class(:users,
+                             :id,
+                             [
+                               mock_column(:id, :integer),
+                               mock_column(:foreign_thing_id, :integer),
+                               mock_column(:another_column, :text)
+                             ],
+                             [
+                              mock_index('index_rails_02e851e3b7', columns: ['id']),
+                              mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id']),
+                              mock_index('index_rails_02e851e3b9',
+                                columns: ['another_column'],
+                                where: "another_column LIKE '\\\\%'"
+                              )
+                             ])
+          @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', show_indexes: true)
+          annotate_one_file
+          expect(File.read(@model_file_name)).to eq("#{@schema_info}#{@file_content}")
+        end
+      end
     end
 
     describe 'with existing annotation => :before' do

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -2932,8 +2932,8 @@ describe AnnotateModels do
                                mock_column(:foreign_thing_id, :integer)
                              ],
                              [
-                              mock_index('index_rails_02e851e3b7', columns: ['id']),
-                              mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
+                               mock_index('index_rails_02e851e3b7', columns: ['id']),
+                               mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id'])
                              ])
           @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', show_indexes: true)
           annotate_one_file
@@ -2948,12 +2948,11 @@ describe AnnotateModels do
                                mock_column(:another_column, :integer)
                              ],
                              [
-                              mock_index('index_rails_02e851e3b7', columns: ['id']),
-                              mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id']),
-                              mock_index('index_rails_02e851e3b9',
-                                columns: ['another_column'],
-                                where: "another_column IS NOT NULL"
-                              )
+                               mock_index('index_rails_02e851e3b7', columns: ['id']),
+                               mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id']),
+                               mock_index('index_rails_02e851e3b9',
+                                          columns: ['another_column'],
+                                          where: "another_column IS NOT NULL")
                              ])
           @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', show_indexes: true)
           annotate_one_file
@@ -2969,12 +2968,11 @@ describe AnnotateModels do
                                mock_column(:another_column, :text)
                              ],
                              [
-                              mock_index('index_rails_02e851e3b7', columns: ['id']),
-                              mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id']),
-                              mock_index('index_rails_02e851e3b9',
-                                columns: ['another_column'],
-                                where: "another_column LIKE '\\\\%'"
-                              )
+                               mock_index('index_rails_02e851e3b7', columns: ['id']),
+                               mock_index('index_rails_02e851e3b8', columns: ['foreign_thing_id']),
+                               mock_index('index_rails_02e851e3b9',
+                                          columns: ['another_column'],
+                                          where: "another_column LIKE '\\\\%'")
                              ])
           @schema_info = AnnotateModels.get_schema_info(klass, '== Schema Info', show_indexes: true)
           annotate_one_file


### PR DESCRIPTION
Where annotations contain backslashes these are incorrectly interpreted by `#sub` as special characters when updating existing annotations.

For example, an index condition may include string matching with special characters.

Using the block version of `#sub` avoids this.