### PR TITLE
Allow annotating models and routes using sorbet's static checks

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -768,6 +768,7 @@ Style/StderrPuts:
 Style/StringConcatenation:
   Exclude:
     - 'lib/annotate/annotate_models.rb'
+    - 'lib/annotate/annotate_routes/helpers.rb'
 
 # Offense count: 57
 # Cop supports --auto-correct.
@@ -817,4 +818,4 @@ Style/TrailingCommaInArrayLiteral:
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Layout/LineLength:
-  Max: 264
+  Max: 245

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -39,7 +39,15 @@ module AnnotateModels
     }
   }.freeze
 
-  MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*(?:\n|r\n))|(^# coding:.*(?:\n|\r\n))|(^# -\*- coding:.*(?:\n|\r\n))|(^# -\*- encoding\s?:.*(?:\n|\r\n))|(^#\s*frozen_string_literal:.+(?:\n|\r\n))|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))/).freeze
+  MAGIC_COMMENT_MATCHER = Regexp.new(
+    '(^#\s*encoding:.*(?:\n|\r\n))' \
+    + '|(^# coding:.*(?:\n|\r\n))' \
+    + '|(^# -\*- coding:.*(?:\n|\r\n))' \
+    + '|(^# -\*- encoding\s?:.*(?:\n|\r\n))' \
+    + '|(^#\s*frozen_string_literal:.+(?:\n|\r\n))' \
+    + '|(^# -\*- frozen_string_literal\s*:.+-\*-(?:\n|\r\n))' \
+    + '|(^#\s*typed:.+(?:\n|\r\n))'
+  ).freeze
 
   class << self
     def annotate_pattern(options = {})

--- a/lib/annotate/annotate_routes/helpers.rb
+++ b/lib/annotate/annotate_routes/helpers.rb
@@ -1,6 +1,14 @@
 module AnnotateRoutes
   module Helpers
-    MAGIC_COMMENT_MATCHER = Regexp.new(/(^#\s*encoding:.*)|(^# coding:.*)|(^# -\*- coding:.*)|(^# -\*- encoding\s?:.*)|(^#\s*frozen_string_literal:.+)|(^# -\*- frozen_string_literal\s*:.+-\*-)/).freeze
+    MAGIC_COMMENT_MATCHER = Regexp.new(
+      '(^#\s*encoding:.*)' \
+      + '|(^# coding:.*)' \
+      + '|(^# -\*- coding:.*)' \
+      + '|(^# -\*- encoding\s?:.*)' \
+      + '|(^#\s*frozen_string_literal:.+)' \
+      + '|(^# -\*- frozen_string_literal\s*:.+-\*-)' \
+      + '|(^#\s*typed:.*)'
+    ).freeze
 
     class << self
       # TODO: write the method doc using ruby rdoc formats

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -18,7 +18,9 @@ describe AnnotateModels do
     "# frozen_string_literal: true\n# encoding: utf-8",
     '# frozen_string_literal: true',
     '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
+    '# -*- frozen_string_literal : true -*-',
+    '#typed: false',
+    '# typed: true'
   ].freeze unless const_defined?(:MAGIC_COMMENTS)
 
   def mock_index(name, params = {})

--- a/spec/lib/annotate/annotate_routes_spec.rb
+++ b/spec/lib/annotate/annotate_routes_spec.rb
@@ -20,7 +20,9 @@ describe AnnotateRoutes do
     "# frozen_string_literal: true\n# encoding: utf-8",
     '# frozen_string_literal: true',
     '#frozen_string_literal: false',
-    '# -*- frozen_string_literal : true -*-'
+    '# -*- frozen_string_literal : true -*-',
+    '#typed: false',
+    '# typed: true'
   ].freeze unless const_defined?(:MAGIC_COMMENTS)
 
   let :stubs do


### PR DESCRIPTION
This PR allows **Annotate** to recognize and keep Sorbet's [static checks](https://sorbet.org/docs/static) sigils.

Diff after running `annotate` for models and routes with Sorbet static check sigils:

**Before**
```diff
-# typed: true
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: …
+#
+#  …
+#
+# typed: true
+
```

**After**
```diff
 # typed: true
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: …
+#
+#  …
+#
```
