### PR TITLE
Account for object default values when annotating models

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -107,7 +107,7 @@ module AnnotateModels
       when BigDecimal               then value.to_s('F')
       when Array                    then value.map { |v| quote(v) }
       else
-        value.inspect
+        value.respond_to?(:to_s) ? value.to_s.inspect : value.inspect
       end
     end
 

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -152,6 +152,20 @@ describe AnnotateModels do
         is_expected.to eq(['1.2'])
       end
     end
+
+    context 'when the argument is an object that responds to to_s' do
+      let(:value) do
+        obj = Object.new
+        def obj.to_s
+          "custom string representation"
+        end
+        obj
+      end
+
+      it 'returns the result of to_s wrapped in quotes' do
+        is_expected.to eq('"custom string representation"')
+      end
+    end
   end
 
   describe '.parse_options' do


### PR DESCRIPTION
Fix Default Value Handling for Objects with to_s Method

This PR updates the quote method in annotate_models.rb to properly handle default values that are objects implementing the `to_s` method. This change improves the annotation behavior when dealing with complex default values in model attributes.

Changes:
- Updated the quote method to properly handle object default values
- Added tests to verify the new behavior

Previous behavior:
- Objects with `to_s` implementation weren't properly quoted in annotations

New behavior:
- Objects with `to_s` implementation are now properly quoted in the annotations

This change ensures more accurate model annotations when dealing with complex default values.

With this change we can effectively annotate object defaults. This is an example with the woking fix in one of our repos:

<img width="936" alt="Screenshot 2025-05-07 at 9 04 59 AM" src="https://github.com/user-attachments/assets/c9bb0f88-ec5a-4642-a8ab-a9cfcceb8743" />
