### PR TITLE
option to group STI column annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ you can do so with a simple environment variable, instead of editing the
             --ignore-unknown-models      don't display warnings for bad model files
             --with-comment               include database comments in model annotations
             --with-comment-column        include database comments in model annotations, as its own column, after all others
+            --group-sti-columns          group annotation columns by STI class ownership
 
 ### Option: `additional_file_patterns`
 

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -172,7 +172,7 @@ module AnnotateModels
       # Output annotation
       bare_max_attrs_length = cols_meta.map { |_, m| m[:simple_formatted_attrs].length }.max
 
-      if options[:classify_sti_columns]
+      if options[:group_sti_columns]
         grouped_cols = Annotate::StiColumns.partition(klass, cols)
       else
         grouped_cols = [[nil, cols]]

--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -3,6 +3,7 @@
 require 'bigdecimal'
 
 require 'annotate/constants'
+require 'annotate/sti_columns'
 require_relative 'annotate_models/file_patterns'
 
 module AnnotateModels
@@ -171,27 +172,43 @@ module AnnotateModels
       # Output annotation
       bare_max_attrs_length = cols_meta.map { |_, m| m[:simple_formatted_attrs].length }.max
 
-      cols.each do |col|
-        col_type = cols_meta[col.name][:col_type]
-        attrs = cols_meta[col.name][:attrs]
-        col_name = cols_meta[col.name][:col_name]
-        simple_formatted_attrs = cols_meta[col.name][:simple_formatted_attrs]
-        col_comment = cols_meta[col.name][:col_comment]
+      if options[:classify_sti_columns]
+        grouped_cols = Annotate::StiColumns.partition(klass, cols)
+      else
+        grouped_cols = [[nil, cols]]
+      end
 
-        if options[:format_rdoc]
-          info << sprintf("# %-#{max_size}.#{max_size}s<tt>%s</tt>", "*#{col_name}*::", attrs.unshift(col_type).join(", ")).rstrip + "\n"
-        elsif options[:format_yard]
-          info << sprintf("# @!attribute #{col_name}") + "\n"
-          ruby_class = col.respond_to?(:array) && col.array ? "Array<#{map_col_type_to_ruby_classes(col_type)}>": map_col_type_to_ruby_classes(col_type)
-          info << sprintf("#   @return [#{ruby_class}]") + "\n"
-        elsif options[:format_markdown]
-          name_remainder = max_size - col_name.length - non_ascii_length(col_name)
-          type_remainder = (md_type_allowance - 2) - col_type.length
-          info << (sprintf("# **`%s`**%#{name_remainder}s | `%s`%#{type_remainder}s | `%s`", col_name, " ", col_type, " ", attrs.join(", ").rstrip)).gsub('``', '  ').rstrip + "\n"
-        elsif with_comments_column
-          info << format_default(col_name, max_size, col_type, bare_type_allowance, simple_formatted_attrs, bare_max_attrs_length, col_comment)
-        else
-          info << format_default(col_name, max_size, col_type, bare_type_allowance, simple_formatted_attrs)
+      grouped_cols.each do |group_label, group_columns|
+        if group_label
+          if options[:format_markdown]
+            info << "#\n# ### #{group_label}\n#\n"
+          else
+            info << "#\n# -- #{group_label} --\n#\n"
+          end
+        end
+
+        group_columns.each do |col|
+          col_type = cols_meta[col.name][:col_type]
+          attrs = cols_meta[col.name][:attrs]
+          col_name = cols_meta[col.name][:col_name]
+          simple_formatted_attrs = cols_meta[col.name][:simple_formatted_attrs]
+          col_comment = cols_meta[col.name][:col_comment]
+
+          if options[:format_rdoc]
+            info << sprintf("# %-#{max_size}.#{max_size}s<tt>%s</tt>", "*#{col_name}*::", attrs.unshift(col_type).join(", ")).rstrip + "\n"
+          elsif options[:format_yard]
+            info << sprintf("# @!attribute #{col_name}") + "\n"
+            ruby_class = col.respond_to?(:array) && col.array ? "Array<#{map_col_type_to_ruby_classes(col_type)}>": map_col_type_to_ruby_classes(col_type)
+            info << sprintf("#   @return [#{ruby_class}]") + "\n"
+          elsif options[:format_markdown]
+            name_remainder = max_size - col_name.length - non_ascii_length(col_name)
+            type_remainder = (md_type_allowance - 2) - col_type.length
+            info << (sprintf("# **`%s`**%#{name_remainder}s | `%s`%#{type_remainder}s | `%s`", col_name, " ", col_type, " ", attrs.join(", ").rstrip)).gsub('``', '  ').rstrip + "\n"
+          elsif with_comments_column
+            info << format_default(col_name, max_size, col_type, bare_type_allowance, simple_formatted_attrs, bare_max_attrs_length, col_comment)
+          else
+            info << format_default(col_name, max_size, col_type, bare_type_allowance, simple_formatted_attrs)
+          end
         end
       end
 
@@ -733,7 +750,7 @@ module AnnotateModels
         klass = get_model_class(file)
         do_annotate = klass.is_a?(Class) &&
           klass < ActiveRecord::Base &&
-          (!options[:exclude_sti_subclasses] || !(klass.superclass < ActiveRecord::Base && klass.table_name == klass.superclass.table_name)) &&
+          (!options[:exclude_sti_subclasses] || !Annotate::StiColumns.subclass?(klass)) &&
           !klass.abstract_class? &&
           klass.table_exists?
 

--- a/lib/annotate/constants.rb
+++ b/lib/annotate/constants.rb
@@ -18,7 +18,7 @@ module Annotate
       :trace, :timestamp, :exclude_serializers, :classified_sort,
       :show_foreign_keys, :show_complete_foreign_keys,
       :exclude_scaffolds, :exclude_controllers, :exclude_helpers,
-      :exclude_sti_subclasses, :classify_sti_columns, :ignore_unknown_models, :with_comment, :with_comment_column,
+      :exclude_sti_subclasses, :group_sti_columns, :ignore_unknown_models, :with_comment, :with_comment_column,
       :show_check_constraints
     ].freeze
 

--- a/lib/annotate/constants.rb
+++ b/lib/annotate/constants.rb
@@ -18,7 +18,7 @@ module Annotate
       :trace, :timestamp, :exclude_serializers, :classified_sort,
       :show_foreign_keys, :show_complete_foreign_keys,
       :exclude_scaffolds, :exclude_controllers, :exclude_helpers,
-      :exclude_sti_subclasses, :ignore_unknown_models, :with_comment, :with_comment_column,
+      :exclude_sti_subclasses, :classify_sti_columns, :ignore_unknown_models, :with_comment, :with_comment_column,
       :show_check_constraints
     ].freeze
 

--- a/lib/annotate/parser.rb
+++ b/lib/annotate/parser.rb
@@ -309,6 +309,11 @@ module Annotate
                        "include database comments in model annotations, as its own column, after all others") do
         env['with_comment_column'] = 'true'
       end
+
+      option_parser.on('--classify-sti-columns',
+                       "group annotation columns by STI class ownership") do
+        env['classify_sti_columns'] = 'true'
+      end
     end
   end
 end

--- a/lib/annotate/parser.rb
+++ b/lib/annotate/parser.rb
@@ -310,9 +310,9 @@ module Annotate
         env['with_comment_column'] = 'true'
       end
 
-      option_parser.on('--classify-sti-columns',
+      option_parser.on('--group-sti-columns',
                        "group annotation columns by STI class ownership") do
-        env['classify_sti_columns'] = 'true'
+        env['group_sti_columns'] = 'true'
       end
     end
   end

--- a/lib/annotate/sti_columns.rb
+++ b/lib/annotate/sti_columns.rb
@@ -10,7 +10,7 @@ module Annotate
 
       def base_class?(klass)
         klass.column_names.include?(klass.inheritance_column) &&
-          klass.subclasses.any? { |d| d.table_name == klass.table_name }
+          sti_descendants(klass).any?
       end
 
       def columns_referenced_in(klass)
@@ -50,11 +50,39 @@ module Annotate
 
       private
 
+      # Returns all descendants of klass that share the same table (STI).
+      # Uses descendants (all levels) rather than subclasses (direct only)
+      # to support multi-level STI hierarchies.
+      #
+      # Attempts eager loading first to ensure all subclasses are visible.
+      def sti_descendants(klass)
+        ensure_models_loaded
+        if klass.respond_to?(:descendants)
+          klass.descendants.select { |d| d.table_name == klass.table_name }
+        else
+          klass.subclasses.select { |d| d.table_name == klass.table_name }
+        end
+      end
+
+      def ensure_models_loaded
+        return if @models_loaded
+
+        if defined?(Rails) && Rails.respond_to?(:application) && Rails.application
+          Rails.application.eager_load! unless Rails.application.config.eager_load
+        end
+        @models_loaded = true
+      end
+
       def partition_for_subclass(klass, cols)
         owned = columns_owned_by(klass)
         base_name = klass.superclass.name.demodulize
         shared = cols.reject { |c| owned.include?(c.name.to_s) }
         specific = cols.select { |c| owned.include?(c.name.to_s) }
+
+        if specific.empty?
+          $stderr.puts "Warning: --group-sti-columns could not determine which columns belong to #{klass.name}."
+          $stderr.puts "  Add validations, associations, or enums to #{klass.name} to improve grouping."
+        end
 
         groups = []
         groups << ["#{base_name} columns", shared] if shared.any?
@@ -63,10 +91,10 @@ module Annotate
       end
 
       def partition_for_base_class(klass, cols)
-        sti_subclasses = klass.subclasses.select { |d| d.table_name == klass.table_name }.sort_by(&:name)
+        all_descendants = sti_descendants(klass).sort_by(&:name)
         ownership = {}
 
-        sti_subclasses.each do |sub|
+        all_descendants.each do |sub|
           columns_owned_by(sub).each do |col_name|
             ownership[col_name] ||= sub.name.demodulize
           end
@@ -75,11 +103,17 @@ module Annotate
         base_cols = cols.reject { |c| ownership.key?(c.name.to_s) }
         groups = [["#{klass.name.demodulize} columns", base_cols]]
 
-        sti_subclasses.each do |sub|
+        all_descendants.each do |sub|
           sub_name = sub.name.demodulize
           sub_cols = cols.select { |c| ownership[c.name.to_s] == sub_name }
           groups << ["#{sub_name} columns", sub_cols] if sub_cols.any?
         end
+
+        if ownership.empty?
+          $stderr.puts "Warning: --group-sti-columns found STI subclasses for #{klass.name} but no columns could be assigned."
+          $stderr.puts "  Add validations, associations, or enums to subclasses to improve grouping."
+        end
+
         groups
       end
     end

--- a/lib/annotate/sti_columns.rb
+++ b/lib/annotate/sti_columns.rb
@@ -27,7 +27,7 @@ module Annotate
         end
         cols.merge(klass.defined_enums.keys) if klass.respond_to?(:defined_enums)
         if klass.respond_to?(:stored_attributes) && klass.stored_attributes.any?
-          cols.merge(klass.stored_attributes.values.flatten.map(&:to_s))
+          cols.merge(klass.stored_attributes.keys.map(&:to_s))
         end
         cols
       end

--- a/lib/annotate/sti_columns.rb
+++ b/lib/annotate/sti_columns.rb
@@ -1,0 +1,87 @@
+require 'set'
+
+module Annotate
+  module StiColumns
+    class << self
+      def subclass?(klass)
+        klass.superclass < ActiveRecord::Base &&
+          klass.table_name == klass.superclass.table_name
+      end
+
+      def base_class?(klass)
+        klass.column_names.include?(klass.inheritance_column) &&
+          klass.subclasses.any? { |d| d.table_name == klass.table_name }
+      end
+
+      def columns_referenced_in(klass)
+        cols = Set.new
+        cols.merge(klass.validators.flat_map { |v| v.attributes.map(&:to_s) })
+        if klass.respond_to?(:reflect_on_all_associations)
+          cols.merge(
+            klass.reflect_on_all_associations(:belongs_to).flat_map { |a|
+              fk = [a.foreign_key.to_s]
+              fk << "#{a.name}_type" if a.respond_to?(:polymorphic?) && a.polymorphic?
+              fk
+            }
+          )
+        end
+        cols.merge(klass.defined_enums.keys) if klass.respond_to?(:defined_enums)
+        if klass.respond_to?(:stored_attributes) && klass.stored_attributes.any?
+          cols.merge(klass.stored_attributes.values.flatten.map(&:to_s))
+        end
+        cols
+      end
+
+      def columns_owned_by(klass)
+        return Set.new unless subclass?(klass)
+
+        columns_referenced_in(klass) - columns_referenced_in(klass.superclass)
+      end
+
+      def partition(klass, cols)
+        if subclass?(klass)
+          partition_for_subclass(klass, cols)
+        elsif base_class?(klass)
+          partition_for_base_class(klass, cols)
+        else
+          [[nil, cols]]
+        end
+      end
+
+      private
+
+      def partition_for_subclass(klass, cols)
+        owned = columns_owned_by(klass)
+        base_name = klass.superclass.name.demodulize
+        shared = cols.reject { |c| owned.include?(c.name.to_s) }
+        specific = cols.select { |c| owned.include?(c.name.to_s) }
+
+        groups = []
+        groups << ["#{base_name} columns", shared] if shared.any?
+        groups << ["#{klass.name.demodulize} columns", specific] if specific.any?
+        groups
+      end
+
+      def partition_for_base_class(klass, cols)
+        sti_subclasses = klass.subclasses.select { |d| d.table_name == klass.table_name }.sort_by(&:name)
+        ownership = {}
+
+        sti_subclasses.each do |sub|
+          columns_owned_by(sub).each do |col_name|
+            ownership[col_name] ||= sub.name.demodulize
+          end
+        end
+
+        base_cols = cols.reject { |c| ownership.key?(c.name.to_s) }
+        groups = [["#{klass.name.demodulize} columns", base_cols]]
+
+        sti_subclasses.each do |sub|
+          sub_name = sub.name.demodulize
+          sub_cols = cols.select { |c| ownership[c.name.to_s] == sub_name }
+          groups << ["#{sub_name} columns", sub_cols] if sub_cols.any?
+        end
+        groups
+      end
+    end
+  end
+end

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -34,7 +34,7 @@ if Rails.env.development?
       'exclude_controllers'         => 'true',
       'exclude_helpers'             => 'true',
       'exclude_sti_subclasses'      => 'false',
-      'classify_sti_columns'        => 'false',
+      'group_sti_columns'           => 'false',
       'ignore_model_sub_dir'        => 'false',
       'ignore_columns'              => nil,
       'ignore_routes'               => nil,

--- a/lib/generators/annotate/templates/auto_annotate_models.rake
+++ b/lib/generators/annotate/templates/auto_annotate_models.rake
@@ -34,6 +34,7 @@ if Rails.env.development?
       'exclude_controllers'         => 'true',
       'exclude_helpers'             => 'true',
       'exclude_sti_subclasses'      => 'false',
+      'classify_sti_columns'        => 'false',
       'ignore_model_sub_dir'        => 'false',
       'ignore_columns'              => nil,
       'ignore_routes'               => nil,

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -35,6 +35,7 @@ task annotate_models: :environment do
   options[:exclude_controllers] = Annotate::Helpers.true?(ENV.fetch('exclude_controllers', 'true'))
   options[:exclude_helpers] = Annotate::Helpers.true?(ENV.fetch('exclude_helpers', 'true'))
   options[:exclude_sti_subclasses] = Annotate::Helpers.true?(ENV['exclude_sti_subclasses'])
+  options[:classify_sti_columns] = Annotate::Helpers.true?(ENV['classify_sti_columns'])
   options[:ignore_model_sub_dir] = Annotate::Helpers.true?(ENV['ignore_model_sub_dir'])
   options[:format_bare] = Annotate::Helpers.true?(ENV['format_bare'])
   options[:format_rdoc] = Annotate::Helpers.true?(ENV['format_rdoc'])

--- a/lib/tasks/annotate_models.rake
+++ b/lib/tasks/annotate_models.rake
@@ -35,7 +35,7 @@ task annotate_models: :environment do
   options[:exclude_controllers] = Annotate::Helpers.true?(ENV.fetch('exclude_controllers', 'true'))
   options[:exclude_helpers] = Annotate::Helpers.true?(ENV.fetch('exclude_helpers', 'true'))
   options[:exclude_sti_subclasses] = Annotate::Helpers.true?(ENV['exclude_sti_subclasses'])
-  options[:classify_sti_columns] = Annotate::Helpers.true?(ENV['classify_sti_columns'])
+  options[:group_sti_columns] = Annotate::Helpers.true?(ENV['group_sti_columns'])
   options[:ignore_model_sub_dir] = Annotate::Helpers.true?(ENV['ignore_model_sub_dir'])
   options[:format_bare] = Annotate::Helpers.true?(ENV['format_bare'])
   options[:format_rdoc] = Annotate::Helpers.true?(ENV['format_rdoc'])

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1942,7 +1942,7 @@ describe AnnotateModels do
     end
   end
 
-  describe '.get_schema_info with classify_sti_columns' do
+  describe '.get_schema_info with group_sti_columns' do
     let(:all_columns) do
       [
         mock_column(:id, :integer),
@@ -2000,7 +2000,7 @@ describe AnnotateModels do
                                  owned_validator_attrs: [:num_doors])
         allow(vehicle).to receive(:subclasses).and_return([car])
 
-        result = AnnotateModels.get_schema_info(car, 'Schema Info', classify_sti_columns: true)
+        result = AnnotateModels.get_schema_info(car, 'Schema Info', group_sti_columns: true)
 
         expect(result).to include('# -- Vehicle columns --')
         expect(result).to include('# -- Car columns --')
@@ -2022,7 +2022,7 @@ describe AnnotateModels do
                                    owned_validator_attrs: [:payload_capacity])
         allow(vehicle).to receive(:subclasses).and_return([car, truck])
 
-        result = AnnotateModels.get_schema_info(vehicle, 'Schema Info', classify_sti_columns: true)
+        result = AnnotateModels.get_schema_info(vehicle, 'Schema Info', group_sti_columns: true)
 
         expect(result).to include('# -- Vehicle columns --')
         expect(result).to include('# -- Car columns --')
@@ -2045,19 +2045,19 @@ describe AnnotateModels do
         allow(vehicle).to receive(:subclasses).and_return([car])
 
         result = AnnotateModels.get_schema_info(car, 'Schema Info',
-                                                classify_sti_columns: true, format_markdown: true)
+                                                group_sti_columns: true, format_markdown: true)
 
         expect(result).to include('# ### Vehicle columns')
         expect(result).to include('# ### Car columns')
       end
     end
 
-    context 'when classify_sti_columns is false' do
+    context 'when group_sti_columns is false' do
       it 'does not add section headers' do
         result = AnnotateModels.get_schema_info(
           mock_class(:users, :id, [mock_column(:id, :integer), mock_column(:name, :string, limit: 50)]),
           'Schema Info',
-          classify_sti_columns: false
+          group_sti_columns: false
         )
 
         expect(result).not_to include('-- ')
@@ -2072,7 +2072,7 @@ describe AnnotateModels do
         allow(klass).to receive(:inheritance_column).and_return('type')
         allow(klass).to receive(:subclasses).and_return([])
 
-        result = AnnotateModels.get_schema_info(klass, 'Schema Info', classify_sti_columns: true)
+        result = AnnotateModels.get_schema_info(klass, 'Schema Info', group_sti_columns: true)
 
         expect(result).not_to include('-- ')
       end
@@ -2717,6 +2717,46 @@ describe AnnotateModels do
       end
 
       it 'removes annotation' do
+        expect(file_content_after_removal).to eq expected_result
+      end
+    end
+
+    context 'when annotation contains STI group headers' do
+      let :filename do
+        'sti_grouped.rb'
+      end
+
+      let :file_content do
+        <<~EOS
+          # == Schema Information
+          #
+          # Table name: vehicles
+          #
+          #
+          # -- Vehicle columns --
+          #
+          #  id         :bigint           not null, primary key
+          #  type       :string
+          #  name       :string           not null
+          #
+          # -- Car columns --
+          #
+          #  num_doors  :integer
+          #
+
+          class Car < Vehicle
+          end
+        EOS
+      end
+
+      let :expected_result do
+        <<~EOS
+          class Car < Vehicle
+          end
+        EOS
+      end
+
+      it 'removes annotation including group headers' do
         expect(file_content_after_removal).to eq expected_result
       end
     end

--- a/spec/lib/annotate/annotate_models_spec.rb
+++ b/spec/lib/annotate/annotate_models_spec.rb
@@ -1942,6 +1942,143 @@ describe AnnotateModels do
     end
   end
 
+  describe '.get_schema_info with classify_sti_columns' do
+    let(:all_columns) do
+      [
+        mock_column(:id, :integer),
+        mock_column(:type, :string, limit: 255),
+        mock_column(:name, :string, limit: 100),
+        mock_column(:num_doors, :integer),
+        mock_column(:payload_capacity, :integer)
+      ]
+    end
+
+    def build_sti_base(columns, name: 'Vehicle')
+      klass = mock_class(:vehicles, :id, columns)
+      allow(klass).to receive(:superclass).and_return(ActiveRecord::Base)
+      allow(klass).to receive(:<).with(ActiveRecord::Base).and_return(true)
+      allow(klass).to receive(:name).and_return(name)
+      allow(klass).to receive(:inheritance_column).and_return('type')
+      allow(klass).to receive(:subclasses).and_return([])
+
+      # Introspection
+      allow(klass).to receive(:validators).and_return([
+        double('Validator', attributes: [:name])
+      ])
+      allow(klass).to receive(:reflect_on_all_associations).with(:belongs_to).and_return([])
+      allow(klass).to receive(:defined_enums).and_return({})
+      allow(klass).to receive(:stored_attributes).and_return({})
+
+      klass
+    end
+
+    def build_sti_subclass(parent, columns, name:, owned_validator_attrs: [])
+      klass = mock_class(:vehicles, :id, columns)
+      allow(klass).to receive(:superclass).and_return(parent)
+      allow(klass).to receive(:<).with(ActiveRecord::Base).and_return(true)
+      allow(klass).to receive(:name).and_return(name)
+      allow(klass).to receive(:inheritance_column).and_return('type')
+      allow(klass).to receive(:subclasses).and_return([])
+
+      # Make parent look like an AR subclass for sti_subclass? check
+      allow(parent).to receive(:<).with(ActiveRecord::Base).and_return(true)
+
+      # Introspection: parent validators + own
+      own_validators = owned_validator_attrs.map { |attr| double('Validator', attributes: [attr]) }
+      allow(klass).to receive(:validators).and_return(parent.validators + own_validators)
+      allow(klass).to receive(:reflect_on_all_associations).with(:belongs_to).and_return([])
+      allow(klass).to receive(:defined_enums).and_return({})
+      allow(klass).to receive(:stored_attributes).and_return({})
+
+      klass
+    end
+
+    context 'when annotating an STI subclass' do
+      it 'groups columns with section headers' do
+        vehicle = build_sti_base(all_columns)
+        car = build_sti_subclass(vehicle, all_columns, name: 'Car',
+                                 owned_validator_attrs: [:num_doors])
+        allow(vehicle).to receive(:subclasses).and_return([car])
+
+        result = AnnotateModels.get_schema_info(car, 'Schema Info', classify_sti_columns: true)
+
+        expect(result).to include('# -- Vehicle columns --')
+        expect(result).to include('# -- Car columns --')
+        expect(result).to include('#  num_doors')
+
+        # Verify num_doors appears after Car header
+        car_section = result.index('# -- Car columns --')
+        num_doors_pos = result.index('#  num_doors')
+        expect(num_doors_pos).to be > car_section
+      end
+    end
+
+    context 'when annotating an STI base class' do
+      it 'groups columns by owning subclass' do
+        vehicle = build_sti_base(all_columns)
+        car = build_sti_subclass(vehicle, all_columns, name: 'Car',
+                                 owned_validator_attrs: [:num_doors])
+        truck = build_sti_subclass(vehicle, all_columns, name: 'Truck',
+                                   owned_validator_attrs: [:payload_capacity])
+        allow(vehicle).to receive(:subclasses).and_return([car, truck])
+
+        result = AnnotateModels.get_schema_info(vehicle, 'Schema Info', classify_sti_columns: true)
+
+        expect(result).to include('# -- Vehicle columns --')
+        expect(result).to include('# -- Car columns --')
+        expect(result).to include('# -- Truck columns --')
+
+        # Base columns should be in Vehicle section
+        vehicle_section = result.index('# -- Vehicle columns --')
+        car_section = result.index('# -- Car columns --')
+        id_pos = result.index('#  id')
+        expect(id_pos).to be > vehicle_section
+        expect(id_pos).to be < car_section
+      end
+    end
+
+    context 'when using markdown format' do
+      it 'uses markdown headers for section labels' do
+        vehicle = build_sti_base(all_columns)
+        car = build_sti_subclass(vehicle, all_columns, name: 'Car',
+                                 owned_validator_attrs: [:num_doors])
+        allow(vehicle).to receive(:subclasses).and_return([car])
+
+        result = AnnotateModels.get_schema_info(car, 'Schema Info',
+                                                classify_sti_columns: true, format_markdown: true)
+
+        expect(result).to include('# ### Vehicle columns')
+        expect(result).to include('# ### Car columns')
+      end
+    end
+
+    context 'when classify_sti_columns is false' do
+      it 'does not add section headers' do
+        result = AnnotateModels.get_schema_info(
+          mock_class(:users, :id, [mock_column(:id, :integer), mock_column(:name, :string, limit: 50)]),
+          'Schema Info',
+          classify_sti_columns: false
+        )
+
+        expect(result).not_to include('-- ')
+      end
+    end
+
+    context 'when model is not STI' do
+      it 'does not add section headers' do
+        klass = mock_class(:users, :id, [mock_column(:id, :integer), mock_column(:name, :string, limit: 50)])
+        allow(klass).to receive(:superclass).and_return(ActiveRecord::Base)
+        allow(klass).to receive(:column_names).and_return(%w[id name])
+        allow(klass).to receive(:inheritance_column).and_return('type')
+        allow(klass).to receive(:subclasses).and_return([])
+
+        result = AnnotateModels.get_schema_info(klass, 'Schema Info', classify_sti_columns: true)
+
+        expect(result).not_to include('-- ')
+      end
+    end
+  end
+
   describe '.set_defaults' do
     subject do
       Annotate::Helpers.true?(ENV['show_complete_foreign_keys'])

--- a/spec/lib/annotate/sti_columns_spec.rb
+++ b/spec/lib/annotate/sti_columns_spec.rb
@@ -3,7 +3,12 @@ require 'active_record'
 require 'annotate/sti_columns'
 
 describe Annotate::StiColumns do
-  def mock_ar_class(name:, table_name:, superclass: ActiveRecord::Base, validators: [], belongs_to: [], enums: {}, stored_attrs: {}, column_names: [], inheritance_column: 'type', subclasses: [])
+  before(:each) do
+    # Reset the models_loaded flag between tests
+    described_class.instance_variable_set(:@models_loaded, true)
+  end
+
+  def mock_ar_class(name:, table_name:, superclass: ActiveRecord::Base, validators: [], belongs_to: [], enums: {}, stored_attrs: {}, column_names: [], inheritance_column: 'type', descendants: [], subclasses: nil)
     klass = double(name)
     allow(klass).to receive(:name).and_return(name)
     allow(klass).to receive(:table_name).and_return(table_name)
@@ -11,7 +16,8 @@ describe Annotate::StiColumns do
     allow(klass).to receive(:<).with(ActiveRecord::Base).and_return(true)
     allow(klass).to receive(:column_names).and_return(column_names)
     allow(klass).to receive(:inheritance_column).and_return(inheritance_column)
-    allow(klass).to receive(:subclasses).and_return(subclasses)
+    allow(klass).to receive(:descendants).and_return(descendants)
+    allow(klass).to receive(:subclasses).and_return(subclasses || descendants)
 
     allow(klass).to receive(:validators).and_return(
       validators.map { |attr| double('Validator', attributes: [attr]) }
@@ -88,13 +94,14 @@ describe Annotate::StiColumns do
     let(:num_doors_col) { mock_column(:num_doors) }
     let(:payload_col) { mock_column(:payload_capacity) }
     let(:color_col) { mock_column(:color) }
+    let(:battery_col) { mock_column(:battery_kwh) }
 
     let(:all_columns) { [id_col, type_col, name_col, num_doors_col, payload_col, color_col] }
 
     context 'for a non-STI class' do
       it 'returns a single group with no label' do
         klass = mock_ar_class(name: 'User', table_name: 'users',
-                              column_names: %w[id name], subclasses: [])
+                              column_names: %w[id name])
         cols = [id_col, name_col]
 
         result = described_class.partition(klass, cols)
@@ -133,6 +140,18 @@ describe Annotate::StiColumns do
         expect(result[0][0]).to eq 'Vehicle columns'
         expect(result[0][1]).to eq cols
       end
+
+      it 'warns when subclass owns no columns' do
+        vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [:name])
+        car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                            validators: [:name])
+        cols = [id_col, type_col, name_col]
+
+        expect($stderr).to receive(:puts).with(/could not determine which columns belong to Car/)
+        expect($stderr).to receive(:puts).with(/Add validations/)
+
+        described_class.partition(car, cols)
+      end
     end
 
     context 'for an STI base class' do
@@ -143,7 +162,7 @@ describe Annotate::StiColumns do
                             validators: [:name, :num_doors])
         truck = mock_ar_class(name: 'Truck', table_name: 'vehicles', superclass: vehicle,
                               validators: [:name, :payload_capacity])
-        allow(vehicle).to receive(:subclasses).and_return([car, truck])
+        allow(vehicle).to receive(:descendants).and_return([car, truck])
 
         result = described_class.partition(vehicle, all_columns)
 
@@ -160,7 +179,7 @@ describe Annotate::StiColumns do
                                 column_names: %w[id type name color])
         car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
                             validators: [:num_doors])
-        allow(vehicle).to receive(:subclasses).and_return([car])
+        allow(vehicle).to receive(:descendants).and_return([car])
 
         cols = [id_col, type_col, name_col, color_col, num_doors_col]
         result = described_class.partition(vehicle, cols)
@@ -176,7 +195,7 @@ describe Annotate::StiColumns do
                             validators: [:color])
         truck = mock_ar_class(name: 'Truck', table_name: 'vehicles', superclass: vehicle,
                               validators: [:color])
-        allow(vehicle).to receive(:subclasses).and_return([car, truck])
+        allow(vehicle).to receive(:descendants).and_return([car, truck])
 
         cols = [id_col, type_col, color_col]
         result = described_class.partition(vehicle, cols)
@@ -186,6 +205,40 @@ describe Annotate::StiColumns do
         truck_group = result.find { |label, _| label == 'Truck columns' }
         expect(car_group[1].map { |c| c.name }).to include('color')
         expect(truck_group).to be_nil
+      end
+
+      it 'warns when no columns can be assigned to subclasses' do
+        vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [:name],
+                                column_names: %w[id type name])
+        car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                            validators: [:name])
+        allow(vehicle).to receive(:descendants).and_return([car])
+
+        expect($stderr).to receive(:puts).with(/found STI subclasses for Vehicle but no columns could be assigned/)
+        expect($stderr).to receive(:puts).with(/Add validations/)
+
+        described_class.partition(vehicle, [id_col, type_col, name_col])
+      end
+
+      it 'includes multi-level descendants via descendants' do
+        vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [:name],
+                                column_names: %w[id type name num_doors battery_kwh])
+        car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                            validators: [:name, :num_doors])
+        electric_car = mock_ar_class(name: 'ElectricCar', table_name: 'vehicles', superclass: car,
+                                     validators: [:name, :num_doors, :battery_kwh])
+        # descendants returns all levels, subclasses returns only direct
+        allow(vehicle).to receive(:descendants).and_return([car, electric_car])
+        allow(car).to receive(:descendants).and_return([electric_car])
+
+        cols = [id_col, type_col, name_col, num_doors_col, battery_col]
+        result = described_class.partition(vehicle, cols)
+
+        labels = result.map(&:first)
+        expect(labels).to include('Vehicle columns', 'Car columns', 'ElectricCar columns')
+
+        electric_group = result.find { |label, _| label == 'ElectricCar columns' }
+        expect(electric_group[1].map { |c| c.name }).to eq ['battery_kwh']
       end
     end
   end

--- a/spec/lib/annotate/sti_columns_spec.rb
+++ b/spec/lib/annotate/sti_columns_spec.rb
@@ -1,0 +1,192 @@
+require_relative '../../spec_helper'
+require 'active_record'
+require 'annotate/sti_columns'
+
+describe Annotate::StiColumns do
+  def mock_ar_class(name:, table_name:, superclass: ActiveRecord::Base, validators: [], belongs_to: [], enums: {}, stored_attrs: {}, column_names: [], inheritance_column: 'type', subclasses: [])
+    klass = double(name)
+    allow(klass).to receive(:name).and_return(name)
+    allow(klass).to receive(:table_name).and_return(table_name)
+    allow(klass).to receive(:superclass).and_return(superclass)
+    allow(klass).to receive(:<).with(ActiveRecord::Base).and_return(true)
+    allow(klass).to receive(:column_names).and_return(column_names)
+    allow(klass).to receive(:inheritance_column).and_return(inheritance_column)
+    allow(klass).to receive(:subclasses).and_return(subclasses)
+
+    allow(klass).to receive(:validators).and_return(
+      validators.map { |attr| double('Validator', attributes: [attr]) }
+    )
+    allow(klass).to receive(:reflect_on_all_associations).with(:belongs_to).and_return(
+      belongs_to.map { |fk| double('Association', foreign_key: fk, name: fk.to_s.sub(/_id$/, ''), polymorphic?: false) }
+    )
+    allow(klass).to receive(:defined_enums).and_return(enums)
+    allow(klass).to receive(:stored_attributes).and_return(stored_attrs)
+
+    klass
+  end
+
+  def mock_column(name)
+    double('Column', name: name.to_s)
+  end
+
+  describe '.columns_referenced_in' do
+    it 'collects columns from validators' do
+      klass = mock_ar_class(name: 'Car', table_name: 'vehicles', validators: [:num_doors, :color])
+      expect(described_class.columns_referenced_in(klass)).to eq Set.new(%w[num_doors color])
+    end
+
+    it 'collects foreign keys from belongs_to associations' do
+      klass = mock_ar_class(name: 'Car', table_name: 'vehicles', belongs_to: [:manufacturer_id])
+      expect(described_class.columns_referenced_in(klass)).to eq Set.new(%w[manufacturer_id])
+    end
+
+    it 'collects enum columns' do
+      klass = mock_ar_class(name: 'Car', table_name: 'vehicles', enums: { 'fuel_type' => { gas: 0, diesel: 1 } })
+      expect(described_class.columns_referenced_in(klass)).to eq Set.new(%w[fuel_type])
+    end
+
+    it 'collects stored attribute columns' do
+      klass = mock_ar_class(name: 'Car', table_name: 'vehicles', stored_attrs: { settings: [:color, :theme] })
+      expect(described_class.columns_referenced_in(klass)).to eq Set.new(%w[color theme])
+    end
+
+    it 'combines all sources' do
+      klass = mock_ar_class(name: 'Car', table_name: 'vehicles',
+                            validators: [:name], belongs_to: [:owner_id],
+                            enums: { 'status' => {} }, stored_attrs: { prefs: [:lang] })
+      expect(described_class.columns_referenced_in(klass)).to eq Set.new(%w[name owner_id status lang])
+    end
+  end
+
+  describe '.columns_owned_by' do
+    it 'returns columns referenced by subclass but not by superclass' do
+      vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [:name])
+      car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                          validators: [:name, :num_doors])
+
+      expect(described_class.columns_owned_by(car)).to eq Set.new(%w[num_doors])
+    end
+
+    it 'returns empty set for non-STI classes' do
+      klass = mock_ar_class(name: 'User', table_name: 'users', superclass: ActiveRecord::Base)
+      expect(described_class.columns_owned_by(klass)).to eq Set.new
+    end
+
+    it 'returns empty set when subclass references no new columns' do
+      vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [:name])
+      car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                          validators: [:name])
+
+      expect(described_class.columns_owned_by(car)).to eq Set.new
+    end
+  end
+
+  describe '.partition' do
+    let(:id_col) { mock_column(:id) }
+    let(:type_col) { mock_column(:type) }
+    let(:name_col) { mock_column(:name) }
+    let(:num_doors_col) { mock_column(:num_doors) }
+    let(:payload_col) { mock_column(:payload_capacity) }
+    let(:color_col) { mock_column(:color) }
+
+    let(:all_columns) { [id_col, type_col, name_col, num_doors_col, payload_col, color_col] }
+
+    context 'for a non-STI class' do
+      it 'returns a single group with no label' do
+        klass = mock_ar_class(name: 'User', table_name: 'users',
+                              column_names: %w[id name], subclasses: [])
+        cols = [id_col, name_col]
+
+        result = described_class.partition(klass, cols)
+
+        expect(result).to eq [[nil, cols]]
+      end
+    end
+
+    context 'for an STI subclass' do
+      it 'separates owned columns from shared columns' do
+        vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [:name],
+                                column_names: %w[id type name num_doors payload_capacity color])
+        car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                            validators: [:name, :num_doors])
+
+        result = described_class.partition(car, all_columns)
+
+        labels = result.map(&:first)
+        expect(labels).to eq ['Vehicle columns', 'Car columns']
+
+        vehicle_col_names = result[0][1].map { |c| c.name }
+        car_col_names = result[1][1].map { |c| c.name }
+        expect(vehicle_col_names).to include('id', 'type', 'name', 'payload_capacity', 'color')
+        expect(car_col_names).to eq ['num_doors']
+      end
+
+      it 'returns only shared group when subclass owns no columns' do
+        vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [:name])
+        car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                            validators: [:name])
+        cols = [id_col, type_col, name_col]
+
+        result = described_class.partition(car, cols)
+
+        expect(result.length).to eq 1
+        expect(result[0][0]).to eq 'Vehicle columns'
+        expect(result[0][1]).to eq cols
+      end
+    end
+
+    context 'for an STI base class' do
+      it 'groups columns by owning subclass' do
+        vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [:name],
+                                column_names: %w[id type name num_doors payload_capacity color])
+        car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                            validators: [:name, :num_doors])
+        truck = mock_ar_class(name: 'Truck', table_name: 'vehicles', superclass: vehicle,
+                              validators: [:name, :payload_capacity])
+        allow(vehicle).to receive(:subclasses).and_return([car, truck])
+
+        result = described_class.partition(vehicle, all_columns)
+
+        labels = result.map(&:first)
+        expect(labels).to eq ['Vehicle columns', 'Car columns', 'Truck columns']
+
+        base_col_names = result[0][1].map { |c| c.name }
+        expect(base_col_names).to include('id', 'type', 'name', 'color')
+        expect(base_col_names).not_to include('num_doors', 'payload_capacity')
+      end
+
+      it 'puts unclaimed columns in the base group' do
+        vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [],
+                                column_names: %w[id type name color])
+        car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                            validators: [:num_doors])
+        allow(vehicle).to receive(:subclasses).and_return([car])
+
+        cols = [id_col, type_col, name_col, color_col, num_doors_col]
+        result = described_class.partition(vehicle, cols)
+
+        base_col_names = result[0][1].map { |c| c.name }
+        expect(base_col_names).to include('id', 'type', 'name', 'color')
+      end
+
+      it 'assigns a column to the first subclass that claims it' do
+        vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [],
+                                column_names: %w[id type color])
+        car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                            validators: [:color])
+        truck = mock_ar_class(name: 'Truck', table_name: 'vehicles', superclass: vehicle,
+                              validators: [:color])
+        allow(vehicle).to receive(:subclasses).and_return([car, truck])
+
+        cols = [id_col, type_col, color_col]
+        result = described_class.partition(vehicle, cols)
+
+        # Car comes first alphabetically, so it claims 'color'
+        car_group = result.find { |label, _| label == 'Car columns' }
+        truck_group = result.find { |label, _| label == 'Truck columns' }
+        expect(car_group[1].map { |c| c.name }).to include('color')
+        expect(truck_group).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/annotate/sti_columns_spec.rb
+++ b/spec/lib/annotate/sti_columns_spec.rb
@@ -53,14 +53,14 @@ describe Annotate::StiColumns do
 
     it 'collects stored attribute columns' do
       klass = mock_ar_class(name: 'Car', table_name: 'vehicles', stored_attrs: { settings: [:color, :theme] })
-      expect(described_class.columns_referenced_in(klass)).to eq Set.new(%w[color theme])
+      expect(described_class.columns_referenced_in(klass)).to eq Set.new(%w[settings])
     end
 
     it 'combines all sources' do
       klass = mock_ar_class(name: 'Car', table_name: 'vehicles',
                             validators: [:name], belongs_to: [:owner_id],
                             enums: { 'status' => {} }, stored_attrs: { prefs: [:lang] })
-      expect(described_class.columns_referenced_in(klass)).to eq Set.new(%w[name owner_id status lang])
+      expect(described_class.columns_referenced_in(klass)).to eq Set.new(%w[name owner_id status prefs])
     end
   end
 
@@ -95,6 +95,7 @@ describe Annotate::StiColumns do
     let(:payload_col) { mock_column(:payload_capacity) }
     let(:color_col) { mock_column(:color) }
     let(:battery_col) { mock_column(:battery_kwh) }
+    let(:settings_col) { mock_column(:settings) }
 
     let(:all_columns) { [id_col, type_col, name_col, num_doors_col, payload_col, color_col] }
 
@@ -218,6 +219,21 @@ describe Annotate::StiColumns do
         expect($stderr).to receive(:puts).with(/Add validations/)
 
         described_class.partition(vehicle, [id_col, type_col, name_col])
+      end
+
+      it 'assigns stored attributes backing columns to the subclass correctly' do
+        vehicle = mock_ar_class(name: 'Vehicle', table_name: 'vehicles', validators: [:name],
+                                column_names: %w[id type name settings])
+        car = mock_ar_class(name: 'Car', table_name: 'vehicles', superclass: vehicle,
+                            validators: [:name], stored_attrs: { settings: [:color, :theme] })
+        allow(vehicle).to receive(:descendants).and_return([car])
+
+        cols = [id_col, type_col, name_col, settings_col]
+        result = described_class.partition(vehicle, cols)
+
+        car_group = result.find { |label, _| label == 'Car columns' }
+        expect(car_group).not_to be_nil
+        expect(car_group[1].map { |c| c.name }).to eq ['settings']
       end
 
       it 'includes multi-level descendants via descendants' do


### PR DESCRIPTION
## Motivation

STI models share a single table, so today every model in an STI hierarchy gets an identical annotation listing all columns — including ones that are only relevant to a specific subclass. On a large hierarchy this creates noise on every schema change and makes it hard to tell at a glance which columns a given model actually uses.

The existing `--exclude-sti-subclasses` option sidesteps this by skipping subclass annotation entirely, but throws away useful context. This option takes the opposite approach: keep annotating all models, but group columns by which class owns them.

## Example output

Base class (`app/models/vehicle.rb`):

```ruby
# == Schema Information
#
# Table name: vehicles
#
#
# -- Vehicle columns --
#
#  id         :bigint           not null, primary key
#  type       :string           not null
#  name       :string           not null
#  created_at :datetime         not null
#  updated_at :datetime         not null
#
# -- Car columns --
#
#  num_doors   :integer
#  engine_type :string
#
# -- Truck columns --
#
#  payload_capacity :decimal
#  num_axles        :integer
#
```

Subclass (`app/models/car.rb`) — Truck columns omitted entirely:

```ruby
# == Schema Information
#
# Table name: vehicles
#
#
# -- Vehicle columns --
#
#  id         :bigint           not null, primary key
#  type       :string           not null
#  name       :string           not null
#  created_at :datetime         not null
#  updated_at :datetime         not null
#
# -- Car columns --
#
#  num_doors   :integer
#  engine_type :string
#
```

## Summary

- Add `--group-sti-columns` CLI option that groups annotation columns by STI class ownership, so base class and subclass annotations show which columns belong where rather than a flat identical list across all models
- Column ownership is determined by introspecting each model's validators, `belongs_to` associations, enums, and stored attributes — no configuration required
- On a subclass, the annotation shows shared (base) columns and subclass-specific columns under separate labeled sections; on the base class, each subclass gets its own section
- Extract STI logic into `Annotate::StiColumns` module to keep it cleanly separated from annotation formatting; also reuse it to simplify the existing `exclude_sti_subclasses` check
- Use `descendants` instead of `subclasses` to support multi-level STI hierarchies (e.g. `ElectricCar < Car < Vehicle`)
- Call `Rails.application.eager_load!` before querying descendants to avoid loading-order issues where the base class is annotated before subclasses are loaded
- Warn to stderr when the heuristic can't assign any columns to a subclass, pointing users toward adding validations/associations/enums

## Notes

- The grouping is descriptive, not enforced — the DB still allows any STI subclass to read/write any column. The annotation documents what's *actually expected/used*, which is only misleading if you're intentionally accessing columns across subclass boundaries (already a code smell)
- The main known limitation: if a subclass uses a column without declaring a validation, association, or enum for it, that column silently lands in the base group. The stderr warning covers this case but can't point to the specific column.
    - Workaround: add a harmless validation like `validates :my_column, absence: false` to the subclass to explicitly claim it.
- Columns not claimed by any subclass default to the base class group (first-subclass-wins for contested columns, sorted alphabetically)
- Option is off by default; existing annotations are unaffected
