### PR TITLE
Add deprecation notice and link to annotaterb to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # This Gem is no longer maintained
 
-**Consider [annotate_rb](https://github.com/drwl/annotaterb)** for an actively maintained alternative.
+**Consider [annotaterb](https://github.com/drwl/annotaterb)** for an actively maintained alternative.
 
 ## Annotate (aka AnnotateModels)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# This Gem is no longer maintained
+
+**Consider [annotate_rb](https://github.com/drwl/annotaterb)** for an actively maintained alternative.
+
 ## Annotate (aka AnnotateModels)
 
 [![Gem Version](https://badge.fury.io/rb/annotate.svg)](http://badge.fury.io/rb/annotate)
@@ -5,6 +9,8 @@
 [![CI Status](https://github.com/ctran/annotate_models/workflows/CI/badge.svg)](https://github.com/ctran/annotate_models/actions?workflow=CI)
 [![Coveralls](https://coveralls.io/repos/ctran/annotate_models/badge.svg?branch=develop)](https://coveralls.io/r/ctran/annotate_models?branch=develop)
 [![Maintenability](https://codeclimate.com/github/ctran/annotate_models/badges/gpa.svg)](https://codeclimate.com/github/ctran/annotate_models)
+
+
 
 Add a comment summarizing the current schema to the top or bottom of each of your...
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 [![Coveralls](https://coveralls.io/repos/ctran/annotate_models/badge.svg?branch=develop)](https://coveralls.io/r/ctran/annotate_models?branch=develop)
 [![Maintenability](https://codeclimate.com/github/ctran/annotate_models/badges/gpa.svg)](https://codeclimate.com/github/ctran/annotate_models)
 
-
-
 Add a comment summarizing the current schema to the top or bottom of each of your...
 
 - ActiveRecord models


### PR DESCRIPTION
This gem is no longer maintained. It doesn't support Rails 8.

This PR adds a note that the gem is no longer maintained and recommends looking at [annotaterb](https://github.com/drwl/annotaterb) for an alternative.

See e.g. https://github.com/ctran/annotate_models/issues/1039