### PR TITLE
Allow running annotate for when the columns are frozen

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -940,6 +940,8 @@ module AnnotateModels
       attrs << 'not null' unless column.null
       attrs << 'primary key' if klass.primary_key && (klass.primary_key.is_a?(Array) ? klass.primary_key.collect(&:to_sym).include?(column.name.to_sym) : column.name.to_sym == klass.primary_key.to_sym)
 
+      column_type = column_type.dup if column_type.frozen?
+
       if column_type == 'decimal'
         column_type << "(#{column.precision}, #{column.scale})"
       elsif !%w[spatial geometry geography].include?(column_type)

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -940,8 +940,6 @@ module AnnotateModels
       attrs << 'not null' unless column.null
       attrs << 'primary key' if klass.primary_key && (klass.primary_key.is_a?(Array) ? klass.primary_key.collect(&:to_sym).include?(column.name.to_sym) : column.name.to_sym == klass.primary_key.to_sym)
 
-      column_type = column_type.dup if column_type.frozen?
-
       if column_type == 'decimal'
         column_type << "(#{column.precision}, #{column.scale})"
       elsif !%w[spatial geometry geography].include?(column_type)

--- a/spec/lib/tasks/annotate_models_spec.rb
+++ b/spec/lib/tasks/annotate_models_spec.rb
@@ -43,20 +43,18 @@ describe 'Annotate annotate_models rake task and Annotate.set_defaults' do # rub
 
     before do
       allow(klass).to receive(:columns).and_return([
-        double('Column', name: 'id', type: 'integer'.freeze, sql_type: 'integer', limit: nil, null: false, default: nil, comment: nil)
+        instance_double('Column', name: 'id', type: 'integer'.freeze, sql_type: 'integer', limit: nil, null: false, default: nil, comment: nil)
       ])
       allow(klass).to receive(:table_exists?).and_return(true)
       allow(klass).to receive(:primary_key).and_return('id')
     end
 
     it 'does not raise an error when modifying column_type' do
-      expect {
-        AnnotateModels.get_schema_info(klass, "Schema Info", {})
-      }.not_to raise_error
+      expect { AnnotateModels.get_schema_info(klass, 'Schema Info', {}) }.not_to raise_error
     end
 
     it 'includes the column information in the schema info' do
-      schema_info = AnnotateModels.get_schema_info(klass, "Schema Info", {})
+      schema_info = AnnotateModels.get_schema_info(klass, 'Schema Info', {})
       expect(schema_info).to include('id :integer')
     end
   end


### PR DESCRIPTION
**Edit:** I noticed that it was fixed in a newer version 🤦 (PR https://github.com/ctran/annotate_models/pull/895). I left the PR open in case you want the tests.

#


In case where the columns are frozen, the gem 💥 when annotating the models:

```ruby
col = MyModel.columns.map { |n| [n.name, n.frozen?] } # => [[a, true], [b, true], [c, true]]
col.frozen? #=> true
col.type.to_s.frozen? # => true
```


The problem is that we're trying to modify the string when doing `column_type << ...` in lines:


https://github.com/ctran/annotate_models/blob/5d01c4171990c4fe7b9b0977b05ce14a98209e53/lib/annotate/annotate_models.rb#L943-L953

### The fix

I duplicated the value if it's frozen https://github.com/ctran/annotate_models/pull/1030/commits/95327bd25bcf0055b0f25757453b15ed0a98647a#diff-60ea710bcc08132bf411088124fcaa2b569a5ac493a5d364e0141f425afe2477R943